### PR TITLE
Removing `easings` prop and allowing `ease` to be array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   `useViewportScrollValues` => `useViewportScroll`.
 
+### Added
+
+-   `ease` can now be an array for keyframes animations.
+
+### Removed
+
+-   `easings` prop.
+
 ## [0.14.3] 2019-04-12
 
 ### Fixed

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -84,10 +84,15 @@ const easingDefinitionToFunction = (definition: Easing) => {
     return definition
 }
 
+const isEasingArray = (ease: any): ease is Easing[] => {
+    return Array.isArray(ease) && typeof ease[0] !== "number"
+}
+
 const transitionOptionParser = {
     tween: (opts: Tween): Tween => {
         if (opts.ease) {
-            opts.ease = easingDefinitionToFunction(opts.ease)
+            const ease = isEasingArray(opts.ease) ? opts.ease[0] : opts.ease
+            opts.ease = easingDefinitionToFunction(ease)
         }
 
         return opts
@@ -100,11 +105,11 @@ const transitionOptionParser = {
         }
 
         if (opts.ease) {
-            opts.ease = easingDefinitionToFunction(opts.ease)
+            opts.easings = isEasingArray(opts.ease)
+                ? opts.ease.map(easingDefinitionToFunction)
+                : easingDefinitionToFunction(opts.ease)
         }
-        if (opts.easings) {
-            opts.easings = opts.easings.map(easingDefinitionToFunction)
-        }
+        opts.ease = linear
 
         return opts
     },

--- a/src/motion/__tests__/animate-prop.test.tsx
+++ b/src/motion/__tests__/animate-prop.test.tsx
@@ -142,4 +142,52 @@ describe("animate prop as object", () => {
             "transform: translateX(30px) translateX(30px) translateZ(0)"
         )
     })
+
+    test("keyframes - accepts ease as an array", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const easingListener = jest.fn()
+            const easing = (v: number) => {
+                easingListener()
+                return v
+            }
+            const onComplete = () => resolve(easingListener)
+            const Component = () => (
+                <motion.div
+                    animate={{ x: [0, 1, 2] }}
+                    transition={{ ease: [easing, easing], duration: 0.1 }}
+                    style={{ x }}
+                    onAnimationComplete={onComplete}
+                />
+            )
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        return expect(promise).resolves.toHaveBeenCalled()
+    })
+
+    test("tween - accepts ease as an array", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const easingListener = jest.fn()
+            const easing = (v: number) => {
+                easingListener()
+                return v
+            }
+            const onComplete = () => resolve(easingListener)
+            const Component = () => (
+                <motion.div
+                    animate={{ x: 2 }}
+                    transition={{ ease: [easing, easing], duration: 0.1 }}
+                    style={{ x }}
+                    onAnimationComplete={onComplete}
+                />
+            )
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        return expect(promise).resolves.toHaveBeenCalled()
+    })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,9 +311,13 @@ export interface Tween {
      * />
      * ```
      *
+     * If the animating value is set as an array of multiple values for a keyframes
+     * animation, `ease` can be set as an array of easing functions to set different easings between
+     * each of those values.
+     *
      * @public
      */
-    ease?: Easing
+    ease?: Easing | Easing[]
 
     /**
      * The duration of time already elapsed in the animation. Set to `0` by
@@ -927,12 +931,14 @@ export interface Keyframes {
      *
      * @public
      */
-    easings?: Easing[]
+    ease?: Easing | Easing[]
 
     /**
+     * Popmotion's easing prop to define individual easings. `ease` will be mapped to this prop in keyframes animations.
+     *
      * @internal
      */
-    ease?: Easing
+    easings?: Easing | Easing[]
 
     /**
      * @internal


### PR DESCRIPTION
Fixes https://github.com/framer/motion/pull/106