### PR TITLE
More accurate type definition for SVG elements in `motion` object

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -192,61 +192,61 @@ export type KeyframesTarget = ResolvedKeyframesTarget | [null, ...CustomValueTyp
 
 // @public
 export const motion: {
-    symbol: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    circle: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    clipPath: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    defs: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    desc: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    ellipse: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feBlend: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feColorMatrix: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feComponentTransfer: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feComposite: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feConvolveMatrix: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feDiffuseLighting: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feDisplacementMap: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feDistantLight: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feFlood: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feFuncA: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feFuncB: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feFuncG: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feFuncR: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feGaussianBlur: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feImage: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feMerge: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feMergeNode: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feMorphology: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feOffset: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    fePointLight: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feSpecularLighting: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feSpotLight: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feTile: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feTurbulence: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    filter: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    foreignObject: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    g: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    image: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    line: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    linearGradient: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    marker: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    mask: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    metadata: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    path: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    pattern: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    polygon: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    polyline: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    radialGradient: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    rect: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    stop: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    svg: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    switch: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    text: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    textPath: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    tspan: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    use: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    view: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    animate: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
-    feDropShadow: ForwardRefExoticComponent<SVGMotionProps & RefAttributes<SVGElement>>;
+    symbol: ForwardRefExoticComponent<SVGMotionProps<SVGSymbolElement> & RefAttributes<SVGSymbolElement>>;
+    circle: ForwardRefExoticComponent<SVGMotionProps<SVGCircleElement> & RefAttributes<SVGCircleElement>>;
+    clipPath: ForwardRefExoticComponent<SVGMotionProps<SVGClipPathElement> & RefAttributes<SVGClipPathElement>>;
+    defs: ForwardRefExoticComponent<SVGMotionProps<SVGDefsElement> & RefAttributes<SVGDefsElement>>;
+    desc: ForwardRefExoticComponent<SVGMotionProps<SVGDescElement> & RefAttributes<SVGDescElement>>;
+    ellipse: ForwardRefExoticComponent<SVGMotionProps<SVGEllipseElement> & RefAttributes<SVGEllipseElement>>;
+    feBlend: ForwardRefExoticComponent<SVGMotionProps<SVGFEBlendElement> & RefAttributes<SVGFEBlendElement>>;
+    feColorMatrix: ForwardRefExoticComponent<SVGMotionProps<SVGFEColorMatrixElement> & RefAttributes<SVGFEColorMatrixElement>>;
+    feComponentTransfer: ForwardRefExoticComponent<SVGMotionProps<SVGFEComponentTransferElement> & RefAttributes<SVGFEComponentTransferElement>>;
+    feComposite: ForwardRefExoticComponent<SVGMotionProps<SVGFECompositeElement> & RefAttributes<SVGFECompositeElement>>;
+    feConvolveMatrix: ForwardRefExoticComponent<SVGMotionProps<SVGFEConvolveMatrixElement> & RefAttributes<SVGFEConvolveMatrixElement>>;
+    feDiffuseLighting: ForwardRefExoticComponent<SVGMotionProps<SVGFEDiffuseLightingElement> & RefAttributes<SVGFEDiffuseLightingElement>>;
+    feDisplacementMap: ForwardRefExoticComponent<SVGMotionProps<SVGFEDisplacementMapElement> & RefAttributes<SVGFEDisplacementMapElement>>;
+    feDistantLight: ForwardRefExoticComponent<SVGMotionProps<SVGFEDistantLightElement> & RefAttributes<SVGFEDistantLightElement>>;
+    feFlood: ForwardRefExoticComponent<SVGMotionProps<SVGFEFloodElement> & RefAttributes<SVGFEFloodElement>>;
+    feFuncA: ForwardRefExoticComponent<SVGMotionProps<SVGFEFuncAElement> & RefAttributes<SVGFEFuncAElement>>;
+    feFuncB: ForwardRefExoticComponent<SVGMotionProps<SVGFEFuncBElement> & RefAttributes<SVGFEFuncBElement>>;
+    feFuncG: ForwardRefExoticComponent<SVGMotionProps<SVGFEFuncGElement> & RefAttributes<SVGFEFuncGElement>>;
+    feFuncR: ForwardRefExoticComponent<SVGMotionProps<SVGFEFuncRElement> & RefAttributes<SVGFEFuncRElement>>;
+    feGaussianBlur: ForwardRefExoticComponent<SVGMotionProps<SVGFEGaussianBlurElement> & RefAttributes<SVGFEGaussianBlurElement>>;
+    feImage: ForwardRefExoticComponent<SVGMotionProps<SVGFEImageElement> & RefAttributes<SVGFEImageElement>>;
+    feMerge: ForwardRefExoticComponent<SVGMotionProps<SVGFEMergeElement> & RefAttributes<SVGFEMergeElement>>;
+    feMergeNode: ForwardRefExoticComponent<SVGMotionProps<SVGFEMergeNodeElement> & RefAttributes<SVGFEMergeNodeElement>>;
+    feMorphology: ForwardRefExoticComponent<SVGMotionProps<SVGFEMorphologyElement> & RefAttributes<SVGFEMorphologyElement>>;
+    feOffset: ForwardRefExoticComponent<SVGMotionProps<SVGFEOffsetElement> & RefAttributes<SVGFEOffsetElement>>;
+    fePointLight: ForwardRefExoticComponent<SVGMotionProps<SVGFEPointLightElement> & RefAttributes<SVGFEPointLightElement>>;
+    feSpecularLighting: ForwardRefExoticComponent<SVGMotionProps<SVGFESpecularLightingElement> & RefAttributes<SVGFESpecularLightingElement>>;
+    feSpotLight: ForwardRefExoticComponent<SVGMotionProps<SVGFESpotLightElement> & RefAttributes<SVGFESpotLightElement>>;
+    feTile: ForwardRefExoticComponent<SVGMotionProps<SVGFETileElement> & RefAttributes<SVGFETileElement>>;
+    feTurbulence: ForwardRefExoticComponent<SVGMotionProps<SVGFETurbulenceElement> & RefAttributes<SVGFETurbulenceElement>>;
+    filter: ForwardRefExoticComponent<SVGMotionProps<SVGFilterElement> & RefAttributes<SVGFilterElement>>;
+    foreignObject: ForwardRefExoticComponent<SVGMotionProps<SVGForeignObjectElement> & RefAttributes<SVGForeignObjectElement>>;
+    g: ForwardRefExoticComponent<SVGMotionProps<SVGGElement> & RefAttributes<SVGGElement>>;
+    image: ForwardRefExoticComponent<SVGMotionProps<SVGImageElement> & RefAttributes<SVGImageElement>>;
+    line: ForwardRefExoticComponent<SVGMotionProps<SVGLineElement> & RefAttributes<SVGLineElement>>;
+    linearGradient: ForwardRefExoticComponent<SVGMotionProps<SVGLinearGradientElement> & RefAttributes<SVGLinearGradientElement>>;
+    marker: ForwardRefExoticComponent<SVGMotionProps<SVGMarkerElement> & RefAttributes<SVGMarkerElement>>;
+    mask: ForwardRefExoticComponent<SVGMotionProps<SVGMaskElement> & RefAttributes<SVGMaskElement>>;
+    metadata: ForwardRefExoticComponent<SVGMotionProps<SVGMetadataElement> & RefAttributes<SVGMetadataElement>>;
+    path: ForwardRefExoticComponent<SVGMotionProps<SVGPathElement> & RefAttributes<SVGPathElement>>;
+    pattern: ForwardRefExoticComponent<SVGMotionProps<SVGPatternElement> & RefAttributes<SVGPatternElement>>;
+    polygon: ForwardRefExoticComponent<SVGMotionProps<SVGPolygonElement> & RefAttributes<SVGPolygonElement>>;
+    polyline: ForwardRefExoticComponent<SVGMotionProps<SVGPolylineElement> & RefAttributes<SVGPolylineElement>>;
+    radialGradient: ForwardRefExoticComponent<SVGMotionProps<SVGRadialGradientElement> & RefAttributes<SVGRadialGradientElement>>;
+    rect: ForwardRefExoticComponent<SVGMotionProps<SVGRectElement> & RefAttributes<SVGRectElement>>;
+    stop: ForwardRefExoticComponent<SVGMotionProps<SVGStopElement> & RefAttributes<SVGStopElement>>;
+    svg: ForwardRefExoticComponent<SVGMotionProps<SVGSVGElement> & RefAttributes<SVGSVGElement>>;
+    switch: ForwardRefExoticComponent<SVGMotionProps<SVGSwitchElement> & RefAttributes<SVGSwitchElement>>;
+    text: ForwardRefExoticComponent<SVGMotionProps<SVGTextElement> & RefAttributes<SVGTextElement>>;
+    textPath: ForwardRefExoticComponent<SVGMotionProps<SVGTextPathElement> & RefAttributes<SVGTextPathElement>>;
+    tspan: ForwardRefExoticComponent<SVGMotionProps<SVGTSpanElement> & RefAttributes<SVGTSpanElement>>;
+    use: ForwardRefExoticComponent<SVGMotionProps<SVGUseElement> & RefAttributes<SVGUseElement>>;
+    view: ForwardRefExoticComponent<SVGMotionProps<SVGViewElement> & RefAttributes<SVGViewElement>>;
+    animate: ForwardRefExoticComponent<SVGMotionProps<SVGElement> & RefAttributes<SVGElement>>;
+    feDropShadow: ForwardRefExoticComponent<SVGMotionProps<SVGFEDropShadowElement> & RefAttributes<SVGFEDropShadowElement>>;
     object: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<import("react").ObjectHTMLAttributes<HTMLObjectElement>, HTMLObjectElement> & MotionProps & RefAttributes<HTMLObjectElement>>;
     big: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<HTMLAttributes<HTMLElement>, HTMLElement> & MotionProps & RefAttributes<HTMLElement>>;
     link: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<import("react").LinkHTMLAttributes<HTMLLinkElement>, HTMLLinkElement> & MotionProps & RefAttributes<HTMLLinkElement>>;
@@ -558,12 +558,12 @@ export type Subscriber<T> = (v: T) => void;
 // Warning: (ae-forgotten-export) The symbol "SVGAttributesWithoutMotionProps" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export type SVGAttributesAsMotionValues = MakeMotion<SVGAttributesWithoutMotionProps>;
+export type SVGAttributesAsMotionValues<T> = MakeMotion<SVGAttributesWithoutMotionProps<T>>;
 
 // Warning: (ae-forgotten-export) The symbol "Omit" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-export interface SVGMotionProps extends SVGAttributesAsMotionValues, Omit<MotionProps, "positionTransition"> {
+export interface SVGMotionProps<T> extends SVGAttributesAsMotionValues<T>, Omit<MotionProps, "positionTransition"> {
 }
 
 // @public (undocumented)

--- a/src/motion/__tests__/component-svg.test.tsx
+++ b/src/motion/__tests__/component-svg.test.tsx
@@ -50,4 +50,16 @@ describe("SVG", () => {
         expect(r.get()).toBe(100)
         expect(fill.get()).toBe("rgba(255, 0, 0, 1)")
     })
+
+    test("motion svg elements should be able to set correct type of ref", () => {
+        const Component = () => {
+            const ref = React.useRef<SVGTextElement>(null)
+            return (
+                <svg>
+                    <motion.text ref={ref}>Framer Motion</motion.text>
+                </svg>
+            )
+        }
+        render(<Component />)
+    })
 })

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -34,6 +34,8 @@ export const htmlMotionComponents: HTMLMotionComponents = htmlElements.reduce(
 
 export const svgMotionComponents: SVGMotionComponents = svgElements.reduce(
     (acc, Component) => {
+        // Suppress "Expression produces a union type that is too complex to represent" error
+        // @ts-ignore
         acc[Component] = createMotionComponent(createDomMotionConfig(Component))
         return acc
     },
@@ -73,6 +75,7 @@ type UnwrapFactoryAttributes<F> = F extends DetailedHTMLFactory<infer P, any>
 type UnwrapFactoryElement<F> = F extends DetailedHTMLFactory<any, infer P>
     ? P
     : never
+type UnwrapSVGFactoryElement<F> = F extends React.SVGProps<infer P> ? P : never
 
 type HTMLAttributesWithoutMotionProps<
     Attributes extends HTMLAttributes<Element>,
@@ -97,30 +100,30 @@ export type HTMLMotionProps<
  */
 export type HTMLMotionComponents = {
     [K in HTMLElements]: ForwardRefComponent<
-        UnwrapFactoryElement<ReactHTML[K]>,
+        UnwrapFactoryElement<JSX.IntrinsicElements[K]>,
         HTMLMotionProps<K>
     >
 }
 
-interface SVGAttributesWithoutMotionProps
+interface SVGAttributesWithoutMotionProps<T>
     extends Pick<
-        SVGAttributes<SVGElement>,
-        Exclude<keyof SVGAttributes<SVGElement>, keyof MotionProps>
+        SVGAttributes<T>,
+        Exclude<keyof SVGAttributes<T>, keyof MotionProps>
     > {}
 
 /**
  * Blanket-accept any SVG attribute as a `MotionValue`
  * @public
  */
-export type SVGAttributesAsMotionValues = MakeMotion<
-    SVGAttributesWithoutMotionProps
+export type SVGAttributesAsMotionValues<T> = MakeMotion<
+    SVGAttributesWithoutMotionProps<T>
 >
 
 /**
  * @public
  */
-export interface SVGMotionProps
-    extends SVGAttributesAsMotionValues,
+export interface SVGMotionProps<T>
+    extends SVGAttributesAsMotionValues<T>,
         Omit<MotionProps, "positionTransition"> {}
 
 type ForwardRefComponent<T, P> = ForwardRefExoticComponent<
@@ -133,5 +136,8 @@ type ForwardRefComponent<T, P> = ForwardRefExoticComponent<
  * @public
  */
 export type SVGMotionComponents = {
-    [K in SVGElements]: ForwardRefComponent<SVGElement, SVGMotionProps>
+    [K in SVGElements]: ForwardRefComponent<
+        UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>,
+        SVGMotionProps<UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>>
+    >
 }

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -100,7 +100,7 @@ export type HTMLMotionProps<
  */
 export type HTMLMotionComponents = {
     [K in HTMLElements]: ForwardRefComponent<
-        UnwrapFactoryElement<JSX.IntrinsicElements[K]>,
+        UnwrapFactoryElement<ReactHTML[K]>,
         HTMLMotionProps<K>
     >
 }

--- a/src/motion/utils/supported-elements.ts
+++ b/src/motion/utils/supported-elements.ts
@@ -1,13 +1,9 @@
-import { ReactHTML, ReactSVG } from "react"
-// These are identity functions that help TypeScript understand the type of the provided array
-const htmlTuple = <T extends keyof ReactHTML>(args: T[]) => args
-const svgTuple = <T extends keyof ReactSVG>(args: T[]) => args
-type UnionStringArray<T extends string[]> = T[number]
+type UnionStringArray<T extends Readonly<string[]>> = T[number]
 
 /**
  * @internal
  */
-export const htmlElements = htmlTuple([
+export const htmlElements = [
     "a",
     "abbr",
     "address",
@@ -122,13 +118,13 @@ export const htmlElements = htmlTuple([
     "video",
     "wbr",
     "webview",
-])
+] as const
 export type HTMLElements = UnionStringArray<typeof htmlElements>
 
 /**
  * @internal
  */
-export const svgElements: (keyof ReactSVG)[] = svgTuple([
+export const svgElements = [
     "animate",
     "circle",
     "clipPath",
@@ -184,5 +180,5 @@ export const svgElements: (keyof ReactSVG)[] = svgTuple([
     "tspan",
     "use",
     "view",
-])
+] as const
 export type SVGElements = UnionStringArray<typeof svgElements>


### PR DESCRIPTION
This PR provides more accurate props definition for SVG elements in `motion`.

Before this PR, the ref of `<motion.text />` is typed as `SVGElement`
<img width="766" alt="Screenshot 2019-07-12 at 12 18 11 AM" src="https://user-images.githubusercontent.com/1313238/61067938-640b5200-a43b-11e9-92e1-ce1960564916.png">

In this PR, the ref of `<motion.text />` is typed as `SVGTextElement`
<img width="763" alt="Screenshot 2019-07-12 at 12 21 03 AM" src="https://user-images.githubusercontent.com/1313238/61067958-6a013300-a43b-11e9-8a08-245e66836fab.png">
