### PR TITLE
Docs: Transform Consistency and Options 

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -63,7 +63,7 @@ const getMixer = (v: any) => (isCustomValueType(v) ? v.mix : undefined)
  * @param inputValue - A number to transform between the input and output ranges.
  * @param inputRange - A linear series of numbers (either all increasing or decreasing).
  * @param outputRange - A series of numbers, colors or strings. Must be the same length as `inputRange`.
- * @param options - Clamp values to within the given range. Defaults to `true`.
+ * @param options - Clamp: Clamp values to within the given range. Defaults to `true`.
  *
  * @public
  */
@@ -95,7 +95,7 @@ export function transform<T>(
  *
  * @param inputRange - A linear series of numbers (either all increasing or decreasing).
  * @param outputRange - A series of numbers, colors or strings. Must be the same length as `inputRange`.
- * @param options - Clamp values to within the given range. Defaults to `true`.
+ * @param options - Clamp: clamp values to within the given range. Defaults to `true`.
  *
  * @public
  */


### PR DESCRIPTION
Fixes these broken lists and coloring and makes examples more consistent.

![image](https://user-images.githubusercontent.com/869934/56949614-a9ee9480-6b33-11e9-9520-807d9630b431.png)
