### PR TITLE
Resolving before commonjs()

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,9 +35,9 @@ const umd = Object.assign({}, config, {
     },
     external: ["react", "react-dom"],
     plugins: [
+        resolve(),
         commonjs(),
         typescript(typescriptConfig),
-        resolve(),
         replace({
             "process.env.NODE_ENV": JSON.stringify("development"),
         }),
@@ -49,9 +49,9 @@ const umdProd = Object.assign({}, umd, {
         file: `dist/${pkg.name}.js`,
     }),
     plugins: [
+        resolve(),
         commonjs(),
         typescript(typescriptConfig),
-        resolve(),
         replace({
             "process.env.NODE_ENV": JSON.stringify("production"),
         }),


### PR DESCRIPTION
This fixes an import issues with @emotion/memoize and @emotion/is-prop-valid

Honestly, I don't really understand what's going on and _why_ this works, I only verified that having the plugins in this order _does_ produce a working build result