### PR TITLE
Blur the active element when we prevent the default of an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.6] 2019-07-23
+
+### Fixed
+
+-   Make sure `select`, `input`, `textarea` loose focus when blocking default behaviour in a draggable element.
+
 ## [1.2.5] 2019-07-23
 
 ### Fixed

--- a/src/behaviours/use-draggable.ts
+++ b/src/behaviours/use-draggable.ts
@@ -787,6 +787,10 @@ export function useDraggable(
                     )
                 ) {
                     event.preventDefault()
+                    // Make sure input elements loose focus when we prevent the default.
+                    if (document.activeElement instanceof HTMLElement) {
+                        document.activeElement.blur()
+                    }
                 }
 
                 // Initiate viewport scroll blocking on touch start. This is a very aggressive approach


### PR DESCRIPTION
To make sure input elements loose focus
Fixes https://github.com/framer/company/issues/13852