### PR TITLE
Fixing unit conversion when non-positional transforms are applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 -   Value type conversion for currently-hidden elements.
+-   Fixing unit type conversions when non-positional transforms are applied.
+-   Fixing variant propagation via `useAnimation()` when the parent component has no `variants` prop set.
 
 ## [1.2.4] 2019-07-15
 

--- a/dev/examples/heightAutoWithRotateAndScale.tsx
+++ b/dev/examples/heightAutoWithRotateAndScale.tsx
@@ -19,9 +19,10 @@ const Accordion = ({ i, expanded, setExpanded }) => {
                 initial="collapsed"
                 animate={isOpen ? "open" : "collapsed"}
                 variants={{
-                    open: { scale: 1, opacity: 1, height: "auto" },
+                    open: { scale: 1, rotate: 0, opacity: 1, height: "auto" },
                     collapsed: {
                         scale: 0.5,
+                        rotate: 45,
                         opacity: 0,
                         height: 0,
                     },

--- a/dev/examples/heightAutoWithRotateAndScale.tsx
+++ b/dev/examples/heightAutoWithRotateAndScale.tsx
@@ -1,0 +1,152 @@
+import * as React from "react"
+import { useState } from "react"
+import { motion } from "@framer"
+import { mix } from "@popmotion/popcorn"
+
+const Accordion = ({ i, expanded, setExpanded }) => {
+    const isOpen = i === expanded
+
+    // By using `AnimatePresence` to mount and unmount the contents, we can animate
+    // them in and out while also only rendering the contents of open accordions
+    return (
+        <>
+            <motion.header
+                initial={false}
+                animate={{ backgroundColor: isOpen ? "#FF0088" : "#0055FF" }}
+                onClick={() => setExpanded(isOpen ? false : i)}
+            />
+            <motion.section
+                initial="collapsed"
+                animate={isOpen ? "open" : "collapsed"}
+                variants={{
+                    open: { scale: 1, opacity: 1, height: "auto" },
+                    collapsed: {
+                        scale: 0.5,
+                        opacity: 0,
+                        height: 0,
+                    },
+                }}
+                transition={{ duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] }}
+            >
+                <ContentPlaceholder />
+            </motion.section>
+        </>
+    )
+}
+
+export const App = () => {
+    // This approach is if you only want max one section open at a time. If you want multiple
+    // sections to potentially be open simultaneously, they can all be given their own `useState`.
+    const [expanded, setExpanded] = useState<false | number>(0)
+
+    return (
+        <div className="example-container">
+            {[0, 1, 2, 3].map(i => (
+                <Accordion
+                    i={i}
+                    expanded={expanded}
+                    setExpanded={setExpanded}
+                />
+            ))}
+            <style>{styles}</style>
+        </div>
+    )
+}
+
+const styles = `body {
+  background-repeat: no-repeat;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+.example-container {
+  width: 320px;
+  padding: 20px;
+}
+
+.content-placeholder {
+  padding: 20px;
+  transform-origin: top center;
+}
+
+header {
+  background: #0055ff;
+  border-radius: 10px;
+  color: white;
+  cursor: pointer;
+  height: 40px;
+  margin-bottom: 20px;
+}
+
+.word {
+  height: 18px;
+  border-radius: 10px;
+  display: inline-block;
+  margin-bottom: 8px;
+  margin-right: 8px;
+  background: #0055ff;
+  border-radius: 10px;
+  display: inline-block;
+}
+
+.paragraph {
+  margin-bottom: 20px;
+}
+
+section {
+  overflow: hidden;
+}
+
+@media (max-width: 600px) {
+  .content-placeholder {
+    padding-left: 20px;
+  }
+
+  .header .word {
+    height: 30px;
+  }
+
+  .word {
+    height: 14px;
+    margin-bottom: 5px;
+    margin-right: 5px;
+  }
+
+  .paragraph {
+    margin-bottom: 20px;
+  }
+}`
+
+const randomInt = (min, max) => Math.round(mix(min, max, Math.random()))
+const generateParagraphLength = () => randomInt(5, 20)
+const generateWordLength = () => randomInt(20, 100)
+
+// Randomly generate some paragraphs of word lengths
+const paragraphs = Array(3)
+    .fill(1)
+    .map(() => {
+        return Array(generateParagraphLength())
+            .fill(1)
+            .map(generateWordLength)
+    })
+
+export const Word = ({ width }) => <div className="word" style={{ width }} />
+
+const Paragraph = ({ words }) => (
+    <div className="paragraph">
+        {words.map(width => (
+            <Word width={width} />
+        ))}
+    </div>
+)
+
+export const ContentPlaceholder = () => (
+    <motion.div transition={{ duration: 0.8 }} className="content-placeholder">
+        {paragraphs.map(words => (
+            <Paragraph words={words} />
+        ))}
+    </motion.div>
+)

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "hey-listen": "^1.0.8",
         "popmotion": "^9.0.0-beta-7",
         "style-value-types": "^3.1.5",
-        "stylefire": "^6.0.5",
+        "stylefire": "^6.0.6",
         "tslib": "^1.10.0"
     },
     "husky": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "hey-listen": "^1.0.8",
         "popmotion": "^9.0.0-beta-7",
         "style-value-types": "^3.1.5",
-        "stylefire": "^6.0.4",
+        "stylefire": "^6.0.5",
         "tslib": "^1.10.0"
     },
     "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,7 +394,7 @@
   resolved "https://registry.yarnpkg.com/@popmotion/easing/-/easing-1.0.2.tgz#17d925c45b4bf44189e5a38038d149df42d8c0b4"
   integrity sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==
 
-"@popmotion/popcorn@^0.4.1":
+"@popmotion/popcorn@^0.4.0", "@popmotion/popcorn@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@popmotion/popcorn/-/popcorn-0.4.1.tgz#02a3aa146dabef4e1bae0567511427fd89fc9cbf"
   integrity sha512-vFqx+NXPGj0iXNUPgxehayiMHR1bOpTqYYF0nypay3J6ltp831hit1ml+OBJYQkk4Dcq3GSQzSokVZdLBQuC5Q==
@@ -2987,7 +2987,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framesync@^4.0.4:
+framesync@^4.0.0, framesync@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/framesync/-/framesync-4.0.4.tgz#79c42c0118f26821c078570db0ff81fb863516a2"
   integrity sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==
@@ -7196,7 +7196,7 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-style-value-types@^3.1.5:
+style-value-types@^3.1.4, style-value-types@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.1.5.tgz#b3a8cac34059b0e7e0458593fb96892e2d3a9b13"
   integrity sha512-D4ksO88QUxpqiogoyl5nKvFgOpoNZrD4pr0BbZRdS2WsPdVYetdbKUtbsBlwX5mUdfXfoMNuv2pS8h+XRey+Eg==
@@ -7219,16 +7219,15 @@ styled-components@^4.1.1:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-stylefire@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.4.tgz#3291d2e2b92eeb7c63f7ac9e5a1f8c1e1ccbebcf"
-  integrity sha512-94jy496blL+/zfqmxRYXl4xApvwndG6V9YubVIDxkULI6hiTdZqamBqWemusMNMXgrqzNKp8JjcH898+UD9K/A==
+stylefire@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.5.tgz#2a676488b890a5bcbc7040e6ccf7f9ad45ec5b60"
+  integrity sha512-Uq3QW25CSBTAFP2I0Lvhg/mCGewD17RX500fNVPhg8vUtU9hl1TZHGkbxpL9ye7RtWC650775WSguDxZKAbIhQ==
   dependencies:
-    "@popmotion/popcorn" "^0.4.1"
-    framesync "^4.0.4"
+    "@popmotion/popcorn" "^0.4.0"
+    framesync "^4.0.0"
     hey-listen "^1.0.8"
-    style-value-types "^3.1.5"
-    tslib "^1.10.0"
+    style-value-types "^3.1.4"
 
 stylis-rule-sheet@^0.0.10:
   version "0.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7219,10 +7219,10 @@ styled-components@^4.1.1:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-stylefire@^6.0.5:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.5.tgz#2a676488b890a5bcbc7040e6ccf7f9ad45ec5b60"
-  integrity sha512-Uq3QW25CSBTAFP2I0Lvhg/mCGewD17RX500fNVPhg8vUtU9hl1TZHGkbxpL9ye7RtWC650775WSguDxZKAbIhQ==
+stylefire@^6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.6.tgz#035efe068f1dd76914eb91de25bf1b9026db5e01"
+  integrity sha512-l0guH3eHc0b2R4BrTgvk7/h7abIHDMSf1aj+PP5ua8vTwSw4WMBkzfupRCrUOYY25RXqzeT+KpHjtSaquwbD8Q==
   dependencies:
     "@popmotion/popcorn" "^0.4.0"
     framesync "^4.0.0"


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/207

Stylefire updated also fixes https://github.com/framer/motion/issues/204

Stuff like rotate/scale/skew can ruin bounding box calculations, so temporarily unapplying these when measuring.