### PR TITLE
AnimatePresence single prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--   `AnimatePresence.enterBeforeExit` prop as beta.
+-   `AnimatePresence.exitBeforeEnter` prop as beta.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+-   `AnimatePresence.enterBeforeExit` prop as beta.
+
 ### Fixed
 
 -   Fixing issue with drag constraints (ref-based) being reset, while dragging, on unrelated parent component updates.

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -21,16 +21,18 @@ import { RefObject } from 'react';
 import { SpringProps } from 'popmotion';
 import { SVGAttributes } from 'react';
 
+// Warning: (ae-forgotten-export) The symbol "AnimatePresenceProps" needs to be exported by the entry point index.d.ts
+// 
 // @public
-export const AnimatePresence: FunctionComponent<AnimatePresenceProps>;
+export const AnimatePresence: FunctionComponent<AnimatePresenceProps_2>;
 
 // @public (undocumented)
 export interface AnimatePresenceProps {
     custom?: any;
+    // @beta
+    enterBeforeExit?: boolean;
     initial?: boolean;
     onExitComplete?: () => void;
-    // @beta
-    single?: boolean;
     // @internal
     _syncLayout?: () => void;
 }

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -21,8 +21,10 @@ import { RefObject } from 'react';
 import { SpringProps } from 'popmotion';
 import { SVGAttributes } from 'react';
 
+// Warning: (ae-forgotten-export) The symbol "AnimatePresenceProps" needs to be exported by the entry point index.d.ts
+// 
 // @public
-export const AnimatePresence: FunctionComponent<AnimatePresenceProps>;
+export const AnimatePresence: FunctionComponent<AnimatePresenceProps_2>;
 
 // @public (undocumented)
 export interface AnimatePresenceProps {
@@ -30,6 +32,8 @@ export interface AnimatePresenceProps {
     initial?: boolean;
     onExitComplete?: () => void;
     // @beta
+    single?: boolean;
+    // @internal
     _syncLayout?: () => void;
 }
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -21,10 +21,8 @@ import { RefObject } from 'react';
 import { SpringProps } from 'popmotion';
 import { SVGAttributes } from 'react';
 
-// Warning: (ae-forgotten-export) The symbol "AnimatePresenceProps" needs to be exported by the entry point index.d.ts
-// 
 // @public
-export const AnimatePresence: FunctionComponent<AnimatePresenceProps_2>;
+export const AnimatePresence: FunctionComponent<AnimatePresenceProps>;
 
 // @public (undocumented)
 export interface AnimatePresenceProps {

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -28,7 +28,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps>;
 export interface AnimatePresenceProps {
     custom?: any;
     // @beta
-    enterBeforeExit?: boolean;
+    exitBeforeEnter?: boolean;
     initial?: boolean;
     onExitComplete?: () => void;
     // @internal

--- a/dev/examples/animatePresenceDeferIncoming.tsx
+++ b/dev/examples/animatePresenceDeferIncoming.tsx
@@ -1,0 +1,55 @@
+import { motion, AnimatePresence } from "@framer"
+import * as React from "react"
+import { useState } from "react"
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "red",
+    opacity: 1,
+}
+
+export const App = () => {
+    const [count, setCount] = useState(0)
+
+    return (
+        <>
+            <AnimatePresence
+                initial={false}
+                onRest={() => console.log("rest")}
+                single
+            >
+                <motion.div
+                    key={items[count]}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 2 }}
+                    style={{ ...style, background: items[count] }}
+                />
+                <motion.div
+                    key={items[count + 1]}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 2 }}
+                    style={{ ...style, background: items[count + 1] }}
+                />
+            </AnimatePresence>
+            <button
+                style={{ position: "absolute", top: 0, left: 50 }}
+                onClick={() => setCount(count + 1)}
+            >
+                Right
+            </button>
+            <button
+                style={{ position: "absolute", top: 0, left: 0 }}
+                onClick={() => setCount(count - 1)}
+            >
+                Left
+            </button>
+        </>
+    )
+}
+
+const items = ["red", "green", "blue", "yellow", "orange", "purple"]

--- a/src/behaviours/utils/lock.ts
+++ b/src/behaviours/utils/lock.ts
@@ -16,6 +16,7 @@ export function createLock(name: string) {
 
 const globalHorizontalLock = createLock("dragHorizontal")
 const globalVerticalLock = createLock("dragVertical")
+
 export function getGlobalLock(
     drag: boolean | "x" | "y" | "lockDirection"
 ): Lock {

--- a/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -119,11 +119,11 @@ describe("AnimatePresence", () => {
         return await expect(promise).resolves.toBe(3)
     })
 
-    test("Only renders one child at a time if single={true}", async () => {
+    test("Only renders one child at a time if exitBeforeEnter={true}", async () => {
         const promise = new Promise<number>(resolve => {
             const Component = ({ i }: { i: number }) => {
                 return (
-                    <AnimatePresence single>
+                    <AnimatePresence exitBeforeEnter>
                         <motion.div
                             key={i}
                             animate={{ opacity: 1 }}

--- a/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -1,7 +1,8 @@
-import "../../../jest.setup"
+import "../../../../jest.setup"
 import * as React from "react"
 import { render } from "react-testing-library"
-import { AnimatePresence, motion, motionValue } from "../.."
+import { AnimatePresence, motion } from "../../.."
+import { motionValue } from "../../../value"
 
 describe("AnimatePresence", () => {
     test("Does nothing on initial render by default", async () => {
@@ -118,12 +119,44 @@ describe("AnimatePresence", () => {
         return await expect(promise).resolves.toBe(3)
     })
 
+    test("Only renders one child at a time if single={true}", async () => {
+        const promise = new Promise<number>(resolve => {
+            const Component = ({ i }: { i: number }) => {
+                return (
+                    <AnimatePresence single>
+                        <motion.div
+                            key={i}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ duration: 0.5 }}
+                        />
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component i={0} />)
+            rerender(<Component i={0} />)
+            setTimeout(() => {
+                rerender(<Component i={1} />)
+                rerender(<Component i={1} />)
+            }, 50)
+            setTimeout(() => {
+                rerender(<Component i={2} />)
+                rerender(<Component i={2} />)
+                resolve(container.childElementCount)
+            }, 150)
+        })
+
+        return await expect(promise).resolves.toBe(1)
+    })
+
     test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
         const variants = {
             enter: { x: 0, transition: { type: false } },
             exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
         }
         const promise = new Promise(resolve => {
+            const x = motionValue(0)
             const Component = ({
                 isVisible,
                 onAnimationComplete,
@@ -143,13 +176,14 @@ describe("AnimatePresence", () => {
                                 initial="exit"
                                 animate="enter"
                                 exit="exit"
+                                style={{ x }}
                             />
                         )}
                     </AnimatePresence>
                 )
             }
 
-            const { container, rerender } = render(<Component isVisible />)
+            const { rerender } = render(<Component isVisible />)
             rerender(<Component isVisible />)
 
             rerender(<Component isVisible={false} />)
@@ -157,16 +191,12 @@ describe("AnimatePresence", () => {
             rerender(
                 <Component
                     isVisible={false}
-                    onAnimationComplete={() =>
-                        resolve(container.firstChild as Element)
-                    }
+                    onAnimationComplete={() => resolve(x.get())}
                 />
             )
         })
 
-        const element = await promise
-        expect(element).toHaveStyle(
-            "transform: translateX(200px) translateZ(0)"
-        )
+        const resolvedX = await promise
+        expect(resolvedX).toBe(200)
     })
 })

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -115,7 +115,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
     custom,
     initial = true,
     onExitComplete,
-    enterBeforeExit,
+    exitBeforeEnter,
     _syncLayout,
 }) => {
     const isInitialRender = useRef(true)
@@ -182,7 +182,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
 
     // If we currently have exiting children, and we're deferring rendering incoming children
     // until after all current children have exiting, empty the childrenToRender array
-    if (enterBeforeExit && exiting.size) {
+    if (exitBeforeEnter && exiting.size) {
         childrenToRender = []
     }
 
@@ -236,11 +236,11 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
 
     if (
         process.env.NODE_ENV !== "production" &&
-        enterBeforeExit &&
+        exitBeforeEnter &&
         childrenToRender.length > 1
     ) {
         console.warn(
-            `You're attempting to animate multiple children within AnimatePresence, but its enterBeforeExit prop is set to true. This will lead to odd visual behaviour.`
+            `You're attempting to animate multiple children within AnimatePresence, but its exitBeforeEnter prop is set to true. This will lead to odd visual behaviour.`
         )
     }
 

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -115,7 +115,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
     custom,
     initial = true,
     onExitComplete,
-    single,
+    enterBeforeExit,
     _syncLayout,
 }) => {
     const isInitialRender = useRef(true)
@@ -182,7 +182,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
 
     // If we currently have exiting children, and we're deferring rendering incoming children
     // until after all current children have exiting, empty the childrenToRender array
-    if (single && exiting.size) {
+    if (enterBeforeExit && exiting.size) {
         childrenToRender = []
     }
 
@@ -236,11 +236,11 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
 
     if (
         process.env.NODE_ENV !== "production" &&
-        single &&
+        enterBeforeExit &&
         childrenToRender.length > 1
     ) {
         console.warn(
-            `You're attempting to animate multiple children within AnimatePresence, but its single prop is set to true. This will lead to odd visual behaviour.`
+            `You're attempting to animate multiple children within AnimatePresence, but its enterBeforeExit prop is set to true. This will lead to odd visual behaviour.`
         )
     }
 

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -9,103 +9,7 @@ import {
     FunctionComponent,
 } from "react"
 import * as React from "react"
-
-/**
- * @public
- */
-export interface AnimatePresenceProps {
-    /**
-     * By passing `initial={false}`, `AnimatePresence` will disable any initial animations on children
-     * that are present when the component is first rendered.
-     *
-     * @library
-     *
-     * ```jsx
-     * <AnimatePresence initial={false}>
-     *   {isVisible && (
-     *     <Frame
-     *       key="modal"
-     *       initial={{ opacity: 0 }}
-     *       animate={{ opacity: 1 }}
-     *       exit={{ opacity: 0 }}
-     *     />
-     *   )}
-     * </AnimatePresence>
-     * ```
-     *
-     * @motion
-     *
-     * ```jsx
-     * <AnimatePresence initial={false}>
-     *   {isVisible && (
-     *     <motion.div
-     *       key="modal"
-     *       initial={{ opacity: 0 }}
-     *       animate={{ opacity: 1 }}
-     *       exit={{ opacity: 0 }}
-     *     />
-     *   )}
-     * </AnimatePresence>
-     * ```
-     *
-     * @public
-     */
-    initial?: boolean
-
-    /**
-     * When a component is removed, there's no longer a chance to update its props. So if a component's `exit`
-     * prop is defined as a dynamic variant and you want to pass a new `custom` prop, you can do so via `AnimatePresence`.
-     * This will ensure all leaving components animate using the latest data.
-     *
-     * @public
-     */
-    custom?: any
-
-    /**
-     * Fires when all exiting nodes have completed animating out.
-     *
-     * @public
-     */
-    onExitComplete?: () => void
-
-    /**
-     * `AnimatePresence` locally re-renders its children once exit animations are
-     * complete. This means that if surrounding or parent components are also set to `positionTransition`,
-     * they aren't informed of updates to the layout when they happen asynchronous to a render.
-     *
-     * This prop allows `AnimatePresence` to trigger re-renders at a higher level, so more
-     * components can be made aware of the layout change and animate accordingly.
-     *
-     * In this example, the both the parent and sibling will animate to their new layout
-     * once the div within `AnimatePresence` has finished animating:
-     *
-     * ```jsx
-     * const MyComponent = ({ isVisible }) => {
-     *   const forceRender = useForceRender() // Forces a set state or something
-     *
-     *   return (
-     *     <motion.div positionTransition>
-     *       <AnimatePresence _syncLayout={forceRender}>
-     *         <motion.div positionTransition exit={{ opacity: 0 }} />
-     *       </AnimatePresence>
-     *       <motion.div positionTransition />
-     *     </motion.div>
-     *   )
-     * }
-     * ```
-     *
-     * In the final implementation `syncLayout` might be better as a component
-     * that provides this function to children via context, or some other method
-     * that obfuscates
-     *
-     * This isn't generally a problem for most use-cases but this capability will be useful
-     * for advanced uses but also more so for phase 2 of `sizeTransition`, as we'd gain the power
-     * to declaratively relayout entire parts of the page using only performant transforms.
-     *
-     * @beta
-     */
-    _syncLayout?: () => void
-}
+import { AnimatePresenceProps } from "./types"
 
 type ComponentKey = string | number
 
@@ -211,6 +115,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
     custom,
     initial = true,
     onExitComplete,
+    single,
     _syncLayout,
 }) => {
     const isInitialRender = useRef(true)
@@ -256,7 +161,7 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
     }
 
     // If this is a subsequent render, deal with entering and exiting children
-    const childrenToRender = [...filteredChildren]
+    let childrenToRender = [...filteredChildren]
 
     // Diff the keys of the currently-present and target children to update our
     // exiting list.
@@ -273,6 +178,12 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
             // In case this key has re-entered, remove from the exiting list
             exiting.delete(key)
         }
+    }
+
+    // If we currently have exiting children, and we're deferring rendering incoming children
+    // until after all current children have exiting, empty the childrenToRender array
+    if (single && exiting.size) {
+        childrenToRender = []
     }
 
     // Loop through all currently exiting components and clone them to overwrite `animate`
@@ -322,6 +233,16 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
     })
 
     presentChildren.current = childrenToRender
+
+    if (
+        process.env.NODE_ENV !== "production" &&
+        single &&
+        childrenToRender.length > 1
+    ) {
+        console.warn(
+            `You're attempting to animate multiple children within AnimatePresence, but its single prop is set to true. This will lead to odd visual behaviour.`
+        )
+    }
 
     return (
         <>

--- a/src/components/AnimatePresence/types.ts
+++ b/src/components/AnimatePresence/types.ts
@@ -95,15 +95,15 @@ export interface AnimatePresenceProps {
     _syncLayout?: () => void
 
     /**
-     * If set to `true`, `AnimatePresence` will only render one component at a time. Exiting components
-     * will finished their exit animation before the entering component is rendered.
+     * If set to `true`, `AnimatePresence` will only render one component at a time. The exiting component
+     * will finished its exit animation before the entering component is rendered.
      *
      * @library
      *
      * ```jsx
      * function MyComponent({ currentItem }) {
      *   return (
-     *     <AnimatePresence single>
+     *     <AnimatePresence enterBeforeExit>
      *       <Frame key={currentItem} exit={{ opacity: 0 }} />
      *     </AnimatePresence>
      *   )
@@ -114,7 +114,7 @@ export interface AnimatePresenceProps {
      *
      * ```jsx
      * const MyComponent = ({ currentItem }) => (
-     *   <AnimatePresence single>
+     *   <AnimatePresence enterBeforeExit>
      *     <motion.div key={currentItem} exit={{ opacity: 0 }} />
      *   </AnimatePresence>
      * )
@@ -122,5 +122,5 @@ export interface AnimatePresenceProps {
      *
      * @beta
      */
-    single?: boolean
+    enterBeforeExit?: boolean
 }

--- a/src/components/AnimatePresence/types.ts
+++ b/src/components/AnimatePresence/types.ts
@@ -95,7 +95,8 @@ export interface AnimatePresenceProps {
     _syncLayout?: () => void
 
     /**
-     * If set to `true`, this prop will animate the old component out before rendering the new component.
+     * If set to `true`, `AnimatePresence` will only render one component at a time. Exiting components
+     * will finished their exit animation before the entering component is rendered.
      *
      * @library
      *

--- a/src/components/AnimatePresence/types.ts
+++ b/src/components/AnimatePresence/types.ts
@@ -1,0 +1,125 @@
+/**
+ * @public
+ */
+export interface AnimatePresenceProps {
+    /**
+     * By passing `initial={false}`, `AnimatePresence` will disable any initial animations on children
+     * that are present when the component is first rendered.
+     *
+     * @library
+     *
+     * ```jsx
+     * <AnimatePresence initial={false}>
+     *   {isVisible && (
+     *     <Frame
+     *       key="modal"
+     *       initial={{ opacity: 0 }}
+     *       animate={{ opacity: 1 }}
+     *       exit={{ opacity: 0 }}
+     *     />
+     *   )}
+     * </AnimatePresence>
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * <AnimatePresence initial={false}>
+     *   {isVisible && (
+     *     <motion.div
+     *       key="modal"
+     *       initial={{ opacity: 0 }}
+     *       animate={{ opacity: 1 }}
+     *       exit={{ opacity: 0 }}
+     *     />
+     *   )}
+     * </AnimatePresence>
+     * ```
+     *
+     * @public
+     */
+    initial?: boolean
+
+    /**
+     * When a component is removed, there's no longer a chance to update its props. So if a component's `exit`
+     * prop is defined as a dynamic variant and you want to pass a new `custom` prop, you can do so via `AnimatePresence`.
+     * This will ensure all leaving components animate using the latest data.
+     *
+     * @public
+     */
+    custom?: any
+
+    /**
+     * Fires when all exiting nodes have completed animating out.
+     *
+     * @public
+     */
+    onExitComplete?: () => void
+
+    /**
+     * `AnimatePresence` locally re-renders its children once exit animations are
+     * complete. This means that if surrounding or parent components are also set to `positionTransition`,
+     * they aren't informed of updates to the layout when they happen asynchronous to a render.
+     *
+     * This prop allows `AnimatePresence` to trigger re-renders at a higher level, so more
+     * components can be made aware of the layout change and animate accordingly.
+     *
+     * In this example, the both the parent and sibling will animate to their new layout
+     * once the div within `AnimatePresence` has finished animating:
+     *
+     * ```jsx
+     * const MyComponent = ({ isVisible }) => {
+     *   const forceRender = useForceRender() // Forces a set state or something
+     *
+     *   return (
+     *     <motion.div positionTransition>
+     *       <AnimatePresence _syncLayout={forceRender}>
+     *         <motion.div positionTransition exit={{ opacity: 0 }} />
+     *       </AnimatePresence>
+     *       <motion.div positionTransition />
+     *     </motion.div>
+     *   )
+     * }
+     * ```
+     *
+     * In the final implementation `syncLayout` might be better as a component
+     * that provides this function to children via context, or some other method
+     * that obfuscates
+     *
+     * This isn't generally a problem for most use-cases but this capability will be useful
+     * for advanced uses but also more so for phase 2 of `sizeTransition`, as we'd gain the power
+     * to declaratively relayout entire parts of the page using only performant transforms.
+     *
+     * @internal
+     */
+    _syncLayout?: () => void
+
+    /**
+     * If set to `true`, this prop will animate the old component out before rendering the new component.
+     *
+     * @library
+     *
+     * ```jsx
+     * function MyComponent({ currentItem }) {
+     *   return (
+     *     <AnimatePresence single>
+     *       <Frame key={currentItem} exit={{ opacity: 0 }} />
+     *     </AnimatePresence>
+     *   )
+     * }
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * const MyComponent = ({ currentItem }) => (
+     *   <AnimatePresence single>
+     *     <motion.div key={currentItem} exit={{ opacity: 0 }} />
+     *   </AnimatePresence>
+     * )
+     * ```
+     *
+     * @beta
+     */
+    single?: boolean
+}

--- a/src/components/AnimatePresence/types.ts
+++ b/src/components/AnimatePresence/types.ts
@@ -103,7 +103,7 @@ export interface AnimatePresenceProps {
      * ```jsx
      * function MyComponent({ currentItem }) {
      *   return (
-     *     <AnimatePresence enterBeforeExit>
+     *     <AnimatePresence exitBeforeEnter>
      *       <Frame key={currentItem} exit={{ opacity: 0 }} />
      *     </AnimatePresence>
      *   )
@@ -114,7 +114,7 @@ export interface AnimatePresenceProps {
      *
      * ```jsx
      * const MyComponent = ({ currentItem }) => (
-     *   <AnimatePresence enterBeforeExit>
+     *   <AnimatePresence exitBeforeEnter>
      *     <motion.div key={currentItem} exit={{ opacity: 0 }} />
      *   </AnimatePresence>
      * )
@@ -122,5 +122,5 @@ export interface AnimatePresenceProps {
      *
      * @beta
      */
-    enterBeforeExit?: boolean
+    exitBeforeEnter?: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,8 +69,6 @@ export {
 } from "./types"
 export { EventInfo } from "./events"
 export { safeWindow } from "./events/utils/window"
-export {
-    AnimatePresence,
-    AnimatePresenceProps,
-} from "./components/AnimatePresence"
+export { AnimatePresence } from "./components/AnimatePresence"
+export { AnimatePresenceProps } from "./components/AnimatePresence/types"
 export { isValidMotionProp } from "./motion/utils/valid-prop"

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,6 @@ export {
 } from "./types"
 export { EventInfo } from "./events"
 export { safeWindow } from "./events/utils/window"
-export { AnimatePresence } from "./components/AnimatePresence"
 export { AnimatePresenceProps } from "./components/AnimatePresence/types"
+export { AnimatePresence } from "./components/AnimatePresence"
 export { isValidMotionProp } from "./motion/utils/valid-prop"


### PR DESCRIPTION
Enables `AnimatePresence` to block an incoming child until the old one has animated out.

For instance with paginated form flows/tutorial flows etc.