### PR TITLE
Fixing drag propagation

### DIFF
--- a/src/behaviours/use-draggable.ts
+++ b/src/behaviours/use-draggable.ts
@@ -602,6 +602,10 @@ export function useDraggable(
         y: dragOriginY || defaultOriginY,
     }
 
+    // This is a reference to the global drag gesture lock, ensuring only one component
+    // can "capture" the drag of one or both axes.
+    const openGlobalLock = useRef<Lock | null>(null)
+
     const { transformPagePoint } = useContext(MotionPluginContext)
 
     // By keeping a reference to the user-defined drag handlers and referring
@@ -711,12 +715,6 @@ export function useDraggable(
 
             // Don't start dragging until we've detected a direction.
             let currentDirection: null | DragDirection = null
-
-            // This is a reference to the global drag gesture lock, ensuring only one component
-            // can "capture" the drag of one or both axes. In some odd circumstances, a re-render
-            // has caused reference to this lock to be lost, if we see this appear again it might
-            // be safer to move this to a hook-root `ref`.
-            let openGlobalLock: null | Lock = null
 
             // If `dragConstraints` is set to `false` or `Constraints`, set constraints immediately.
             // Otherwise we'll resolve on mount.
@@ -837,10 +835,10 @@ export function useDraggable(
 
                 // Attempt to grab the global drag gesture lock.
                 if (!dragPropagation) {
-                    if (openGlobalLock) openGlobalLock()
-                    openGlobalLock = getGlobalLock(drag)
+                    if (openGlobalLock.current) openGlobalLock.current()
+                    openGlobalLock.current = getGlobalLock(drag)
 
-                    if (!openGlobalLock) {
+                    if (!openGlobalLock.current) {
                         return
                     }
                 }
@@ -854,7 +852,7 @@ export function useDraggable(
 
             const onPan = (event: MouseEvent | TouchEvent, info: PanInfo) => {
                 // If we didn't successfully receive the gesture lock, early return.
-                if (!dragPropagation && !openGlobalLock) {
+                if (!dragPropagation && !openGlobalLock.current) {
                     return
                 }
 
@@ -884,8 +882,9 @@ export function useDraggable(
                 unblockViewportScroll()
                 isDragging.current = false
 
-                if (!dragPropagation && openGlobalLock) {
-                    openGlobalLock()
+                if (!dragPropagation && openGlobalLock.current) {
+                    openGlobalLock.current()
+                    openGlobalLock.current = null
                 }
             }
 
@@ -939,11 +938,11 @@ export function useDraggable(
                 event: MouseEvent | TouchEvent,
                 info: PanInfo
             ) => {
-                cancelDrag()
-
-                if (!openGlobalLock || !hasDragged) {
+                if (!openGlobalLock.current || !hasDragged) {
                     return
                 }
+
+                cancelDrag()
 
                 // If we have either `dragMomentum` or `dragElastic`, initiate momentum and boundary spring animation for both axes.
                 if (dragMomentum || dragElastic) {

--- a/src/behaviours/use-draggable.ts
+++ b/src/behaviours/use-draggable.ts
@@ -938,11 +938,9 @@ export function useDraggable(
                 event: MouseEvent | TouchEvent,
                 info: PanInfo
             ) => {
-                if (!openGlobalLock.current || !hasDragged) {
-                    return
-                }
-
                 cancelDrag()
+
+                if (!hasDragged) return
 
                 // If we have either `dragMomentum` or `dragElastic`, initiate momentum and boundary spring animation for both axes.
                 if (dragMomentum || dragElastic) {


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/227

Accidentally commited test for this to master: https://github.com/framer/motion/blob/master/src/behaviours/__tests__/index.test.tsx#L406

I've moved the reference to the `openGlobalLock` to a ref as this was being lost in hot-reloading environments like CodeSandbox. The actual fix here is deleting the reference to the unlock function as this was being called by every component that had gained reference to it. So once you'd started dragging a draggable parent, it gains access to unlocking the global lock, and now when the child is dragged they both can gain the lock by simply unlocking it first.