### PR TITLE
Improving unencountered value initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   Fixing unsetting `whileHover` and `whileTap` if they contain `transitionEnd` values.
 -   Child components within variant trees now animate to `animate` as set by their parent.
 -   Checking animation props for array variants as well as strings.
+-   If unencountered value is animated, first attempt to extract an initial value from keyframes definition. Also upgrading `stylefire` to gracefully handle transform requests.
 
 ## [1.2.4] 2019-07-15
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -29,6 +29,8 @@ export interface AnimatePresenceProps {
     custom?: any;
     initial?: boolean;
     onExitComplete?: () => void;
+    // @beta
+    _syncLayout?: () => void;
 }
 
 // @public

--- a/dev/examples/animateSVGWithoutInitialValues.tsx
+++ b/dev/examples/animateSVGWithoutInitialValues.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { useState, useEffect, useCallback } from "react"
+import { motion, useMotionValue, useTransform, useAnimation } from "@framer"
+
+// https://github.com/framer/motion/issues/216
+const animation = {
+    strokeDasharray: ["1px, 200px", "100px, 200px", "100px, 200px"],
+    strokeDashoffset: [0, -15, -125],
+    transition: { duration: 1.4, ease: "linear" },
+}
+
+export const App = () => {
+    const controls = useAnimation()
+
+    const handleAnimationComplete = useCallback(
+        () => {
+            controls.start(animation)
+        },
+        [controls]
+    )
+
+    useEffect(
+        () => {
+            controls.start(animation)
+        },
+        [controls]
+    )
+
+    return (
+        <motion.svg
+            viewBox="22 22 44 44"
+            width="44"
+            height="44"
+            animate={{ rotate: 90 }}
+        >
+            <motion.circle
+                animate={controls}
+                onAnimationComplete={handleAnimationComplete}
+                cx="44"
+                cy="44"
+                r="20.2"
+                fill="none"
+                stroke="white"
+                strokeWidth="3.6"
+            />
+        </motion.svg>
+    )
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "hey-listen": "^1.0.8",
         "popmotion": "^9.0.0-beta-7",
         "style-value-types": "^3.1.5",
-        "stylefire": "^6.0.6",
+        "stylefire": "^6.0.7",
         "tslib": "^1.10.0"
     },
     "husky": {

--- a/src/motion/__tests__/component-svg.test.tsx
+++ b/src/motion/__tests__/component-svg.test.tsx
@@ -62,4 +62,22 @@ describe("SVG", () => {
         }
         render(<Component />)
     })
+
+    // https://github.com/framer/motion/issues/216
+    test("doesn't throw if animating unencounterd value", () => {
+        const animation = {
+            strokeDasharray: ["1px, 200px", "100px, 200px", "100px, 200px"],
+            strokeDashoffset: [0, -15, -125],
+            transition: { duration: 1.4, ease: "linear" },
+        }
+
+        const Component = () => {
+            return (
+                <motion.svg animate={{ rotate: 100 }}>
+                    <motion.circle animate={animation} />
+                </motion.svg>
+            )
+        }
+        render(<Component />)
+    })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7219,10 +7219,10 @@ styled-components@^4.1.1:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-stylefire@^6.0.6:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.6.tgz#035efe068f1dd76914eb91de25bf1b9026db5e01"
-  integrity sha512-l0guH3eHc0b2R4BrTgvk7/h7abIHDMSf1aj+PP5ua8vTwSw4WMBkzfupRCrUOYY25RXqzeT+KpHjtSaquwbD8Q==
+stylefire@^6.0.7:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.7.tgz#200289dba4d0f1bc3938ea8e9c5c5eb70c978953"
+  integrity sha512-nI9GAtxSv0nzvc6d8k+CLg/2iDDGFqHyU0NI3St4nNQi1hcPcvl42PqBmYyNgAm+9O5fXNjvjosfXYGFj0w3EA==
   dependencies:
     "@popmotion/popcorn" "^0.4.0"
     framesync "^4.0.0"


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/216

When trying to animate an otherwise-undefined SVG attribute, Framer Motion would read it via Stylefire. Unlike CSS and computed style, SVG returns `null` for undefined attributes. To help with that the first thing we now do is check if the target value is a keyframes array, if so take the first value of that instead of reading from Stylefire. It also didn't correctly return SVG `transform` default values which has been fixed in an update.