### PR TITLE
Fixing whileX unsetting if they contain transitionEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   Value type conversion for currently-hidden elements.
 -   Fixing unit type conversions when non-positional transforms are applied.
 -   Fixing variant propagation via `useAnimation()` when the parent component has no `variants` prop set.
+-   Fixing unsetting `whileHover` and `whileTap` if they contain `transitionEnd` values.
 
 ## [1.2.4] 2019-07-15
 

--- a/dev/examples/whileHoverUnitConversion.tsx
+++ b/dev/examples/whileHoverUnitConversion.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import { motion } from "@framer"
+import { useAnimation } from "../../src"
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "rgba(255, 0, 0, 1)",
+}
+
+const container = {
+    hidden: { width: 10 },
+    visible: {
+        width: "100%",
+    },
+}
+
+export const App = () => {
+    return (
+        <motion.div
+            variants={container}
+            initial="hidden"
+            whileHover="visible"
+            style={style}
+        />
+    )
+}

--- a/src/animation/ValueAnimationControls.ts
+++ b/src/animation/ValueAnimationControls.ts
@@ -20,10 +20,16 @@ export type AnimationDefinition =
     | VariantLabels
     | TargetAndTransition
     | TargetResolver
+
 type AnimationOptions = {
     delay?: number
     priority?: number
     transitionOverride?: Transition
+}
+
+type SetOptions = {
+    isActive?: Set<string>
+    priority?: number
 }
 
 /**
@@ -196,7 +202,7 @@ export class ValueAnimationControls<P extends {} = {}, V extends {} = {}> {
      */
     private setValues(
         target: TargetWithKeyframes,
-        isActive: Set<string> = new Set()
+        { isActive = new Set(), priority }: SetOptions = {}
     ) {
         target = this.transformValues(target as any)
 
@@ -213,7 +219,7 @@ export class ValueAnimationControls<P extends {} = {}, V extends {} = {}> {
                 this.values.set(key, motionValue(targetValue))
             }
 
-            this.baseTarget[key] = targetValue
+            if (!priority) this.baseTarget[key] = targetValue
         })
     }
 
@@ -398,7 +404,7 @@ export class ValueAnimationControls<P extends {} = {}, V extends {} = {}> {
      * Apply variant labels without animation
      */
     private applyVariantLabels(variantLabelList: string[]) {
-        const isSetting: Set<string> = new Set()
+        const isActive: Set<string> = new Set()
         const reversedList = [...variantLabelList].reverse()
 
         reversedList.forEach(key => {
@@ -407,11 +413,11 @@ export class ValueAnimationControls<P extends {} = {}, V extends {} = {}> {
             )
 
             if (transitionEnd) {
-                this.setValues(transitionEnd, isSetting)
+                this.setValues(transitionEnd, { isActive })
             }
 
             if (target) {
-                this.setValues(target, isSetting)
+                this.setValues(target, { isActive })
             }
 
             if (this.children && this.children.size) {
@@ -511,7 +517,7 @@ export class ValueAnimationControls<P extends {} = {}, V extends {} = {}> {
 
         return Promise.all(animations).then(() => {
             if (!transitionEnd) return
-            this.setValues(transitionEnd)
+            this.setValues(transitionEnd, { priority })
         })
     }
 

--- a/src/animation/ValueAnimationControls.ts
+++ b/src/animation/ValueAnimationControls.ts
@@ -27,7 +27,7 @@ type AnimationOptions = {
     transitionOverride?: Transition
 }
 
-type SetOptions = {
+type SetterOptions = {
     isActive?: Set<string>
     priority?: number
 }
@@ -202,7 +202,7 @@ export class ValueAnimationControls<P extends {} = {}, V extends {} = {}> {
      */
     private setValues(
         target: TargetWithKeyframes,
-        { isActive = new Set(), priority }: SetOptions = {}
+        { isActive = new Set(), priority }: SetterOptions = {}
     ) {
         target = this.transformValues(target as any)
 

--- a/src/gestures/__tests__/hover.test.tsx
+++ b/src/gestures/__tests__/hover.test.tsx
@@ -142,7 +142,7 @@ describe("hover", () => {
             }, 10)
         })
 
-        return expect(promise).resolves.toBe(0.5)
+        return expect(promise).resolves.toBe(1)
     })
 
     test("whileHover only animates values that arent being controlled by a higher-priority gesture ", () => {

--- a/src/gestures/__tests__/hover.test.tsx
+++ b/src/gestures/__tests__/hover.test.tsx
@@ -112,7 +112,7 @@ describe("hover", () => {
     test("whileHover is unapplied when hover ends", () => {
         const promise = new Promise(resolve => {
             const variant = {
-                hidden: { opacity: 0.5 },
+                hidden: { opacity: 0.5, transitionEnd: { opacity: 0.75 } },
             }
             const opacity = motionValue(1)
 
@@ -142,7 +142,7 @@ describe("hover", () => {
             }, 10)
         })
 
-        return expect(promise).resolves.toBe(1)
+        return expect(promise).resolves.toBe(0.5)
     })
 
     test("whileHover only animates values that arent being controlled by a higher-priority gesture ", () => {


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/181

The transitionEnd value was being set as the base value in every instance, but we only want it set when it **isn't** part of a whileX gesture prop.