### PR TITLE
Exporting list of valid MotionProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## Unreleased
+
+### Added
+
+-   Exporting `validMotionProps`.
+
+## [1.2.3] 2019-07-11
 
 ### Fixed
 
--   Don't attempt to run useLayoutEffect when SSRing.
+-   Don't load `positionTransition` functionality component server-side.
+-   In development mode, ensuring all child keys are unique.
 
 ## [1.2.2] 2019-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--   Exporting `validMotionProps`.
+-   Exporting `_validMotionProps`.
 
 ## [1.2.3] 2019-07-11
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -687,10 +687,8 @@ export function useTransform<T>(parent: MotionValue<number>, from: number[], to:
 // @public
 export function useViewportScroll(): ScrollMotionValues;
 
-// Warning: (ae-internal-missing-underscore) The name "validMotionProps" should be prefixed with an underscore because the declaration is marked as @internal
-// 
 // @internal
-export const validMotionProps: Set<"custom" | "inherit" | "exit" | "style" | "drag" | "initial" | "static" | "animate" | "transition" | "onDrag" | "onDragEnd" | "onDragStart" | "transformValues" | "onAnimationComplete" | "onPan" | "onPanStart" | "onPanEnd" | "onPanSessionStart" | "whileHover" | "whileTap" | "onTap" | "onTapStart" | "onTapCancel" | "onHoverStart" | "onHoverEnd" | "dragConstraints" | "dragDirectionLock" | "dragPropagation" | "dragElastic" | "dragMomentum" | "dragOriginX" | "dragOriginY" | "dragTransition" | "onDirectionLock" | "onDragTransitionEnd" | "onUpdate" | "transformTemplate" | "variants" | "positionTransition">;
+export const _validMotionProps: Set<"custom" | "inherit" | "exit" | "style" | "drag" | "initial" | "static" | "animate" | "transition" | "onDrag" | "onDragEnd" | "onDragStart" | "transformValues" | "onAnimationComplete" | "onPan" | "onPanStart" | "onPanEnd" | "onPanSessionStart" | "whileHover" | "whileTap" | "onTap" | "onTapStart" | "onTapCancel" | "onHoverStart" | "onHoverEnd" | "dragConstraints" | "dragDirectionLock" | "dragPropagation" | "dragElastic" | "dragMomentum" | "dragOriginX" | "dragOriginY" | "dragTransition" | "onDirectionLock" | "onDragTransitionEnd" | "onUpdate" | "transformTemplate" | "variants" | "positionTransition">;
 
 // @public (undocumented)
 export type ValueTarget = SingleTarget | KeyframesTarget;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -687,6 +687,11 @@ export function useTransform<T>(parent: MotionValue<number>, from: number[], to:
 // @public
 export function useViewportScroll(): ScrollMotionValues;
 
+// Warning: (ae-internal-missing-underscore) The name "validMotionProps" should be prefixed with an underscore because the declaration is marked as @internal
+// 
+// @internal
+export const validMotionProps: Set<"custom" | "inherit" | "exit" | "style" | "drag" | "initial" | "static" | "animate" | "transition" | "onDrag" | "onDragEnd" | "onDragStart" | "transformValues" | "onAnimationComplete" | "onPan" | "onPanStart" | "onPanEnd" | "onPanSessionStart" | "whileHover" | "whileTap" | "onTap" | "onTapStart" | "onTapCancel" | "onHoverStart" | "onHoverEnd" | "dragConstraints" | "dragDirectionLock" | "dragPropagation" | "dragElastic" | "dragMomentum" | "dragOriginX" | "dragOriginY" | "dragTransition" | "onDirectionLock" | "onDragTransitionEnd" | "onUpdate" | "transformTemplate" | "variants" | "positionTransition">;
+
 // @public (undocumented)
 export type ValueTarget = SingleTarget | KeyframesTarget;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,4 +73,4 @@ export {
     AnimatePresence,
     AnimatePresenceProps,
 } from "./components/AnimatePresence"
-export { validMotionProps } from "./motion/functionality/dom"
+export { _validMotionProps } from "./motion/functionality/dom"

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,3 +73,4 @@ export {
     AnimatePresence,
     AnimatePresenceProps,
 } from "./components/AnimatePresence"
+export { validMotionProps } from "./motion/functionality/dom"

--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -313,4 +313,9 @@ describe("motion component rendering and styles", () => {
             "transform: translateY(20px) translateX(10px)"
         )
     })
+
+    it("filters MotionProps from the DOM", () => {
+        const { container } = render(<motion.div initial={{ opacity: 0 }} />)
+        expect(container.firstChild).not.toHaveAttribute("initial")
+    })
 })

--- a/src/motion/functionality/dom.tsx
+++ b/src/motion/functionality/dom.tsx
@@ -20,51 +20,66 @@ type RenderProps = FunctionalProps & {
     isStatic: boolean | undefined
 }
 
-// TODO: Type this in a way that ensures no `MotionProps` are remaining.
-// Oddly, `Omit<MotionProps, keyof MotionProps>` or types to that extend
-// didn't throw and error when props were actually present.
-function stripMotionProps({
-    initial,
-    animate,
-    exit,
-    style,
-    variants,
-    transition,
-    transformTemplate,
-    custom,
-    inherit,
-    static: s,
-    positionTransition,
-    onAnimationComplete,
-    onUpdate,
-    onDragStart,
-    onDrag,
-    onDragEnd,
-    onDirectionLock,
-    onDragTransitionEnd,
-    drag,
-    dragConstraints,
-    dragDirectionLock,
-    dragElastic,
-    dragMomentum,
-    dragPropagation,
-    dragTransition,
-    dragOriginX,
-    dragOriginY,
-    onPan,
-    onPanStart,
-    onPanEnd,
-    onPanSessionStart,
-    onTap,
-    onTapStart,
-    onTapCancel,
-    whileHover,
-    whileTap,
-    onHoverEnd,
-    onHoverStart,
-    ...props
-}: MotionProps) {
-    return props
+/**
+ * A list of all valid MotionProps
+ *
+ * @internalremarks
+ * This doesn't throw if a `MotionProp` name is missing - it should.
+ *
+ * @internal
+ */
+export const validMotionProps = new Set<keyof MotionProps>([
+    "initial",
+    "animate",
+    "exit",
+    "style",
+    "variants",
+    "transition",
+    "transformTemplate",
+    "transformValues",
+    "custom",
+    "inherit",
+    "static",
+    "positionTransition",
+    "onAnimationComplete",
+    "onUpdate",
+    "onDragStart",
+    "onDrag",
+    "onDragEnd",
+    "onDirectionLock",
+    "onDragTransitionEnd",
+    "drag",
+    "dragConstraints",
+    "dragDirectionLock",
+    "dragElastic",
+    "dragMomentum",
+    "dragPropagation",
+    "dragTransition",
+    "dragOriginX",
+    "dragOriginY",
+    "onPan",
+    "onPanStart",
+    "onPanEnd",
+    "onPanSessionStart",
+    "onTap",
+    "onTapStart",
+    "onTapCancel",
+    "whileHover",
+    "whileTap",
+    "onHoverEnd",
+    "onHoverStart",
+])
+
+function stripMotionProps(props: MotionProps) {
+    const domProps = {}
+
+    for (const key in props) {
+        if (!validMotionProps.has(key as keyof MotionProps)) {
+            domProps[key] = props[key]
+        }
+    }
+
+    return domProps
 }
 
 const buildSVGProps = (values: MotionValuesMap, style: CSSProperties) => {

--- a/src/motion/functionality/dom.tsx
+++ b/src/motion/functionality/dom.tsx
@@ -28,7 +28,7 @@ type RenderProps = FunctionalProps & {
  *
  * @internal
  */
-export const validMotionProps = new Set<keyof MotionProps>([
+export const _validMotionProps = new Set<keyof MotionProps>([
     "initial",
     "animate",
     "exit",
@@ -74,7 +74,7 @@ function stripMotionProps(props: MotionProps) {
     const domProps = {}
 
     for (const key in props) {
-        if (!validMotionProps.has(key as keyof MotionProps)) {
+        if (!_validMotionProps.has(key as keyof MotionProps)) {
             domProps[key] = props[key]
         }
     }


### PR DESCRIPTION
So we can select these in Library.

Also moving from a destructuring approach to object iteration + Set lookup for filtering out MotionProps, which is 10x faster and allocates less memory.

![image](https://user-images.githubusercontent.com/7850794/61209408-f50f5100-a6f9-11e9-93d9-fc5770ed5323.png)

(The Map lookup is marginally faster still, but the definition is messier)