### PR TITLE
Fix MotionProp.style @library example doc

### DIFF
--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -475,7 +475,7 @@ export interface MotionProps
      * export function MyComponent() {
      *   const x = useMotionValue(0)
      *
-     *   return <Frame x={x} opacity={1} scale={0.5} />
+     *   return <Frame style={{ x, opacity: 1, scale: 0.5 }}  />
      * }
      * ```
      *


### PR DESCRIPTION
It was using the individual `x`, `opacity` and `scale` props instead of `style`.