### PR TITLE
Support CSS variables

### DIFF
--- a/dev/examples/colorVariables.tsx
+++ b/dev/examples/colorVariables.tsx
@@ -1,0 +1,39 @@
+import * as React from "react"
+import { useEffect } from "react"
+import { motion } from "@framer"
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "var(--from)",
+}
+
+export const App = () => {
+    const transition = {
+        type: "tween",
+        ease: "anticipate",
+        duration: 1,
+    }
+
+    const ref = React.useRef<HTMLDivElement>(null)
+    useEffect(() => {
+        function changeToVar() {
+            ref.current.style.setProperty("--to", "cyan")
+        }
+        const timer = setTimeout(changeToVar, 2000)
+        return () => clearTimeout(timer)
+    })
+
+    return (
+        <div style={{ "--from": "#09F", "--to": "#F00" } as any} ref={ref}>
+            <motion.div
+                animate={{
+                    background: "var(--to)",
+                    // transitionEnd: { background: "var(--to)" },
+                }}
+                transition={transition}
+                style={style}
+            />
+        </div>
+    )
+}

--- a/src/animation/ComponentAnimationControls.ts
+++ b/src/animation/ComponentAnimationControls.ts
@@ -14,6 +14,7 @@ import {
     ValueTarget,
 } from "../types"
 import { unitConversion } from "../dom/unit-type-conversion"
+import { resolveVariables } from "../dom/css-variables-conversion"
 import styler from "stylefire"
 import { VariantLabels, MotionProps } from "../motion/types"
 import { resolveFinalValueInKeyframes } from "../utils/resolve-value"
@@ -295,6 +296,17 @@ export class ComponentAnimationControls<P extends {} = {}, V extends {} = {}> {
         if (!target) return Promise.resolve()
 
         target = this.transformValues(target as any)
+
+        // Resolve CSS variables, returns modified copies if changed
+        const resolved = resolveVariables(
+            this.values,
+            target,
+            transitionEnd,
+            this.ref
+        )
+        target = resolved.target
+        transitionEnd = resolved.transitionEnd
+
         if (transitionEnd) {
             transitionEnd = this.transformValues(transitionEnd as any)
         }

--- a/src/dom/css-variables-conversion.ts
+++ b/src/dom/css-variables-conversion.ts
@@ -1,0 +1,66 @@
+import { RefObject } from "react"
+import { MotionValuesMap } from "../motion/utils/use-motion-values"
+import { Target, TargetWithKeyframes } from "../types"
+
+function isVariable(value: any): value is string {
+    return typeof value === "string" && value.startsWith("var(--")
+}
+
+const VariableRegex = /var\(([^\),]+)/
+
+function getVariableValue(
+    name: string,
+    element: HTMLElement
+): string | undefined {
+    const match = VariableRegex.exec(name)
+    const customProperty = match ? match[1].trim() : ""
+    return getComputedStyle(element).getPropertyValue(customProperty)
+}
+
+export function resolveVariables(
+    values: MotionValuesMap,
+    target: TargetWithKeyframes,
+    transitionEnd: Target | undefined,
+    ref: RefObject<Element>
+): { target: TargetWithKeyframes; transitionEnd?: Target } {
+    const { current: element } = ref
+    if (!(element instanceof HTMLElement)) return { target, transitionEnd }
+
+    values.forEach(value => {
+        const name = value.get()
+        if (isVariable(name)) {
+            const variableValue = getVariableValue(name, element)
+            if (variableValue) {
+                value.set(variableValue)
+            }
+        }
+    })
+
+    let targetClone: TargetWithKeyframes | undefined
+    let transitionEndClone: Target | undefined
+
+    const keys = Object.keys(target)
+    for (const key of keys) {
+        const name = target[key]
+        if (isVariable(name)) {
+            const variableValue = getVariableValue(name, element)
+            if (variableValue) {
+                if (!targetClone) {
+                    targetClone = { ...target }
+                }
+                targetClone[key] = variableValue
+                if (!transitionEndClone) {
+                    transitionEndClone = { ...transitionEnd }
+                }
+                if (transitionEndClone[key] === undefined) {
+                    transitionEndClone[key] = name
+                }
+            }
+        }
+    }
+
+    return {
+        target: targetClone || target,
+        transitionEnd: transitionEndClone || transitionEnd,
+    }
+}


### PR DESCRIPTION
Added a `resolveVariables` function that checks for any CSS variable values and transforms them into the actual values. The CSS variable values can be extracted from the DOM without having to change any styles.

## Example
Checkout the included `colorVariables.tsx` example.

## Todo
- [ ] Add tests (@InventingWithMonster what's the best approach?)