### PR TITLE
useInvertedScale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.0] Unreleased
+
+### Added
+
+-   `useInvertedScale`.
+
 ## [1.4.2] 2019-07-31
 
 ### Fixed

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -658,7 +658,7 @@ export function useGestures<GestureHandlers>(props: GestureHandlers, ref: RefObj
 // Warning: (ae-forgotten-export) The symbol "ScaleMotionValues" needs to be exported by the entry point index.d.ts
 // 
 // @beta
-export const useInvertedScale: () => ScaleMotionValues;
+export const useInvertedScale: ({ scaleX: parentScaleX, scaleY: parentScaleY, }?: Partial<ScaleMotionValues>) => ScaleMotionValues;
 
 // @public
 export function useMotionValue<T>(initial: T): MotionValue<T>;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -655,6 +655,11 @@ export function useExternalRef<E = Element>(external?: Ref<E>): RefObject<E>;
 // @public
 export function useGestures<GestureHandlers>(props: GestureHandlers, ref: RefObject<Element>): void;
 
+// Warning: (ae-forgotten-export) The symbol "ScaleMotionValues" needs to be exported by the entry point index.d.ts
+// 
+// @beta
+export const useInvertedScale: () => ScaleMotionValues;
+
 // @public
 export function useMotionValue<T>(initial: T): MotionValue<T>;
 

--- a/dev/examples/use-inverted-scale.tsx
+++ b/dev/examples/use-inverted-scale.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { motion, useInvertedScale } from "@framer"
+
+const container = {
+    width: 500,
+    height: 250,
+    padding: 20,
+    background: "white",
+    overflow: "hidden",
+}
+
+const content = {
+    width: "100%",
+    height: "100%",
+    background: "blue",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+}
+
+const box = {
+    width: 50,
+    height: 50,
+    margin: 20,
+    flex: "0 0 50px",
+    background: "red",
+}
+
+const Content = () => {
+    const inverted = useInvertedScale()
+
+    return (
+        <motion.div style={{ ...inverted, ...content }}>
+            <div style={box} />
+            <div style={box} />
+            <div style={box} />
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    return (
+        <motion.div
+            initial={{ scaleX: 0, scaleY: 0 }}
+            animate={{ scaleX: 2, scaleY: 2 }}
+            transition={{ duration: 5, yoyo: Infinity }}
+            style={container}
+        >
+            <Content />
+        </motion.div>
+    )
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export {
 export { useMotionValue } from "./value/use-motion-value"
 export { MotionValue, motionValue, PassiveEffect, Subscriber } from "./value"
 export { unwrapMotionValue } from "./value/utils/unwrap-value"
-export { useInvertedScale } from "./values/use-inverted-scale"
+export { useInvertedScale } from "./value/use-inverted-scale"
 export { useTransform } from "./value/use-transform"
 export { useSpring } from "./value/use-spring"
 export { useViewportScroll } from "./value/use-viewport-scroll"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { useMotionValue } from "./value/use-motion-value"
 export { MotionValue, motionValue, PassiveEffect, Subscriber } from "./value"
 export { unwrapMotionValue } from "./value/utils/unwrap-value"
+export { useInvertedScale } from "./values/use-inverted-scale"
 export { useTransform } from "./value/use-transform"
 export { useSpring } from "./value/use-spring"
 export { useViewportScroll } from "./value/use-viewport-scroll"

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -69,6 +69,7 @@ export const createMotionComponent = <P extends {}>({
         const context = useMotionContext(
             parentContext,
             controls,
+            values,
             isStatic,
             props
         )

--- a/src/motion/context/MotionContext.ts
+++ b/src/motion/context/MotionContext.ts
@@ -5,6 +5,7 @@ import { VariantLabels, MotionProps } from "../types"
 import { useMaxTimes } from "../../utils/use-max-times"
 import { AnimationControls } from "../../animation/AnimationControls"
 import { Target } from "../../types"
+import { MotionValuesMap } from "../utils/use-motion-values"
 
 export interface ExitProps {
     initial?: false | VariantLabels
@@ -15,6 +16,7 @@ export interface ExitProps {
 
 export interface MotionContextProps {
     controls?: ValueAnimationControls
+    values?: MotionValuesMap
     initial?: false | VariantLabels
     animate?: VariantLabels
     static?: boolean
@@ -47,6 +49,7 @@ const isAnimationControls = (
 export const useMotionContext = (
     parentContext: MotionContextProps,
     controls: ValueAnimationControls,
+    values: MotionValuesMap,
     isStatic: boolean = false,
     { initial, animate, variants, whileTap, whileHover }: MotionProps
 ) => {
@@ -108,6 +111,7 @@ export const useMotionContext = (
                 : parentContext.controls,
             initial: targetInitial,
             animate: targetAnimate,
+            values,
             hasMounted,
         }),
         [initialDependency, animateDependency]

--- a/src/value/__tests__/use-inverted-scale.test.tsx
+++ b/src/value/__tests__/use-inverted-scale.test.tsx
@@ -3,12 +3,33 @@ import { render } from "react-testing-library"
 import * as React from "react"
 import { motion } from "../../motion"
 import { useInvertedScale } from "../use-inverted-scale"
+import { motionValue } from ".."
 
 describe("useInvertedScale", () => {
     test("Provides motion values that are the inverse of their parent's scale", () => {
         const Child = () => {
             const { scaleX, scaleY } = useInvertedScale()
             expect([scaleX.get(), scaleY.get()]).toEqual([0.5, 2])
+            return null
+        }
+
+        const Component = () => {
+            return (
+                <motion.div style={{ scaleX: 2, scaleY: 0.5 }}>
+                    <Child />
+                </motion.div>
+            )
+        }
+
+        render(<Component />)
+    })
+
+    test("Provides motion values that are the inverse of the provided scale", () => {
+        const parent = { scaleX: motionValue(0.5), scaleY: motionValue(2) }
+
+        const Child = () => {
+            const { scaleX, scaleY } = useInvertedScale(parent)
+            expect([scaleX.get(), scaleY.get()]).toEqual([2, 0.5])
             return null
         }
 

--- a/src/value/__tests__/use-inverted-scale.test.tsx
+++ b/src/value/__tests__/use-inverted-scale.test.tsx
@@ -1,0 +1,43 @@
+import "../../../jest.setup"
+import { render } from "react-testing-library"
+import * as React from "react"
+import { motion } from "../../motion"
+import { useInvertedScale } from "../use-inverted-scale"
+
+describe("useInvertedScale", () => {
+    test("Provides motion values that are the inverse of their parent's scale", () => {
+        const Child = () => {
+            const { scaleX, scaleY } = useInvertedScale()
+            expect([scaleX.get(), scaleY.get()]).toEqual([0.5, 2])
+            return null
+        }
+
+        const Component = () => {
+            return (
+                <motion.div style={{ scaleX: 2, scaleY: 0.5 }}>
+                    <Child />
+                </motion.div>
+            )
+        }
+
+        render(<Component />)
+    })
+
+    test("Sensibly handles inverse of 0", () => {
+        const Child = () => {
+            const { scaleX } = useInvertedScale()
+            expect(scaleX.get()).toEqual(10000)
+            return null
+        }
+
+        const Component = () => {
+            return (
+                <motion.div style={{ scaleX: 0 }}>
+                    <Child />
+                </motion.div>
+            )
+        }
+
+        render(<Component />)
+    })
+})

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -1,6 +1,13 @@
 import { useContext } from "react"
 import { MotionContext } from "../motion/context/MotionContext"
 import { useTransform } from "../value/use-transform"
+import { MotionValue } from "./"
+import { invariant } from "hey-listen"
+
+interface ScaleMotionValues {
+    scaleX: MotionValue<number>
+    scaleY: MotionValue<number>
+}
 
 // Keep things reasonable and avoid scale: Infinity. In practise we might need
 // to add another value, opacity, that could interpolate scaleX/Y [0,0.01] => [0,1]
@@ -25,9 +32,25 @@ const invertScale = (scale: number) => (scale > 0.01 ? 1 / scale : maxScale)
  *
  * @beta
  */
-export const useInvertedScale = () => {
+export const useInvertedScale = ({
+    scaleX: parentScaleX,
+    scaleY: parentScaleY,
+}: Partial<ScaleMotionValues> = {}): ScaleMotionValues => {
     const { values } = useContext(MotionContext)
-    const scaleX = useTransform(values!.get("scaleX", 1), invertScale)
-    const scaleY = useTransform(values!.get("scaleY", 1), invertScale)
+
+    invariant(
+        !!values,
+        "useInvertedScale must be used within a child of another motion component."
+    )
+
+    const scaleX = useTransform(
+        parentScaleX || values!.get("scaleX", 1),
+        invertScale
+    )
+    const scaleY = useTransform(
+        parentScaleY || values!.get("scaleY", 1),
+        invertScale
+    )
+
     return { scaleX, scaleY }
 }

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -2,9 +2,24 @@ import { useContext } from "react"
 import { MotionContext } from "../motion/context/MotionContext"
 import { useTransform } from "../value/use-transform"
 
-const invertScale = (scale: number) => 1 / scale
+const maxScale = 10000
+const invertScale = (scale: number) => (scale > 0.01 ? 1 / scale : maxScale)
 
 /**
+ * Returns a `MotionValue` each for `scaleX` and `scaleY` that update with the inverse
+ * of their respective parent scales.
+ *
+ * This is useful for undoing the distortion of content when scaling a parent component.
+ *
+ * @motion
+ *
+ * ```jsx
+ * const MyComponent = () => {
+ *   const { scaleX, scaleY } = useInvertedScale()
+ *   return <motion.div style={{ scaleX, scaleY }} />
+ * }
+ * ```
+ *
  * @beta
  */
 export const useInvertedScale = () => {

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -1,0 +1,15 @@
+import { useContext } from "react"
+import { MotionContext } from "../motion/context/MotionContext"
+import { useTransform } from "../value/use-transform"
+
+const invertScale = (scale: number) => 1 / scale
+
+/**
+ * @beta
+ */
+export const useInvertedScale = () => {
+    const { values } = useContext(MotionContext)
+    const scaleX = useTransform(values!.get("scaleX", 1), invertScale)
+    const scaleY = useTransform(values!.get("scaleY", 1), invertScale)
+    return { scaleX, scaleY }
+}

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -21,12 +21,25 @@ const invertScale = (scale: number) => (scale > 0.01 ? 1 / scale : maxScale)
  *
  * This is useful for undoing the distortion of content when scaling a parent component.
  *
+ * By default, `useInvertedScale` will automatically fetch `scaleX` and `scaleY` from the nearest parent.
+ * By passing other `MotionValue`s in as `useInvertedScale({ scaleX, scaleY })`, it will invert the output
+ * of those instead.
+ *
  * @motion
  *
  * ```jsx
  * const MyComponent = () => {
  *   const { scaleX, scaleY } = useInvertedScale()
  *   return <motion.div style={{ scaleX, scaleY }} />
+ * }
+ * ```
+ *
+ * @library
+ *
+ * ```jsx
+ * function MyComponent() {
+ *   const { scaleX, scaleY } = useInvertedScale()
+ *   return <Frame scaleX={scaleX} scaleY={scaleY} />
  * }
  * ```
  *

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -2,6 +2,9 @@ import { useContext } from "react"
 import { MotionContext } from "../motion/context/MotionContext"
 import { useTransform } from "../value/use-transform"
 
+// Keep things reasonable and avoid scale: Infinity. In practise we might need
+// to add another value, opacity, that could interpolate scaleX/Y [0,0.01] => [0,1]
+// to simply hide content at unreasonable scales.
 const maxScale = 10000
 const invertScale = (scale: number) => (scale > 0.01 ? 1 / scale : maxScale)
 


### PR DESCRIPTION
A hook for returning scale values that update with the inverse of their parent scale.

Used to remove visual distortion induced from scaling parent components.

```jsx
const MyComponent = () => {
  const { scaleX, scaleY } = useInvertedScale()
  return <motion.div style={{ scaleX, scaleY }} />
}
```