### PR TITLE
Animating existing variants on newly-added variant children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   Fixing unit type conversions when non-positional transforms are applied.
 -   Fixing variant propagation via `useAnimation()` when the parent component has no `variants` prop set.
 -   Fixing unsetting `whileHover` and `whileTap` if they contain `transitionEnd` values.
+-   Child components within variant trees now animate to `animate` as set by their parent.
+-   Checking animation props for array variants as well as strings.
 
 ## [1.2.4] 2019-07-15
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -70,7 +70,7 @@ export interface AnimationProps {
 // Warning: (ae-internal-missing-underscore) The name "createMotionComponent" should be prefixed with an underscore because the declaration is marked as @internal
 // 
 // @internal (undocumented)
-export const createMotionComponent: <P extends {}>({ useFunctionalityComponents, getValueControlsConfig, }: MotionComponentConfig) => React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<Element>>;
+export const createMotionComponent: <P extends {}>({ getValueControlsConfig, loadFunctionalityComponents, renderComponent, }: MotionComponentConfig) => React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<Element>>;
 
 // @public (undocumented)
 export interface CustomValueType {

--- a/src/animation/use-value-animation-controls.ts
+++ b/src/animation/use-value-animation-controls.ts
@@ -15,14 +15,14 @@ import { useConstant } from "../utils/use-constant"
  * @param values
  * @param props
  * @param ref
- * @param inheritVariantChanges
+ * @param subscribeToParentControls
  *
  * @internal
  */
 export function useValueAnimationControls<P>(
     config: ValueAnimationConfig,
     props: P & MotionProps,
-    inheritVariantChanges: boolean
+    subscribeToParentControls: boolean
 ) {
     const { variants, transition } = props
     const parentControls = useContext(MotionContext).controls
@@ -34,7 +34,7 @@ export function useValueAnimationControls<P>(
     controls.setVariants(variants)
     controls.setDefaultTransition(transition)
 
-    if (inheritVariantChanges && parentControls) {
+    if (subscribeToParentControls && parentControls) {
         parentControls.addChild(controls)
     }
 

--- a/src/animation/use-value-animation-controls.ts
+++ b/src/animation/use-value-animation-controls.ts
@@ -30,6 +30,9 @@ export function useValueAnimationControls<P>(
 
     // Reset and resubscribe children every render to ensure stagger order is correct
     controls.resetChildren()
+    controls.setProps(props)
+    controls.setVariants(variants)
+    controls.setDefaultTransition(transition)
 
     if (inheritVariantChanges && parentControls) {
         parentControls.addChild(controls)
@@ -39,10 +42,6 @@ export function useValueAnimationControls<P>(
         () => () => parentControls && parentControls.removeChild(controls),
         []
     )
-
-    controls.setProps(props)
-    controls.setVariants(variants)
-    controls.setDefaultTransition(transition)
 
     return controls
 }

--- a/src/animation/use-variants.ts
+++ b/src/animation/use-variants.ts
@@ -4,7 +4,8 @@ import {
     resolveVariantLabels,
     asDependencyList,
 } from "./utils/variant-resolvers"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useContext } from "react"
+import { MotionContext } from "../motion"
 
 const hasVariantChanged = (oldVariant: string[], newVariant: string[]) => {
     return oldVariant.join(",") !== newVariant.join(",")
@@ -13,34 +14,38 @@ const hasVariantChanged = (oldVariant: string[], newVariant: string[]) => {
 /**
  * Handle variants and the `animate` prop when its set as variant labels.
  *
- * @param targetVariant
- * @param inherit
- * @param controls
- * @param initialVariant
+ * @param initial - Initial variant(s)
+ * @param animate - Variant(s) to animate to
+ * @param inherit - `true` is inheriting animations from parent
+ * @param controls - Animation controls
  *
  * @internal
  */
 export function useVariants(
-    targetVariant: VariantLabels,
+    initial: VariantLabels,
+    animate: VariantLabels,
     inherit: boolean,
-    controls: ValueAnimationControls,
-    initialVariant: VariantLabels
+    controls: ValueAnimationControls
 ) {
-    const variantList = resolveVariantLabels(targetVariant)
+    const targetVariants = resolveVariantLabels(animate)
+    const context = useContext(MotionContext)
+    // const parentAlreadyMounted =
+    //     context.hasMounted && context.hasMounted.current
     const hasMounted = useRef(false)
 
-    // Fire animations when poses change
+    console.log(inherit, animate, context.hasMounted)
     useEffect(() => {
-        // TODO: This logic might mean we don't need to load this hook at all
-        if (inherit) return
+        let shouldAnimate = false
 
-        if (
-            hasMounted.current ||
-            hasVariantChanged(resolveVariantLabels(initialVariant), variantList)
-        ) {
-            controls.start(variantList)
+        if (inherit) {
+        } else {
+            shouldAnimate =
+                hasMounted.current ||
+                hasVariantChanged(resolveVariantLabels(initial), targetVariants)
         }
 
+        shouldAnimate && controls.start(targetVariants)
+
         hasMounted.current = true
-    }, asDependencyList(variantList))
+    }, asDependencyList(targetVariants))
 }

--- a/src/animation/use-variants.ts
+++ b/src/animation/use-variants.ts
@@ -27,17 +27,21 @@ export function useVariants(
     inherit: boolean,
     controls: ValueAnimationControls
 ) {
-    const targetVariants = resolveVariantLabels(animate)
+    let targetVariants = resolveVariantLabels(animate)
     const context = useContext(MotionContext)
-    // const parentAlreadyMounted =
-    //     context.hasMounted && context.hasMounted.current
+    const parentAlreadyMounted =
+        context.hasMounted && context.hasMounted.current
     const hasMounted = useRef(false)
 
-    console.log(inherit, animate, context.hasMounted)
     useEffect(() => {
         let shouldAnimate = false
 
         if (inherit) {
+            // If we're inheriting variant changes and the parent has already
+            // mounted when this component loads, we need to manually trigger
+            // this animation.
+            shouldAnimate = !!parentAlreadyMounted
+            targetVariants = resolveVariantLabels(context.animate)
         } else {
             shouldAnimate =
                 hasMounted.current ||

--- a/src/events/use-event.ts
+++ b/src/events/use-event.ts
@@ -19,8 +19,6 @@ export const eventListener = (
             return
         }
 
-        // TODO: Pointer events are stacking after every pan start
-        // https://github.com/framer/company/issues/12814
         target.addEventListener(name, handler, options)
     }
     const stopListening = () => {

--- a/src/motion/__tests__/variant.test.tsx
+++ b/src/motion/__tests__/variant.test.tsx
@@ -10,396 +10,425 @@ describe("animate prop as variant", () => {
         hidden: { opacity: 0, x: -100, transition: { type: false } },
         visible: { opacity: 1, x: 100, transition: { type: false } },
     }
-    const childVariants: Variants = {
-        hidden: { opacity: 0, x: -100, transition: { type: false } },
-        visible: { opacity: 1, x: 50, transition: { type: false } },
-    }
+    // const childVariants: Variants = {
+    //     hidden: { opacity: 0, x: -100, transition: { type: false } },
+    //     visible: { opacity: 1, x: 50, transition: { type: false } },
+    // }
 
-    test("animates to set variant", async () => {
-        const promise = new Promise(resolve => {
-            const x = motionValue(0)
-            const onComplete = () => resolve(x.get())
-            const { rerender } = render(
-                <motion.div
-                    animate="visible"
-                    variants={variants}
-                    style={{ x }}
-                    onAnimationComplete={onComplete}
-                />
-            )
-            rerender(
-                <motion.div
-                    animate="visible"
-                    variants={variants}
-                    style={{ x }}
-                    onAnimationComplete={onComplete}
-                />
-            )
-        })
+    // test("animates to set variant", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const x = motionValue(0)
+    //         const onComplete = () => resolve(x.get())
+    //         const { rerender } = render(
+    //             <motion.div
+    //                 animate="visible"
+    //                 variants={variants}
+    //                 style={{ x }}
+    //                 onAnimationComplete={onComplete}
+    //             />
+    //         )
+    //         rerender(
+    //             <motion.div
+    //                 animate="visible"
+    //                 variants={variants}
+    //                 style={{ x }}
+    //                 onAnimationComplete={onComplete}
+    //             />
+    //         )
+    //     })
 
-        return expect(promise).resolves.toBe(100)
-    })
+    //     return expect(promise).resolves.toBe(100)
+    // })
 
-    test("child animates to set variant", async () => {
-        const promise = new Promise(resolve => {
-            const x = motionValue(0)
-            const onComplete = () => resolve(x.get())
-            const Component = () => (
-                <motion.div
-                    animate="visible"
-                    variants={variants}
-                    onAnimationComplete={onComplete}
-                >
-                    <motion.div variants={childVariants} style={{ x }} />
+    // test("child animates to set variant", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const x = motionValue(0)
+    //         const onComplete = () => resolve(x.get())
+    //         const Component = () => (
+    //             <motion.div
+    //                 animate="visible"
+    //                 variants={variants}
+    //                 onAnimationComplete={onComplete}
+    //             >
+    //                 <motion.div variants={childVariants} style={{ x }} />
+    //             </motion.div>
+    //         )
+
+    //         const { rerender } = render(<Component />)
+    //         rerender(<Component />)
+    //     })
+
+    //     return expect(promise).resolves.toBe(50)
+    // })
+
+    // test("child animates to set variant even if variants are not found on parent", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const x = motionValue(0)
+    //         const onComplete = () => resolve(x.get())
+    //         const Component = () => (
+    //             <motion.div animate="visible" onAnimationComplete={onComplete}>
+    //                 <motion.div variants={childVariants} style={{ x }} />
+    //             </motion.div>
+    //         )
+
+    //         const { rerender } = render(<Component />)
+    //         rerender(<Component />)
+    //     })
+
+    //     return expect(promise).resolves.toBe(50)
+    // })
+
+    // test("applies applyOnEnd if set on initial", () => {
+    //     const variants: Variants = {
+    //         visible: {
+    //             background: "#f00",
+    //             transitionEnd: { display: "none" },
+    //         },
+    //     }
+
+    //     const { container } = render(
+    //         <motion.div variants={variants} initial="visible" />
+    //     )
+    //     expect(container.firstChild).toHaveStyle("display: none")
+    // })
+
+    // test("applies applyOnEnd and end of animation", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const variants: Variants = {
+    //             hidden: { background: "#00f" },
+    //             visible: {
+    //                 background: "#f00",
+    //                 transitionEnd: { display: "none" },
+    //             },
+    //         }
+    //         const display = motionValue("block")
+    //         const onComplete = () => resolve(display.get())
+    //         const Component = () => (
+    //             <motion.div
+    //                 initial="hidden"
+    //                 animate="visible"
+    //                 variants={variants}
+    //                 transition={{ type: false }}
+    //                 onAnimationComplete={onComplete}
+    //                 style={{ display }}
+    //             />
+    //         )
+
+    //         const { rerender } = render(<Component />)
+    //         rerender(<Component />)
+    //     })
+
+    //     return expect(promise).resolves.toBe("none")
+    // })
+
+    // test("accepts custom transition", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const variants: Variants = {
+    //             hidden: { background: "#00f" },
+    //             visible: {
+    //                 background: "#f00",
+    //                 transition: { to: "#555" },
+    //             },
+    //         }
+    //         const background = motionValue("#00f")
+    //         const onComplete = () => resolve(background.get())
+    //         const Component = () => (
+    //             <motion.div
+    //                 initial="hidden"
+    //                 animate="visible"
+    //                 variants={variants}
+    //                 transition={{ type: false }}
+    //                 onAnimationComplete={onComplete}
+    //                 style={{ background }}
+    //             />
+    //         )
+
+    //         const { rerender } = render(<Component />)
+    //         rerender(<Component />)
+    //     })
+
+    //     return expect(promise).resolves.toBe("rgba(85, 85, 85, 1)")
+    // })
+
+    // test("respects orchestration props in transition prop", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const opacity = motionValue(0)
+    //         const variants: Variants = {
+    //             visible: {
+    //                 opacity: 1,
+    //             },
+    //             hidden: {
+    //                 opacity: 0,
+    //             },
+    //         }
+
+    //         render(
+    //             <motion.div
+    //                 variants={variants}
+    //                 initial="hidden"
+    //                 animate="visible"
+    //                 transition={{ type: false, delayChildren: 1 }}
+    //             >
+    //                 <motion.div
+    //                     variants={variants}
+    //                     transition={{ type: false }}
+    //                     style={{ opacity }}
+    //                 />
+    //             </motion.div>
+    //         )
+
+    //         requestAnimationFrame(() => resolve(opacity.get()))
+    //     })
+
+    //     return expect(promise).resolves.toBe(0)
+    // })
+
+    // test("propagates through components with no `animate` prop", async () => {
+    //     const promise = new Promise(resolve => {
+    //         const opacity = motionValue(0)
+    //         const variants: Variants = {
+    //             visible: {
+    //                 opacity: 1,
+    //             },
+    //         }
+
+    //         render(
+    //             <motion.div
+    //                 variants={variants}
+    //                 initial="hidden"
+    //                 animate="visible"
+    //                 transition={{ type: false }}
+    //             >
+    //                 <motion.div>
+    //                     <motion.div
+    //                         variants={variants}
+    //                         transition={{ type: false }}
+    //                         style={{ opacity }}
+    //                     />
+    //                 </motion.div>
+    //             </motion.div>
+    //         )
+
+    //         requestAnimationFrame(() => resolve(opacity.get()))
+    //     })
+
+    //     return expect(promise).resolves.toBe(1)
+    // })
+
+    // test("components without variants are transparent to stagger order", async () => {
+    //     const [recordedOrder, staggeredEqually] = await new Promise(resolve => {
+    //         const order: number[] = []
+    //         const delayedBy: number[] = []
+    //         const staggerDuration = 0.1
+
+    //         const updateDelayedBy = (i: number) => {
+    //             if (delayedBy[i]) return
+    //             delayedBy[i] = performance.now()
+    //         }
+
+    //         // Checking a rough equidistance between stagger times allows us to see
+    //         // if any of the supposedly invisible interim `motion.div`s were considered part of the
+    //         // stagger order (which would mess up the timings)
+    //         const checkStaggerEquidistance = () => {
+    //             let isEquidistant = true
+    //             let prev = 0
+    //             for (let i = 0; i < delayedBy.length; i++) {
+    //                 if (prev) {
+    //                     const timeSincePrev = prev - delayedBy[i]
+    //                     if (
+    //                         Math.round(timeSincePrev / 100) * 100 !==
+    //                         staggerDuration * 1000
+    //                     ) {
+    //                         isEquidistant = false
+    //                     }
+    //                 }
+    //                 prev = delayedBy[i]
+    //             }
+
+    //             return isEquidistant
+    //         }
+
+    //         const parentVariants: Variants = {
+    //             visible: {
+    //                 transition: {
+    //                     staggerChildren: staggerDuration,
+    //                     staggerDirection: -1,
+    //                 },
+    //             },
+    //         }
+
+    //         const variants: Variants = {
+    //             hidden: { opacity: 0 },
+    //             visible: {
+    //                 opacity: 1,
+    //                 transition: {
+    //                     duration: 0.01,
+    //                 },
+    //             },
+    //         }
+
+    //         render(
+    //             <motion.div
+    //                 initial="hidden"
+    //                 animate="visible"
+    //                 variants={parentVariants}
+    //                 onAnimationComplete={() =>
+    //                     requestAnimationFrame(() =>
+    //                         resolve([order, checkStaggerEquidistance()])
+    //                     )
+    //                 }
+    //             >
+    //                 <motion.div>
+    //                     <motion.div />
+    //                     <motion.div
+    //                         variants={variants}
+    //                         onUpdate={() => {
+    //                             updateDelayedBy(0)
+    //                             order.push(1)
+    //                         }}
+    //                     />
+    //                     <motion.div
+    //                         variants={variants}
+    //                         onUpdate={() => {
+    //                             updateDelayedBy(1)
+    //                             order.push(2)
+    //                         }}
+    //                     />
+    //                 </motion.div>
+    //                 <motion.div>
+    //                     <motion.div
+    //                         variants={variants}
+    //                         onUpdate={() => {
+    //                             updateDelayedBy(2)
+    //                             order.push(3)
+    //                         }}
+    //                     />
+    //                     <motion.div
+    //                         variants={variants}
+    //                         onUpdate={() => {
+    //                             updateDelayedBy(3)
+    //                             order.push(4)
+    //                         }}
+    //                     />
+    //                 </motion.div>
+    //             </motion.div>
+    //         )
+    //     })
+
+    //     expect(recordedOrder).toEqual([4, 3, 2, 1])
+    //     expect(staggeredEqually).toEqual(true)
+    // })
+
+    // test("onUpdate", async () => {
+    //     const promise = new Promise(resolve => {
+    //         let latest = {}
+
+    //         const onUpdate = (l: { [key: string]: number | string }) => {
+    //             latest = l
+    //         }
+
+    //         const Component = () => (
+    //             <motion.div
+    //                 onUpdate={onUpdate}
+    //                 initial={{ x: 0, y: 0 }}
+    //                 animate={{ x: 100, y: 100 }}
+    //                 transition={{ duration: 0.1 }}
+    //                 onAnimationComplete={() => resolve(latest)}
+    //             />
+    //         )
+
+    //         const { rerender } = render(<Component />)
+    //         rerender(<Component />)
+    //     })
+
+    //     return expect(promise).resolves.toEqual({ x: 100, y: 100 })
+    // })
+
+    // test("onUpdate doesnt fire if no values have changed", async () => {
+    //     const onUpdate = jest.fn()
+
+    //     await new Promise(resolve => {
+    //         const x = motionValue(0)
+    //         const Component = ({ xTarget = 0 }) => (
+    //             <motion.div
+    //                 animate={{ x: xTarget }}
+    //                 transition={{ type: false }}
+    //                 onUpdate={onUpdate}
+    //                 style={{ x }}
+    //             />
+    //         )
+
+    //         const { rerender } = render(<Component xTarget={0} />)
+    //         setTimeout(() => rerender(<Component xTarget={1} />), 30)
+    //         setTimeout(() => rerender(<Component xTarget={1} />), 60)
+    //         setTimeout(() => resolve(), 90)
+    //     })
+
+    //     expect(onUpdate).toHaveBeenCalledTimes(1)
+    // })
+
+    // test("accepts variants without being typed", () => {
+    //     expect(() => {
+    //         const variants = {
+    //             withoutTransition: { opacity: 0 },
+    //             withJustDefaultTransitionType: {
+    //                 opacity: 0,
+    //                 transition: {
+    //                     duration: 1,
+    //                 },
+    //             },
+    //             withTransitionIndividual: {
+    //                 transition: {
+    //                     when: "beforeChildren",
+    //                     opacity: { type: "spring" },
+    //                 },
+    //             },
+    //             withTransitionType: {
+    //                 transition: {
+    //                     type: "spring",
+    //                 },
+    //             },
+    //             asResolver: () => ({
+    //                 opacity: 0,
+    //                 transition: {
+    //                     type: "physics",
+    //                     delay: 10,
+    //                 },
+    //             }),
+    //             withTransitionEnd: {
+    //                 transitionEnd: { opacity: 0 },
+    //             },
+    //         }
+    //         render(<motion.div variants={variants} />)
+    //     }).not.toThrowError()
+    // })
+
+    test("new child items animate from initial to animate", () => {
+        const x = motionValue(0)
+        const Component = ({ length }: { length: number }) => {
+            const items = []
+            for (let i = 0; i < length; i++) {
+                items.push(
+                    <motion.div
+                        key={i}
+                        variants={variants}
+                        style={{ x: i === 1 ? x : 0 }}
+                    />
+                )
+            }
+
+            return (
+                <motion.div initial="hidden" animate="visible">
+                    {items}
                 </motion.div>
             )
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        return expect(promise).resolves.toBe(50)
-    })
-
-    test("child animates to set variant even if variants are not found on parent", async () => {
-        const promise = new Promise(resolve => {
-            const x = motionValue(0)
-            const onComplete = () => resolve(x.get())
-            const Component = () => (
-                <motion.div animate="visible" onAnimationComplete={onComplete}>
-                    <motion.div variants={childVariants} style={{ x }} />
-                </motion.div>
-            )
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        return expect(promise).resolves.toBe(50)
-    })
-
-    test("applies applyOnEnd if set on initial", () => {
-        const variants: Variants = {
-            visible: {
-                background: "#f00",
-                transitionEnd: { display: "none" },
-            },
         }
 
-        const { container } = render(
-            <motion.div variants={variants} initial="visible" />
-        )
-        expect(container.firstChild).toHaveStyle("display: none")
-    })
+        const { rerender } = render(<Component length={1} />)
+        rerender(<Component length={1} />)
+        rerender(<Component length={2} />)
+        rerender(<Component length={2} />)
 
-    test("applies applyOnEnd and end of animation", async () => {
-        const promise = new Promise(resolve => {
-            const variants: Variants = {
-                hidden: { background: "#00f" },
-                visible: {
-                    background: "#f00",
-                    transitionEnd: { display: "none" },
-                },
-            }
-            const display = motionValue("block")
-            const onComplete = () => resolve(display.get())
-            const Component = () => (
-                <motion.div
-                    initial="hidden"
-                    animate="visible"
-                    variants={variants}
-                    transition={{ type: false }}
-                    onAnimationComplete={onComplete}
-                    style={{ display }}
-                />
-            )
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        return expect(promise).resolves.toBe("none")
-    })
-
-    test("accepts custom transition", async () => {
-        const promise = new Promise(resolve => {
-            const variants: Variants = {
-                hidden: { background: "#00f" },
-                visible: {
-                    background: "#f00",
-                    transition: { to: "#555" },
-                },
-            }
-            const background = motionValue("#00f")
-            const onComplete = () => resolve(background.get())
-            const Component = () => (
-                <motion.div
-                    initial="hidden"
-                    animate="visible"
-                    variants={variants}
-                    transition={{ type: false }}
-                    onAnimationComplete={onComplete}
-                    style={{ background }}
-                />
-            )
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        return expect(promise).resolves.toBe("rgba(85, 85, 85, 1)")
-    })
-
-    test("respects orchestration props in transition prop", async () => {
-        const promise = new Promise(resolve => {
-            const opacity = motionValue(0)
-            const variants: Variants = {
-                visible: {
-                    opacity: 1,
-                },
-                hidden: {
-                    opacity: 0,
-                },
-            }
-
-            render(
-                <motion.div
-                    variants={variants}
-                    initial="hidden"
-                    animate="visible"
-                    transition={{ type: false, delayChildren: 1 }}
-                >
-                    <motion.div
-                        variants={variants}
-                        transition={{ type: false }}
-                        style={{ opacity }}
-                    />
-                </motion.div>
-            )
-
-            requestAnimationFrame(() => resolve(opacity.get()))
-        })
-
-        return expect(promise).resolves.toBe(0)
-    })
-
-    test("propagates through components with no `animate` prop", async () => {
-        const promise = new Promise(resolve => {
-            const opacity = motionValue(0)
-            const variants: Variants = {
-                visible: {
-                    opacity: 1,
-                },
-            }
-
-            render(
-                <motion.div
-                    variants={variants}
-                    initial="hidden"
-                    animate="visible"
-                    transition={{ type: false }}
-                >
-                    <motion.div>
-                        <motion.div
-                            variants={variants}
-                            transition={{ type: false }}
-                            style={{ opacity }}
-                        />
-                    </motion.div>
-                </motion.div>
-            )
-
-            requestAnimationFrame(() => resolve(opacity.get()))
-        })
-
-        return expect(promise).resolves.toBe(1)
-    })
-
-    test("components without variants are transparent to stagger order", async () => {
-        const [recordedOrder, staggeredEqually] = await new Promise(resolve => {
-            const order: number[] = []
-            const delayedBy: number[] = []
-            const staggerDuration = 0.1
-
-            const updateDelayedBy = (i: number) => {
-                if (delayedBy[i]) return
-                delayedBy[i] = performance.now()
-            }
-
-            // Checking a rough equidistance between stagger times allows us to see
-            // if any of the supposedly invisible interim `motion.div`s were considered part of the
-            // stagger order (which would mess up the timings)
-            const checkStaggerEquidistance = () => {
-                let isEquidistant = true
-                let prev = 0
-                for (let i = 0; i < delayedBy.length; i++) {
-                    if (prev) {
-                        const timeSincePrev = prev - delayedBy[i]
-                        if (
-                            Math.round(timeSincePrev / 100) * 100 !==
-                            staggerDuration * 1000
-                        ) {
-                            isEquidistant = false
-                        }
-                    }
-                    prev = delayedBy[i]
-                }
-
-                return isEquidistant
-            }
-
-            const parentVariants: Variants = {
-                visible: {
-                    transition: {
-                        staggerChildren: staggerDuration,
-                        staggerDirection: -1,
-                    },
-                },
-            }
-
-            const variants: Variants = {
-                hidden: { opacity: 0 },
-                visible: {
-                    opacity: 1,
-                    transition: {
-                        duration: 0.01,
-                    },
-                },
-            }
-
-            render(
-                <motion.div
-                    initial="hidden"
-                    animate="visible"
-                    variants={parentVariants}
-                    onAnimationComplete={() =>
-                        requestAnimationFrame(() =>
-                            resolve([order, checkStaggerEquidistance()])
-                        )
-                    }
-                >
-                    <motion.div>
-                        <motion.div />
-                        <motion.div
-                            variants={variants}
-                            onUpdate={() => {
-                                updateDelayedBy(0)
-                                order.push(1)
-                            }}
-                        />
-                        <motion.div
-                            variants={variants}
-                            onUpdate={() => {
-                                updateDelayedBy(1)
-                                order.push(2)
-                            }}
-                        />
-                    </motion.div>
-                    <motion.div>
-                        <motion.div
-                            variants={variants}
-                            onUpdate={() => {
-                                updateDelayedBy(2)
-                                order.push(3)
-                            }}
-                        />
-                        <motion.div
-                            variants={variants}
-                            onUpdate={() => {
-                                updateDelayedBy(3)
-                                order.push(4)
-                            }}
-                        />
-                    </motion.div>
-                </motion.div>
-            )
-        })
-
-        expect(recordedOrder).toEqual([4, 3, 2, 1])
-        expect(staggeredEqually).toEqual(true)
-    })
-
-    test("onUpdate", async () => {
-        const promise = new Promise(resolve => {
-            let latest = {}
-
-            const onUpdate = (l: { [key: string]: number | string }) => {
-                latest = l
-            }
-
-            const Component = () => (
-                <motion.div
-                    onUpdate={onUpdate}
-                    initial={{ x: 0, y: 0 }}
-                    animate={{ x: 100, y: 100 }}
-                    transition={{ duration: 0.1 }}
-                    onAnimationComplete={() => resolve(latest)}
-                />
-            )
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        return expect(promise).resolves.toEqual({ x: 100, y: 100 })
-    })
-
-    test("onUpdate doesnt fire if no values have changed", async () => {
-        const onUpdate = jest.fn()
-
-        await new Promise(resolve => {
-            const x = motionValue(0)
-            const Component = ({ xTarget = 0 }) => (
-                <motion.div
-                    animate={{ x: xTarget }}
-                    transition={{ type: false }}
-                    onUpdate={onUpdate}
-                    style={{ x }}
-                />
-            )
-
-            const { rerender } = render(<Component xTarget={0} />)
-            setTimeout(() => rerender(<Component xTarget={1} />), 30)
-            setTimeout(() => rerender(<Component xTarget={1} />), 60)
-            setTimeout(() => resolve(), 90)
-        })
-
-        expect(onUpdate).toHaveBeenCalledTimes(1)
-    })
-
-    test("accepts variants without being typed", () => {
-        expect(() => {
-            const variants = {
-                withoutTransition: { opacity: 0 },
-                withJustDefaultTransitionType: {
-                    opacity: 0,
-                    transition: {
-                        duration: 1,
-                    },
-                },
-                withTransitionIndividual: {
-                    transition: {
-                        when: "beforeChildren",
-                        opacity: { type: "spring" },
-                    },
-                },
-                withTransitionType: {
-                    transition: {
-                        type: "spring",
-                    },
-                },
-                asResolver: () => ({
-                    opacity: 0,
-                    transition: {
-                        type: "physics",
-                        delay: 10,
-                    },
-                }),
-                withTransitionEnd: {
-                    transitionEnd: { opacity: 0 },
-                },
-            }
-            render(<motion.div variants={variants} />)
-        }).not.toThrowError()
+        expect(x.get()).toBe(100)
     })
 })

--- a/src/motion/__tests__/variant.test.tsx
+++ b/src/motion/__tests__/variant.test.tsx
@@ -10,398 +10,398 @@ describe("animate prop as variant", () => {
         hidden: { opacity: 0, x: -100, transition: { type: false } },
         visible: { opacity: 1, x: 100, transition: { type: false } },
     }
-    // const childVariants: Variants = {
-    //     hidden: { opacity: 0, x: -100, transition: { type: false } },
-    //     visible: { opacity: 1, x: 50, transition: { type: false } },
-    // }
+    const childVariants: Variants = {
+        hidden: { opacity: 0, x: -100, transition: { type: false } },
+        visible: { opacity: 1, x: 50, transition: { type: false } },
+    }
 
-    // test("animates to set variant", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const x = motionValue(0)
-    //         const onComplete = () => resolve(x.get())
-    //         const { rerender } = render(
-    //             <motion.div
-    //                 animate="visible"
-    //                 variants={variants}
-    //                 style={{ x }}
-    //                 onAnimationComplete={onComplete}
-    //             />
-    //         )
-    //         rerender(
-    //             <motion.div
-    //                 animate="visible"
-    //                 variants={variants}
-    //                 style={{ x }}
-    //                 onAnimationComplete={onComplete}
-    //             />
-    //         )
-    //     })
+    test("animates to set variant", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const onComplete = () => resolve(x.get())
+            const { rerender } = render(
+                <motion.div
+                    animate="visible"
+                    variants={variants}
+                    style={{ x }}
+                    onAnimationComplete={onComplete}
+                />
+            )
+            rerender(
+                <motion.div
+                    animate="visible"
+                    variants={variants}
+                    style={{ x }}
+                    onAnimationComplete={onComplete}
+                />
+            )
+        })
 
-    //     return expect(promise).resolves.toBe(100)
-    // })
+        return expect(promise).resolves.toBe(100)
+    })
 
-    // test("child animates to set variant", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const x = motionValue(0)
-    //         const onComplete = () => resolve(x.get())
-    //         const Component = () => (
-    //             <motion.div
-    //                 animate="visible"
-    //                 variants={variants}
-    //                 onAnimationComplete={onComplete}
-    //             >
-    //                 <motion.div variants={childVariants} style={{ x }} />
-    //             </motion.div>
-    //         )
+    test("child animates to set variant", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const onComplete = () => resolve(x.get())
+            const Component = () => (
+                <motion.div
+                    animate="visible"
+                    variants={variants}
+                    onAnimationComplete={onComplete}
+                >
+                    <motion.div variants={childVariants} style={{ x }} />
+                </motion.div>
+            )
 
-    //         const { rerender } = render(<Component />)
-    //         rerender(<Component />)
-    //     })
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
 
-    //     return expect(promise).resolves.toBe(50)
-    // })
+        return expect(promise).resolves.toBe(50)
+    })
 
-    // test("child animates to set variant even if variants are not found on parent", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const x = motionValue(0)
-    //         const onComplete = () => resolve(x.get())
-    //         const Component = () => (
-    //             <motion.div animate="visible" onAnimationComplete={onComplete}>
-    //                 <motion.div variants={childVariants} style={{ x }} />
-    //             </motion.div>
-    //         )
+    test("child animates to set variant even if variants are not found on parent", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const onComplete = () => resolve(x.get())
+            const Component = () => (
+                <motion.div animate="visible" onAnimationComplete={onComplete}>
+                    <motion.div variants={childVariants} style={{ x }} />
+                </motion.div>
+            )
 
-    //         const { rerender } = render(<Component />)
-    //         rerender(<Component />)
-    //     })
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
 
-    //     return expect(promise).resolves.toBe(50)
-    // })
+        return expect(promise).resolves.toBe(50)
+    })
 
-    // test("applies applyOnEnd if set on initial", () => {
-    //     const variants: Variants = {
-    //         visible: {
-    //             background: "#f00",
-    //             transitionEnd: { display: "none" },
-    //         },
-    //     }
+    test("applies applyOnEnd if set on initial", () => {
+        const variants: Variants = {
+            visible: {
+                background: "#f00",
+                transitionEnd: { display: "none" },
+            },
+        }
 
-    //     const { container } = render(
-    //         <motion.div variants={variants} initial="visible" />
-    //     )
-    //     expect(container.firstChild).toHaveStyle("display: none")
-    // })
+        const { container } = render(
+            <motion.div variants={variants} initial="visible" />
+        )
+        expect(container.firstChild).toHaveStyle("display: none")
+    })
 
-    // test("applies applyOnEnd and end of animation", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const variants: Variants = {
-    //             hidden: { background: "#00f" },
-    //             visible: {
-    //                 background: "#f00",
-    //                 transitionEnd: { display: "none" },
-    //             },
-    //         }
-    //         const display = motionValue("block")
-    //         const onComplete = () => resolve(display.get())
-    //         const Component = () => (
-    //             <motion.div
-    //                 initial="hidden"
-    //                 animate="visible"
-    //                 variants={variants}
-    //                 transition={{ type: false }}
-    //                 onAnimationComplete={onComplete}
-    //                 style={{ display }}
-    //             />
-    //         )
+    test("applies applyOnEnd and end of animation", async () => {
+        const promise = new Promise(resolve => {
+            const variants: Variants = {
+                hidden: { background: "#00f" },
+                visible: {
+                    background: "#f00",
+                    transitionEnd: { display: "none" },
+                },
+            }
+            const display = motionValue("block")
+            const onComplete = () => resolve(display.get())
+            const Component = () => (
+                <motion.div
+                    initial="hidden"
+                    animate="visible"
+                    variants={variants}
+                    transition={{ type: false }}
+                    onAnimationComplete={onComplete}
+                    style={{ display }}
+                />
+            )
 
-    //         const { rerender } = render(<Component />)
-    //         rerender(<Component />)
-    //     })
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
 
-    //     return expect(promise).resolves.toBe("none")
-    // })
+        return expect(promise).resolves.toBe("none")
+    })
 
-    // test("accepts custom transition", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const variants: Variants = {
-    //             hidden: { background: "#00f" },
-    //             visible: {
-    //                 background: "#f00",
-    //                 transition: { to: "#555" },
-    //             },
-    //         }
-    //         const background = motionValue("#00f")
-    //         const onComplete = () => resolve(background.get())
-    //         const Component = () => (
-    //             <motion.div
-    //                 initial="hidden"
-    //                 animate="visible"
-    //                 variants={variants}
-    //                 transition={{ type: false }}
-    //                 onAnimationComplete={onComplete}
-    //                 style={{ background }}
-    //             />
-    //         )
+    test("accepts custom transition", async () => {
+        const promise = new Promise(resolve => {
+            const variants: Variants = {
+                hidden: { background: "#00f" },
+                visible: {
+                    background: "#f00",
+                    transition: { to: "#555" },
+                },
+            }
+            const background = motionValue("#00f")
+            const onComplete = () => resolve(background.get())
+            const Component = () => (
+                <motion.div
+                    initial="hidden"
+                    animate="visible"
+                    variants={variants}
+                    transition={{ type: false }}
+                    onAnimationComplete={onComplete}
+                    style={{ background }}
+                />
+            )
 
-    //         const { rerender } = render(<Component />)
-    //         rerender(<Component />)
-    //     })
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
 
-    //     return expect(promise).resolves.toBe("rgba(85, 85, 85, 1)")
-    // })
+        return expect(promise).resolves.toBe("rgba(85, 85, 85, 1)")
+    })
 
-    // test("respects orchestration props in transition prop", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const opacity = motionValue(0)
-    //         const variants: Variants = {
-    //             visible: {
-    //                 opacity: 1,
-    //             },
-    //             hidden: {
-    //                 opacity: 0,
-    //             },
-    //         }
+    test("respects orchestration props in transition prop", async () => {
+        const promise = new Promise(resolve => {
+            const opacity = motionValue(0)
+            const variants: Variants = {
+                visible: {
+                    opacity: 1,
+                },
+                hidden: {
+                    opacity: 0,
+                },
+            }
 
-    //         render(
-    //             <motion.div
-    //                 variants={variants}
-    //                 initial="hidden"
-    //                 animate="visible"
-    //                 transition={{ type: false, delayChildren: 1 }}
-    //             >
-    //                 <motion.div
-    //                     variants={variants}
-    //                     transition={{ type: false }}
-    //                     style={{ opacity }}
-    //                 />
-    //             </motion.div>
-    //         )
+            render(
+                <motion.div
+                    variants={variants}
+                    initial="hidden"
+                    animate="visible"
+                    transition={{ type: false, delayChildren: 1 }}
+                >
+                    <motion.div
+                        variants={variants}
+                        transition={{ type: false }}
+                        style={{ opacity }}
+                    />
+                </motion.div>
+            )
 
-    //         requestAnimationFrame(() => resolve(opacity.get()))
-    //     })
+            requestAnimationFrame(() => resolve(opacity.get()))
+        })
 
-    //     return expect(promise).resolves.toBe(0)
-    // })
+        return expect(promise).resolves.toBe(0)
+    })
 
-    // test("propagates through components with no `animate` prop", async () => {
-    //     const promise = new Promise(resolve => {
-    //         const opacity = motionValue(0)
-    //         const variants: Variants = {
-    //             visible: {
-    //                 opacity: 1,
-    //             },
-    //         }
+    test("propagates through components with no `animate` prop", async () => {
+        const promise = new Promise(resolve => {
+            const opacity = motionValue(0)
+            const variants: Variants = {
+                visible: {
+                    opacity: 1,
+                },
+            }
 
-    //         render(
-    //             <motion.div
-    //                 variants={variants}
-    //                 initial="hidden"
-    //                 animate="visible"
-    //                 transition={{ type: false }}
-    //             >
-    //                 <motion.div>
-    //                     <motion.div
-    //                         variants={variants}
-    //                         transition={{ type: false }}
-    //                         style={{ opacity }}
-    //                     />
-    //                 </motion.div>
-    //             </motion.div>
-    //         )
+            render(
+                <motion.div
+                    variants={variants}
+                    initial="hidden"
+                    animate="visible"
+                    transition={{ type: false }}
+                >
+                    <motion.div>
+                        <motion.div
+                            variants={variants}
+                            transition={{ type: false }}
+                            style={{ opacity }}
+                        />
+                    </motion.div>
+                </motion.div>
+            )
 
-    //         requestAnimationFrame(() => resolve(opacity.get()))
-    //     })
+            requestAnimationFrame(() => resolve(opacity.get()))
+        })
 
-    //     return expect(promise).resolves.toBe(1)
-    // })
+        return expect(promise).resolves.toBe(1)
+    })
 
-    // test("components without variants are transparent to stagger order", async () => {
-    //     const [recordedOrder, staggeredEqually] = await new Promise(resolve => {
-    //         const order: number[] = []
-    //         const delayedBy: number[] = []
-    //         const staggerDuration = 0.1
+    test("components without variants are transparent to stagger order", async () => {
+        const [recordedOrder, staggeredEqually] = await new Promise(resolve => {
+            const order: number[] = []
+            const delayedBy: number[] = []
+            const staggerDuration = 0.1
 
-    //         const updateDelayedBy = (i: number) => {
-    //             if (delayedBy[i]) return
-    //             delayedBy[i] = performance.now()
-    //         }
+            const updateDelayedBy = (i: number) => {
+                if (delayedBy[i]) return
+                delayedBy[i] = performance.now()
+            }
 
-    //         // Checking a rough equidistance between stagger times allows us to see
-    //         // if any of the supposedly invisible interim `motion.div`s were considered part of the
-    //         // stagger order (which would mess up the timings)
-    //         const checkStaggerEquidistance = () => {
-    //             let isEquidistant = true
-    //             let prev = 0
-    //             for (let i = 0; i < delayedBy.length; i++) {
-    //                 if (prev) {
-    //                     const timeSincePrev = prev - delayedBy[i]
-    //                     if (
-    //                         Math.round(timeSincePrev / 100) * 100 !==
-    //                         staggerDuration * 1000
-    //                     ) {
-    //                         isEquidistant = false
-    //                     }
-    //                 }
-    //                 prev = delayedBy[i]
-    //             }
+            // Checking a rough equidistance between stagger times allows us to see
+            // if any of the supposedly invisible interim `motion.div`s were considered part of the
+            // stagger order (which would mess up the timings)
+            const checkStaggerEquidistance = () => {
+                let isEquidistant = true
+                let prev = 0
+                for (let i = 0; i < delayedBy.length; i++) {
+                    if (prev) {
+                        const timeSincePrev = prev - delayedBy[i]
+                        if (
+                            Math.round(timeSincePrev / 100) * 100 !==
+                            staggerDuration * 1000
+                        ) {
+                            isEquidistant = false
+                        }
+                    }
+                    prev = delayedBy[i]
+                }
 
-    //             return isEquidistant
-    //         }
+                return isEquidistant
+            }
 
-    //         const parentVariants: Variants = {
-    //             visible: {
-    //                 transition: {
-    //                     staggerChildren: staggerDuration,
-    //                     staggerDirection: -1,
-    //                 },
-    //             },
-    //         }
+            const parentVariants: Variants = {
+                visible: {
+                    transition: {
+                        staggerChildren: staggerDuration,
+                        staggerDirection: -1,
+                    },
+                },
+            }
 
-    //         const variants: Variants = {
-    //             hidden: { opacity: 0 },
-    //             visible: {
-    //                 opacity: 1,
-    //                 transition: {
-    //                     duration: 0.01,
-    //                 },
-    //             },
-    //         }
+            const variants: Variants = {
+                hidden: { opacity: 0 },
+                visible: {
+                    opacity: 1,
+                    transition: {
+                        duration: 0.01,
+                    },
+                },
+            }
 
-    //         render(
-    //             <motion.div
-    //                 initial="hidden"
-    //                 animate="visible"
-    //                 variants={parentVariants}
-    //                 onAnimationComplete={() =>
-    //                     requestAnimationFrame(() =>
-    //                         resolve([order, checkStaggerEquidistance()])
-    //                     )
-    //                 }
-    //             >
-    //                 <motion.div>
-    //                     <motion.div />
-    //                     <motion.div
-    //                         variants={variants}
-    //                         onUpdate={() => {
-    //                             updateDelayedBy(0)
-    //                             order.push(1)
-    //                         }}
-    //                     />
-    //                     <motion.div
-    //                         variants={variants}
-    //                         onUpdate={() => {
-    //                             updateDelayedBy(1)
-    //                             order.push(2)
-    //                         }}
-    //                     />
-    //                 </motion.div>
-    //                 <motion.div>
-    //                     <motion.div
-    //                         variants={variants}
-    //                         onUpdate={() => {
-    //                             updateDelayedBy(2)
-    //                             order.push(3)
-    //                         }}
-    //                     />
-    //                     <motion.div
-    //                         variants={variants}
-    //                         onUpdate={() => {
-    //                             updateDelayedBy(3)
-    //                             order.push(4)
-    //                         }}
-    //                     />
-    //                 </motion.div>
-    //             </motion.div>
-    //         )
-    //     })
+            render(
+                <motion.div
+                    initial="hidden"
+                    animate="visible"
+                    variants={parentVariants}
+                    onAnimationComplete={() =>
+                        requestAnimationFrame(() =>
+                            resolve([order, checkStaggerEquidistance()])
+                        )
+                    }
+                >
+                    <motion.div>
+                        <motion.div />
+                        <motion.div
+                            variants={variants}
+                            onUpdate={() => {
+                                updateDelayedBy(0)
+                                order.push(1)
+                            }}
+                        />
+                        <motion.div
+                            variants={variants}
+                            onUpdate={() => {
+                                updateDelayedBy(1)
+                                order.push(2)
+                            }}
+                        />
+                    </motion.div>
+                    <motion.div>
+                        <motion.div
+                            variants={variants}
+                            onUpdate={() => {
+                                updateDelayedBy(2)
+                                order.push(3)
+                            }}
+                        />
+                        <motion.div
+                            variants={variants}
+                            onUpdate={() => {
+                                updateDelayedBy(3)
+                                order.push(4)
+                            }}
+                        />
+                    </motion.div>
+                </motion.div>
+            )
+        })
 
-    //     expect(recordedOrder).toEqual([4, 3, 2, 1])
-    //     expect(staggeredEqually).toEqual(true)
-    // })
+        expect(recordedOrder).toEqual([4, 3, 2, 1])
+        expect(staggeredEqually).toEqual(true)
+    })
 
-    // test("onUpdate", async () => {
-    //     const promise = new Promise(resolve => {
-    //         let latest = {}
+    test("onUpdate", async () => {
+        const promise = new Promise(resolve => {
+            let latest = {}
 
-    //         const onUpdate = (l: { [key: string]: number | string }) => {
-    //             latest = l
-    //         }
+            const onUpdate = (l: { [key: string]: number | string }) => {
+                latest = l
+            }
 
-    //         const Component = () => (
-    //             <motion.div
-    //                 onUpdate={onUpdate}
-    //                 initial={{ x: 0, y: 0 }}
-    //                 animate={{ x: 100, y: 100 }}
-    //                 transition={{ duration: 0.1 }}
-    //                 onAnimationComplete={() => resolve(latest)}
-    //             />
-    //         )
+            const Component = () => (
+                <motion.div
+                    onUpdate={onUpdate}
+                    initial={{ x: 0, y: 0 }}
+                    animate={{ x: 100, y: 100 }}
+                    transition={{ duration: 0.1 }}
+                    onAnimationComplete={() => resolve(latest)}
+                />
+            )
 
-    //         const { rerender } = render(<Component />)
-    //         rerender(<Component />)
-    //     })
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
 
-    //     return expect(promise).resolves.toEqual({ x: 100, y: 100 })
-    // })
+        return expect(promise).resolves.toEqual({ x: 100, y: 100 })
+    })
 
-    // test("onUpdate doesnt fire if no values have changed", async () => {
-    //     const onUpdate = jest.fn()
+    test("onUpdate doesnt fire if no values have changed", async () => {
+        const onUpdate = jest.fn()
 
-    //     await new Promise(resolve => {
-    //         const x = motionValue(0)
-    //         const Component = ({ xTarget = 0 }) => (
-    //             <motion.div
-    //                 animate={{ x: xTarget }}
-    //                 transition={{ type: false }}
-    //                 onUpdate={onUpdate}
-    //                 style={{ x }}
-    //             />
-    //         )
+        await new Promise(resolve => {
+            const x = motionValue(0)
+            const Component = ({ xTarget = 0 }) => (
+                <motion.div
+                    animate={{ x: xTarget }}
+                    transition={{ type: false }}
+                    onUpdate={onUpdate}
+                    style={{ x }}
+                />
+            )
 
-    //         const { rerender } = render(<Component xTarget={0} />)
-    //         setTimeout(() => rerender(<Component xTarget={1} />), 30)
-    //         setTimeout(() => rerender(<Component xTarget={1} />), 60)
-    //         setTimeout(() => resolve(), 90)
-    //     })
+            const { rerender } = render(<Component xTarget={0} />)
+            setTimeout(() => rerender(<Component xTarget={1} />), 30)
+            setTimeout(() => rerender(<Component xTarget={1} />), 60)
+            setTimeout(() => resolve(), 90)
+        })
 
-    //     expect(onUpdate).toHaveBeenCalledTimes(1)
-    // })
+        expect(onUpdate).toHaveBeenCalledTimes(1)
+    })
 
-    // test("accepts variants without being typed", () => {
-    //     expect(() => {
-    //         const variants = {
-    //             withoutTransition: { opacity: 0 },
-    //             withJustDefaultTransitionType: {
-    //                 opacity: 0,
-    //                 transition: {
-    //                     duration: 1,
-    //                 },
-    //             },
-    //             withTransitionIndividual: {
-    //                 transition: {
-    //                     when: "beforeChildren",
-    //                     opacity: { type: "spring" },
-    //                 },
-    //             },
-    //             withTransitionType: {
-    //                 transition: {
-    //                     type: "spring",
-    //                 },
-    //             },
-    //             asResolver: () => ({
-    //                 opacity: 0,
-    //                 transition: {
-    //                     type: "physics",
-    //                     delay: 10,
-    //                 },
-    //             }),
-    //             withTransitionEnd: {
-    //                 transitionEnd: { opacity: 0 },
-    //             },
-    //         }
-    //         render(<motion.div variants={variants} />)
-    //     }).not.toThrowError()
-    // })
+    test("accepts variants without being typed", () => {
+        expect(() => {
+            const variants = {
+                withoutTransition: { opacity: 0 },
+                withJustDefaultTransitionType: {
+                    opacity: 0,
+                    transition: {
+                        duration: 1,
+                    },
+                },
+                withTransitionIndividual: {
+                    transition: {
+                        when: "beforeChildren",
+                        opacity: { type: "spring" },
+                    },
+                },
+                withTransitionType: {
+                    transition: {
+                        type: "spring",
+                    },
+                },
+                asResolver: () => ({
+                    opacity: 0,
+                    transition: {
+                        type: "physics",
+                        delay: 10,
+                    },
+                }),
+                withTransitionEnd: {
+                    transitionEnd: { opacity: 0 },
+                },
+            }
+            render(<motion.div variants={variants} />)
+        }).not.toThrowError()
+    })
 
     test("new child items animate from initial to animate", () => {
         const x = motionValue(0)
@@ -419,7 +419,7 @@ describe("animate prop as variant", () => {
 
             return (
                 <motion.div initial="hidden" animate="visible">
-                    {items}
+                    <motion.div>{items}</motion.div>
                 </motion.div>
             )
         }

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -67,13 +67,15 @@ export const createMotionComponent = <P extends {}>({
             props
         )
 
-        const functionality = loadFunctionalityComponents(
-            values,
-            props,
-            controls,
-            shouldInheritVariant,
-            isStatic
-        )
+        const functionality = isStatic
+            ? null
+            : loadFunctionalityComponents(
+                  ref,
+                  values,
+                  props,
+                  controls,
+                  shouldInheritVariant
+              )
 
         const renderedComponent = renderComponent(
             ref,

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -11,8 +11,8 @@ import { useValueAnimationControls } from "../animation/use-value-animation-cont
 import { MotionContext, useMotionContext } from "./context/MotionContext"
 import { MotionProps } from "./types"
 import {
-    UseFunctionalityComponents,
-    UseRenderComponent,
+    LoadFunctionalityComponents,
+    RenderComponent,
 } from "./functionality/types"
 import { checkShouldInheritVariant } from "./utils/should-inherit-variant"
 import { ValueAnimationConfig } from "../animation/ValueAnimationControls"
@@ -20,8 +20,8 @@ import { useConstant } from "../utils/use-constant"
 export { MotionProps }
 
 export interface MotionComponentConfig {
-    useFunctionalityComponents: UseFunctionalityComponents
-    useRenderComponent: UseRenderComponent
+    loadFunctionalityComponents: LoadFunctionalityComponents
+    renderComponent: RenderComponent
     getValueControlsConfig: (
         ref: RefObject<any>,
         values: MotionValuesMap
@@ -33,8 +33,8 @@ export interface MotionComponentConfig {
  */
 export const createMotionComponent = <P extends {}>({
     getValueControlsConfig,
-    useFunctionalityComponents,
-    useRenderComponent,
+    loadFunctionalityComponents,
+    renderComponent,
 }: MotionComponentConfig) => {
     function MotionComponent(
         props: P & MotionProps,
@@ -67,16 +67,15 @@ export const createMotionComponent = <P extends {}>({
             props
         )
 
-        const functionality = useFunctionalityComponents(
-            ref,
-            style,
+        const functionality = loadFunctionalityComponents(
             values,
             props,
             controls,
+            shouldInheritVariant,
             isStatic
         )
 
-        const renderComponent = useRenderComponent(
+        const renderedComponent = renderComponent(
             ref,
             style,
             values,
@@ -93,7 +92,7 @@ export const createMotionComponent = <P extends {}>({
                 />
                 {functionality}
                 <MotionContext.Provider value={context}>
-                    {renderComponent}
+                    {renderedComponent}
                 </MotionContext.Provider>
             </>
         )

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -10,15 +10,18 @@ import { useMotionStyles } from "./utils/use-styles"
 import { useValueAnimationControls } from "../animation/use-value-animation-controls"
 import { MotionContext, useMotionContext } from "./context/MotionContext"
 import { MotionProps } from "./types"
-import { UseFunctionalityComponents } from "./functionality/types"
+import {
+    UseFunctionalityComponents,
+    UseRenderComponent,
+} from "./functionality/types"
 import { checkShouldInheritVariant } from "./utils/should-inherit-variant"
-import { getAnimateComponent } from "./functionality/animation"
 import { ValueAnimationConfig } from "../animation/ValueAnimationControls"
 import { useConstant } from "../utils/use-constant"
 export { MotionProps }
 
 export interface MotionComponentConfig {
     useFunctionalityComponents: UseFunctionalityComponents
+    useRenderComponent: UseRenderComponent
     getValueControlsConfig: (
         ref: RefObject<any>,
         values: MotionValuesMap
@@ -29,8 +32,9 @@ export interface MotionComponentConfig {
  * @internal
  */
 export const createMotionComponent = <P extends {}>({
-    useFunctionalityComponents,
     getValueControlsConfig,
+    useFunctionalityComponents,
+    useRenderComponent,
 }: MotionComponentConfig) => {
     function MotionComponent(
         props: P & MotionProps,
@@ -55,44 +59,43 @@ export const createMotionComponent = <P extends {}>({
             props,
             shouldInheritVariant
         )
+
         const context = useMotionContext(
             parentContext,
             controls,
             isStatic,
             props
         )
-        // Add functionality
-        const Animate = getAnimateComponent(props, context.static)
 
-        const handleAnimate = Animate && (
-            <Animate
-                {...props}
-                inherit={shouldInheritVariant}
-                innerRef={ref}
-                values={values}
-                controls={controls}
-            />
-        )
-
-        const handleActiveFunctionality = useFunctionalityComponents(
-            props,
-            values,
-            controls,
+        const functionality = useFunctionalityComponents(
             ref,
             style,
-            context.static
+            values,
+            props,
+            controls,
+            isStatic
+        )
+
+        const renderComponent = useRenderComponent(
+            ref,
+            style,
+            values,
+            props,
+            isStatic
         )
 
         return (
-            <MotionContext.Provider value={context}>
+            <>
                 <MountMotionValues
                     ref={ref}
                     values={values}
                     isStatic={isStatic}
                 />
-                {handleAnimate}
-                {handleActiveFunctionality}
-            </MotionContext.Provider>
+                {functionality}
+                <MotionContext.Provider value={context}>
+                    {renderComponent}
+                </MotionContext.Provider>
+            </>
         )
     }
 

--- a/src/motion/functionality/animation.ts
+++ b/src/motion/functionality/animation.ts
@@ -1,4 +1,4 @@
-import { ComponentType, RefObject } from "react"
+import { ComponentType } from "react"
 import { MotionProps, AnimatePropType, VariantLabels } from "../types"
 import { makeHookComponent } from "../utils/make-hook-component"
 import { useAnimateProp } from "../../animation/use-animate-prop"
@@ -9,10 +9,13 @@ import { ValueAnimationControls } from "../../animation/ValueAnimationControls"
 import { MotionValuesMap } from "../../motion/utils/use-motion-values"
 import { TargetAndTransition } from "../../types"
 
-interface AnimationFunctionalProps extends MotionProps {
+interface AnimationFunctionalProps {
+    initial: MotionProps["initial"]
+    animate: MotionProps["animate"]
+    transition: MotionProps["transition"]
+    variants: MotionProps["variants"]
     controls: ValueAnimationControls
     values: MotionValuesMap
-    innerRef: RefObject<Element | null>
     inherit: boolean
 }
 
@@ -82,7 +85,7 @@ const animatePropTypeTests = {
     [AnimatePropType.AnimationSubscription]: isAnimationSubscription,
 }
 
-export const getAnimateComponent = (
+export const getAnimationComponent = (
     props: MotionProps,
     isStatic: boolean = false
 ): ComponentType<AnimationFunctionalProps> | undefined => {

--- a/src/motion/functionality/animation.ts
+++ b/src/motion/functionality/animation.ts
@@ -40,10 +40,10 @@ export const AnimatePropComponents = {
             initial,
         }: AnimationFunctionalProps) => {
             return useVariants(
+                initial as VariantLabels,
                 animate as VariantLabels,
                 inherit,
-                controls,
-                initial as VariantLabels
+                controls
             )
         }
     ),

--- a/src/motion/functionality/animation.ts
+++ b/src/motion/functionality/animation.ts
@@ -86,8 +86,7 @@ const animatePropTypeTests = {
 }
 
 export const getAnimationComponent = (
-    props: MotionProps,
-    isStatic: boolean = false
+    props: MotionProps
 ): ComponentType<AnimationFunctionalProps> | undefined => {
     let animatePropType: AnimatePropType | undefined = undefined
 
@@ -97,7 +96,5 @@ export const getAnimationComponent = (
         }
     }
 
-    return !isStatic && animatePropType
-        ? AnimatePropComponents[animatePropType]
-        : undefined
+    return animatePropType ? AnimatePropComponents[animatePropType] : undefined
 }

--- a/src/motion/functionality/dom.tsx
+++ b/src/motion/functionality/dom.tsx
@@ -107,6 +107,27 @@ export function createDomMotionConfig<P = MotionProps>(
         ) => {
             const activeComponents: JSX.Element[] = []
 
+            // const Animate = getAnimateComponent(props, context.static)
+
+            // const handleAnimate = Animate && (
+            //     <Animate
+            //         {...props}
+            //         inherit={shouldInheritVariant}
+            //         innerRef={ref}
+            //         values={values}
+            //         controls={controls}
+            //     />
+            // )
+
+            // const handleActiveFunctionality = useFunctionalityComponents(
+            //     props,
+            //     values,
+            //     controls,
+            //     ref,
+            //     style,
+            //     context.static
+            // )
+
             // TODO: Refactor the following loading strategy into something more dynamic
             // This is also a good target for filesize reduction by making these present externally.
             // It might be possible to code-split these out and useState to re-render children when the

--- a/src/motion/functionality/dom.tsx
+++ b/src/motion/functionality/dom.tsx
@@ -86,8 +86,6 @@ export function createDomMotionConfig<P = MotionProps>(
          *  2) User-defined "clean props" function that removes their plugin's props before being passed to the DOM.
          */
         loadFunctionalityComponents: (
-            ref,
-            style,
             values,
             props,
             controls,
@@ -111,18 +109,6 @@ export function createDomMotionConfig<P = MotionProps>(
                     />
                 )
             }
-
-            // const Animate = getAnimateComponent(props, context.static)
-
-            // const handleAnimate = Animate && (
-            //     <Animate
-            //         {...props}
-            //         inherit={shouldInheritVariant}
-            //         innerRef={ref}
-            //         values={values}
-            //         controls={controls}
-            //     />
-            // )
 
             // const handleActiveFunctionality = useFunctionalityComponents(
             //     props,
@@ -173,18 +159,6 @@ export function createDomMotionConfig<P = MotionProps>(
             //         />
             //     )
             // }
-
-            // activeComponents.push(
-            //     <RenderComponent
-            //         componentProps={props}
-            //         values={values}
-            //         controls={controls}
-            //         innerRef={ref}
-            //         style={style}
-            //         isStatic={isStatic}
-            //         key="renderComponent"
-            //     />
-            // )
 
             return activeComponents
         },

--- a/src/motion/functionality/drag.ts
+++ b/src/motion/functionality/drag.ts
@@ -4,8 +4,9 @@ import { makeHookComponent } from "../utils/make-hook-component"
 import { FunctionalProps, FunctionalComponentDefinition } from "./types"
 
 export const Drag: FunctionalComponentDefinition = {
+    key: "drag",
     shouldRender: (props: MotionProps) => !!props.drag,
-    component: makeHookComponent(
+    Component: makeHookComponent(
         ({ innerRef, values, controls, ...props }: FunctionalProps) => {
             return useDraggable(props, innerRef, values, controls)
         }

--- a/src/motion/functionality/gestures.ts
+++ b/src/motion/functionality/gestures.ts
@@ -19,10 +19,11 @@ export const gestureProps = [
 ]
 
 export const Gestures: FunctionalComponentDefinition = {
+    key: "gestures",
     shouldRender: (props: MotionProps) => {
         return gestureProps.some(key => props.hasOwnProperty(key))
     },
-    component: makeHookComponent(({ innerRef, ...props }: FunctionalProps) => {
+    Component: makeHookComponent(({ innerRef, ...props }: FunctionalProps) => {
         useGestures(props, innerRef)
     }),
 }

--- a/src/motion/functionality/position.ts
+++ b/src/motion/functionality/position.ts
@@ -93,9 +93,10 @@ function usePositionAnimation(
 }
 
 export const Position: FunctionalComponentDefinition = {
+    key: "position",
     shouldRender: (props: MotionProps) =>
         typeof window !== "undefined" && !!props.positionTransition,
-    component: makeHookComponent(
+    Component: makeHookComponent(
         ({
             innerRef,
             controls,

--- a/src/motion/functionality/types.ts
+++ b/src/motion/functionality/types.ts
@@ -15,10 +15,18 @@ export interface FunctionalComponentDefinition {
 }
 
 export type UseFunctionalityComponents<P = {}> = (
-    props: P & MotionProps,
-    values: MotionValuesMap,
-    controls: ValueAnimationControls<P>,
     ref: RefObject<Element>,
     style: CSSProperties,
+    values: MotionValuesMap,
+    props: P & MotionProps,
+    controls: ValueAnimationControls<P>,
     isStatic?: boolean
-) => ReactElement<P>[]
+) => ReactElement<FunctionalProps>[]
+
+export type UseRenderComponent<P = {}> = (
+    ref: RefObject<Element>,
+    style: CSSProperties,
+    values: MotionValuesMap,
+    props: P,
+    isStatic?: boolean
+) => ReactElement

--- a/src/motion/functionality/types.ts
+++ b/src/motion/functionality/types.ts
@@ -10,16 +10,17 @@ export interface FunctionalProps extends MotionProps {
 }
 
 export interface FunctionalComponentDefinition {
+    key: string
     shouldRender: (props: MotionProps) => boolean
-    component: ComponentType<FunctionalProps>
+    Component: ComponentType<FunctionalProps>
 }
 
 export type LoadFunctionalityComponents<P = {}> = (
+    ref: RefObject<Element>,
     values: MotionValuesMap,
     props: P & MotionProps,
     controls: ValueAnimationControls<P>,
-    inherit: boolean,
-    isStatic?: boolean
+    inherit: boolean
 ) => ReactElement<FunctionalProps>[]
 
 export type RenderComponent<P = {}> = (

--- a/src/motion/functionality/types.ts
+++ b/src/motion/functionality/types.ts
@@ -14,16 +14,15 @@ export interface FunctionalComponentDefinition {
     component: ComponentType<FunctionalProps>
 }
 
-export type UseFunctionalityComponents<P = {}> = (
-    ref: RefObject<Element>,
-    style: CSSProperties,
+export type LoadFunctionalityComponents<P = {}> = (
     values: MotionValuesMap,
     props: P & MotionProps,
     controls: ValueAnimationControls<P>,
+    inherit: boolean,
     isStatic?: boolean
 ) => ReactElement<FunctionalProps>[]
 
-export type UseRenderComponent<P = {}> = (
+export type RenderComponent<P = {}> = (
     ref: RefObject<Element>,
     style: CSSProperties,
     values: MotionValuesMap,


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/196

Part of the fix was only wrapping the rendered child in the created Context.Provider, had a bit of a cleanup around that.