### PR TITLE
feat(use-viewport-scroll): support passing element ref

### DIFF
--- a/src/value/use-viewport-scroll.ts
+++ b/src/value/use-viewport-scroll.ts
@@ -1,4 +1,7 @@
-import { motionValue, MotionValue } from "."
+import { invariant } from "hey-listen"
+import { useLayoutEffect, RefObject } from "react"
+import { MotionValue } from "../value"
+import { useMotionValue } from "./use-motion-value"
 
 export interface ScrollMotionValues {
     scrollX: MotionValue<number>
@@ -7,54 +10,87 @@ export interface ScrollMotionValues {
     scrollYProgress: MotionValue<number>
 }
 
-const scrollX = motionValue(0)
-const scrollY = motionValue(0)
-const scrollXProgress = motionValue(0)
-const scrollYProgress = motionValue(0)
-
-const setProgress = (offset: number, maxOffset: number, value: MotionValue) => {
-    value.set(!maxOffset || !offset ? 0 : offset / maxOffset)
-}
-
-let hasEventListener = false
-const addScrollListener = () => {
-    hasEventListener = true
-
-    if (typeof window === "undefined") return
-
-    const updateScrollValues = () => {
-        const xOffset = window.pageXOffset
-        const yOffset = window.pageYOffset
-
-        // Set absolute positions
-        scrollX.set(xOffset)
-        scrollY.set(yOffset)
-
-        // Set 0-1 progress
-        setProgress(
-            xOffset,
-            document.body.clientWidth - window.innerWidth,
-            scrollXProgress
-        )
-        setProgress(
-            yOffset,
-            document.body.clientHeight - window.innerHeight,
-            scrollYProgress
-        )
+function getWindowOffsets() {
+    return {
+        xOffset: window.pageXOffset,
+        yOffset: window.pageYOffset,
+        xMaxOffset: document.body.clientWidth - window.innerWidth,
+        yMaxOffset: document.body.clientHeight - window.innerHeight,
     }
-
-    updateScrollValues()
-
-    window.addEventListener("resize", updateScrollValues)
-    window.addEventListener("scroll", updateScrollValues, { passive: true })
 }
 
-const viewportMotionValues: ScrollMotionValues = {
-    scrollX,
-    scrollY,
-    scrollXProgress,
-    scrollYProgress,
+function getElementOffsets(element: HTMLElement) {
+    return {
+        xOffset: element.scrollLeft,
+        yOffset: element.scrollTop,
+        xMaxOffset: element.scrollWidth - element.offsetWidth,
+        yMaxOffset: element.scrollHeight - element.offsetHeight,
+    }
 }
+
+function createWindowListeners(updateCallback) {
+    window.addEventListener("resize", updateCallback)
+    window.addEventListener("scroll", updateCallback, { passive: true })
+    return () => {
+        window.removeEventListener("resize", updateCallback)
+        window.removeEventListener("scroll", updateCallback, { passive: true })
+    }
+}
+
+function createElementListeners(element: HTMLElement, updateCallback) {
+    let resizeObserver
+    if (window.ResizeObserver) {
+        resizeObserver = new window.ResizeObserver(updateCallback)
+        resizeObserver.observe(element)
+    }
+    element.addEventListener("scroll", updateCallback, { passive: true })
+    return () => {
+        if (resizeObserver) {
+            resizeObserver.disconnect()
+        }
+        element.removeEventListener("scroll", updateCallback, { passive: true })
+    }
+}
+
+function setProgress(offset: number, maxOffset: number, value: MotionValue) {
+    value.set(!offset || !maxOffset ? 0 : offset / maxOffset)
+}
+
+/**
+ * Provides `MotionValue`s that update when the viewport scrolls:
+ *
+ * - `scrollX` — Horizontal scroll distance in pixels.
+ * - `scrollY` — Vertical scroll distance in pixels.
+ * - `scrollXProgress` — Horizontal scroll progress between `0` and `1`.
+ * - `scrollYProgress` — Vertical scroll progress between `0` and `1`.
+ *
+ * @library
+ *
+ * ```jsx
+ * import * as React from "react"
+ * import {
+ *   Frame,
+ *   useViewportScroll,
+ *   useTransform
+ * } from "framer"
+ *
+ * export function MyComponent() {
+ *   const { scrollYProgress } = useViewportScroll()
+ *   return <Frame scaleX={scrollYProgress} />
+ * }
+ * ```
+ *
+ * @motion
+ *
+ * ```jsx
+ * export const MyComponent = () => {
+ *   const { scrollYProgress } = useViewportScroll()
+ *   return <motion.div style={{ scaleX: scrollYProgress }} />
+ * }
+ * ```
+ *
+ * @public
+ */
 
 /**
  * Provides `MotionValue`s that update when the viewport scrolls:
@@ -96,10 +132,46 @@ const viewportMotionValues: ScrollMotionValues = {
  *
  * @public
  */
-export function useViewportScroll() {
-    if (!hasEventListener) {
-        addScrollListener()
+export function useViewportScroll(ref: undefined | RefObject<Element>) {
+    const scrollX = useMotionValue(0)
+    const scrollY = useMotionValue(0)
+    const scrollXProgress = useMotionValue(0)
+    const scrollYProgress = useMotionValue(0)
+    const viewportMotionValues: ScrollMotionValues = {
+        scrollX,
+        scrollY,
+        scrollXProgress,
+        scrollYProgress,
     }
+
+    invariant(
+        (ref && ref.current !== null) || true,
+        "If passing a React ref, that ref must be passed to another component's `ref` prop."
+    )
+
+    useLayoutEffect(() => {
+        const isElement = Boolean(ref)
+        const updateScrollValues = () => {
+            const { xOffset, yOffset, xMaxOffset, yMaxOffset } = isElement
+                ? getElementOffsets(ref.current)
+                : getWindowOffsets()
+
+            // Set absolute positions
+            scrollX.set(xOffset)
+            scrollY.set(yOffset)
+
+            // Set 0-1 progress
+            setProgress(xOffset, xMaxOffset, scrollXProgress)
+            setProgress(yOffset, yMaxOffset, scrollYProgress)
+        }
+        const removeEventListeners = isElement
+            ? createElementListeners(ref.current, updateScrollValues)
+            : createWindowListeners(updateScrollValues)
+
+        updateScrollValues()
+
+        return removeEventListeners
+    })
 
     return viewportMotionValues
 }


### PR DESCRIPTION
This was a quick take on adding `ref` support to `useViewportScroll`, curious your thoughts on everything. Still new to Typescript, so I'm sure I'm missing some things 😇. Please comment on any concerns and I can address them. I can also update documentation once there's some finalization and take a stab at adding tests.

Some questions I had while implementing this:
- Should we probably warn if `ref.current` is available but is not `overflow: scroll`?
- Another solution could be to just grab the scroll closest scroll container, I have a small function from another library I can add to implement this
- We should probably handle only adding one listener per element/window similar to what you had originally
- Can we utilize `useResize` hook and implement `ResizeObserver` inside that?

I understand if you don't want to add `ResizeObserver` support. Although, I think it could be ok since most modern browsers will support this in their [next release](https://caniuse.com/#feat=resizeobserver). We could also add docs and point to the polyfill since older browser support is probably needed. 
 
Closes #182 