### PR TITLE
Fixing pan and drag gestures with PointerEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.4.1] 2019-07-30
+
+### Fixed
+
+-   Pan and drag gestures with `PointerEvent`.
+
 ## [1.4.0] 2019-07-29
 
 ### Added

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -106,9 +106,9 @@ export interface DraggableProps extends DragHandlers {
 // @public (undocumented)
 export interface DragHandlers {
     onDirectionLock?(axis: "x" | "y"): void;
-    onDrag?(event: MouseEvent | TouchEvent, info: PanInfo): void;
-    onDragEnd?(event: MouseEvent | TouchEvent, info: PanInfo): void;
-    onDragStart?(event: MouseEvent | TouchEvent, info: PanInfo): void;
+    onDrag?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void;
+    onDragEnd?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void;
+    onDragStart?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void;
     onDragTransitionEnd?(): void;
 }
 
@@ -493,10 +493,10 @@ export interface Orchestration {
 
 // @public (undocumented)
 export interface PanHandlers {
-    onPan?(event: MouseEvent | TouchEvent, info: PanInfo): void;
-    onPanEnd?(event: MouseEvent | TouchEvent, info: PanInfo): void;
-    onPanSessionStart?(event: MouseEvent | TouchEvent, info: EventInfo): void;
-    onPanStart?(event: MouseEvent | TouchEvent, info: PanInfo): void;
+    onPan?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void;
+    onPanEnd?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void;
+    onPanSessionStart?(event: MouseEvent | TouchEvent | PointerEvent, info: EventInfo): void;
+    onPanStart?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void;
 }
 
 // @public
@@ -576,9 +576,9 @@ export interface SVGMotionProps<T> extends SVGAttributesAsMotionValues<T>, Omit<
 
 // @public (undocumented)
 export interface TapHandlers {
-    onTap?(event: MouseEvent | TouchEvent, info: TapInfo): void;
-    onTapCancel?(event: MouseEvent | TouchEvent, info: TapInfo): void;
-    onTapStart?(event: MouseEvent | TouchEvent, info: TapInfo): void;
+    onTap?(event: MouseEvent | TouchEvent | PointerEvent, info: TapInfo): void;
+    onTapCancel?(event: MouseEvent | TouchEvent | PointerEvent, info: TapInfo): void;
+    onTapStart?(event: MouseEvent | TouchEvent | PointerEvent, info: TapInfo): void;
     whileTap?: string | TargetAndTransition;
 }
 

--- a/src/behaviours/use-draggable.ts
+++ b/src/behaviours/use-draggable.ts
@@ -55,7 +55,10 @@ export interface DragHandlers {
      * />
      * ```
      */
-    onDragStart?(event: MouseEvent | TouchEvent, info: PanInfo): void
+    onDragStart?(
+        event: MouseEvent | TouchEvent | PointerEvent,
+        info: PanInfo
+    ): void
 
     /**
      * Callback function that fires when dragging ends.
@@ -81,7 +84,10 @@ export interface DragHandlers {
      * />
      * ```
      */
-    onDragEnd?(event: MouseEvent | TouchEvent, info: PanInfo): void
+    onDragEnd?(
+        event: MouseEvent | TouchEvent | PointerEvent,
+        info: PanInfo
+    ): void
 
     /**
      * Callback function that fires when the component is dragged.
@@ -107,7 +113,7 @@ export interface DragHandlers {
      * />
      * ```
      */
-    onDrag?(event: MouseEvent | TouchEvent, info: PanInfo): void
+    onDrag?(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo): void
 
     /**
      * Callback function that fires a drag direction is determined.
@@ -774,7 +780,9 @@ export function useDraggable(
                 axisPoint.set(current)
             }
 
-            const onPointerDown = (event: MouseEvent | TouchEvent) => {
+            const onPointerDown = (
+                event: MouseEvent | TouchEvent | PointerEvent
+            ) => {
                 // Prevent browser-specific behaviours like text selection or Chrome's image dragging.
                 if (
                     event.target &&
@@ -806,7 +814,7 @@ export function useDraggable(
             }
 
             const onPanStart = (
-                event: MouseEvent | TouchEvent,
+                event: MouseEvent | TouchEvent | PointerEvent,
                 info: PanInfo
             ) => {
                 isDragging.current = true
@@ -850,7 +858,10 @@ export function useDraggable(
                 onDragStart && onDragStart(event, convertPanToDrag(info))
             }
 
-            const onPan = (event: MouseEvent | TouchEvent, info: PanInfo) => {
+            const onPan = (
+                event: MouseEvent | TouchEvent | PointerEvent,
+                info: PanInfo
+            ) => {
                 // If we didn't successfully receive the gesture lock, early return.
                 if (!dragPropagation && !openGlobalLock.current) {
                     return
@@ -935,7 +946,7 @@ export function useDraggable(
             }
 
             const onPanEnd = (
-                event: MouseEvent | TouchEvent,
+                event: MouseEvent | TouchEvent | PointerEvent,
                 info: PanInfo
             ) => {
                 cancelDrag()

--- a/src/events/use-event.ts
+++ b/src/events/use-event.ts
@@ -18,7 +18,6 @@ export const eventListener = (
         if (!target) {
             return
         }
-
         target.addEventListener(name, handler, options)
     }
     const stopListening = () => {

--- a/src/gestures/use-hover-gesture.ts
+++ b/src/gestures/use-hover-gesture.ts
@@ -3,7 +3,7 @@ import { getGesturePriority } from "./utils/gesture-priority"
 import { TargetAndTransition } from "../types"
 import { useConditionalPointerEvents } from "../events"
 import { ControlsProp } from "./types"
-import { isTouchEvent } from "./utils/is-touch-event"
+import { isTouchEvent } from "./utils/event-type"
 
 /**
  * @public
@@ -94,7 +94,9 @@ export function useHoverGesture(
 
     const handlers = useMemo(
         () => {
-            const onPointerEnter = (event: MouseEvent | TouchEvent) => {
+            const onPointerEnter = (
+                event: MouseEvent | TouchEvent | PointerEvent
+            ) => {
                 if (isTouchEvent(event)) return
 
                 if (onHoverStart) onHoverStart(event)
@@ -104,7 +106,9 @@ export function useHoverGesture(
                 }
             }
 
-            const onPointerLeave = (event: MouseEvent | TouchEvent) => {
+            const onPointerLeave = (
+                event: MouseEvent | TouchEvent | PointerEvent
+            ) => {
                 if (isTouchEvent(event)) return
 
                 if (onHoverEnd) onHoverEnd(event)

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -101,7 +101,7 @@ export interface TapHandlers {
      * @param event - The originating pointer event.
      * @param info - An {@link TapInfo} object containing `x` and `y` values for the `point` relative to the device or page.
      */
-    onTap?(event: MouseEvent | TouchEvent, info: TapInfo): void
+    onTap?(event: MouseEvent | TouchEvent | PointerEvent, info: TapInfo): void
 
     /**
      * Callback when the tap gesture starts on this element.
@@ -129,7 +129,10 @@ export interface TapHandlers {
      * @param event - The originating pointer event.
      * @param info - An {@link TapInfo} object containing `x` and `y` values for the `point` relative to the device or page.
      */
-    onTapStart?(event: MouseEvent | TouchEvent, info: TapInfo): void
+    onTapStart?(
+        event: MouseEvent | TouchEvent | PointerEvent,
+        info: TapInfo
+    ): void
 
     /**
      * Callback when the tap gesture ends outside this element.
@@ -157,7 +160,10 @@ export interface TapHandlers {
      * @param event - The originating pointer event.
      * @param info - An {@link TapInfo} object containing `x` and `y` values for the `point` relative to the device or page.
      */
-    onTapCancel?(event: MouseEvent | TouchEvent, info: TapInfo): void
+    onTapCancel?(
+        event: MouseEvent | TouchEvent | PointerEvent,
+        info: TapInfo
+    ): void
 
     /**
      * Properties or variant label to animate to while the component is pressed.
@@ -243,7 +249,7 @@ export function useTapGesture(
             }
 
             const onPointerUp = (
-                event: MouseEvent | TouchEvent,
+                event: MouseEvent | TouchEvent | PointerEvent,
                 { point }: EventInfo
             ) => {
                 stopPointerUp()
@@ -283,7 +289,7 @@ export function useTapGesture(
             }
 
             const onPointerDown = (
-                event: MouseEvent | TouchEvent,
+                event: MouseEvent | TouchEvent | PointerEvent,
                 { point }: EventInfo
             ) => {
                 startPointerUp()

--- a/src/gestures/utils/event-type.ts
+++ b/src/gestures/utils/event-type.ts
@@ -2,7 +2,7 @@ export function isMouseEvent(
     event: MouseEvent | TouchEvent | PointerEvent
 ): event is MouseEvent {
     // PointerEvent inherits from MouseEvent so we can't use a straight instanceof check.
-    if (event instanceof PointerEvent) {
+    if (typeof PointerEvent !== "undefined" && event instanceof PointerEvent) {
         return !!(event.pointerType === "mouse")
     }
 

--- a/src/gestures/utils/event-type.ts
+++ b/src/gestures/utils/event-type.ts
@@ -1,0 +1,17 @@
+export function isMouseEvent(
+    event: MouseEvent | TouchEvent | PointerEvent
+): event is MouseEvent {
+    // PointerEvent inherits from MouseEvent so we can't use a straight instanceof check.
+    if (event instanceof PointerEvent) {
+        return !!(event.pointerType === "mouse")
+    }
+
+    return event instanceof MouseEvent
+}
+
+export function isTouchEvent(
+    event: MouseEvent | TouchEvent | PointerEvent
+): event is TouchEvent {
+    const hasTouches = !!(event as TouchEvent).touches
+    return hasTouches
+}

--- a/src/gestures/utils/is-touch-event.ts
+++ b/src/gestures/utils/is-touch-event.ts
@@ -1,6 +1,0 @@
-export function isTouchEvent(
-    event: MouseEvent | TouchEvent
-): event is TouchEvent {
-    const hasTouches = !!(event as TouchEvent).touches
-    return hasTouches
-}


### PR DESCRIPTION
`PointerEvent` inherits from `MouseEvent` so we need to check `event.pointerType` to determine whether it actually is a mouse event or not.