### PR TITLE
Fix issue with resolvedConstraints being reset on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+-   Fixing issue with drag constraints (ref-based) being reset, while dragging, on unrelated parent component updates.
+
 ## [1.3.0] 2019-07-24
 
 -   Added `onAnimationStart`.

--- a/src/behaviours/__tests__/index.test.tsx
+++ b/src/behaviours/__tests__/index.test.tsx
@@ -788,7 +788,7 @@ describe("dragging", () => {
         })
 
         return expect(promise).resolves.toHaveStyle(
-            "transform: translateX(105px) translateZ(0)"
+            "transform: translateX(105px) translateY(0px) translateZ(0)"
         )
     })
 

--- a/src/behaviours/use-draggable.ts
+++ b/src/behaviours/use-draggable.ts
@@ -482,10 +482,8 @@ const calculateConstraintsFromDom = (
 }
 
 const flattenConstraints = (constraints: DraggableProps["dragConstraints"]) => {
-    if (!constraints) {
+    if (!constraints || isRefObject(constraints)) {
         return [0, 0, 0, 0]
-    } else if (isRefObject(constraints)) {
-        return [constraints.current]
     } else {
         const { top, left, bottom, right } = constraints
         return [top, left, bottom, right]
@@ -977,8 +975,8 @@ export function useDraggable(
             dragTransition,
             dragOriginX,
             dragOriginY,
-            values.get("x"),
-            values.get("y"),
+            values.get("x", 0),
+            values.get("y", 0),
         ]
     )
 


### PR DESCRIPTION
fixes #223

This is a quick, probably a proper one would be to output `[0,0,0,0]` for ref constraint as well. Gonna explore doing this and adding tests later. Do you see anything that could get broken by my proposed "proper" solution?