### PR TITLE
delete unused props from style object

### DIFF
--- a/src/motion/utils/use-styles.ts
+++ b/src/motion/utils/use-styles.ts
@@ -70,7 +70,7 @@ export const useMotionStyles = (
         }
     }
 
-    currentStyleKeys.forEach(key => (style[key] = undefined))
+    currentStyleKeys.forEach(key => delete style[key])
 
     return transformCustomValues(style)
 }


### PR DESCRIPTION
deleting key is much slower that setting it to `undefined` but setting key to `undefined` it not enough because [React relies on keys order](https://codesandbox.io/s/n7wwo93rml) in style object and if `background` is coming after `backgroundColor` it will reset the whole style for `background`

alternative to this fix would be something like:

```typescript
if (!style.background && style.backgroundColor) {
    style.background = style.backgroundColor
}
```
before passing props to `motion.div`

I think fixing it here it better because we might bump into this issue again in future.

fixes https://github.com/framer/company/issues/12682