### PR TITLE
Fixing positionTransition on components within AnimatePresence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+-   `positionTransition` on exiting components within `AnimatePresence`.
+
 ## [1.4.1] 2019-07-30
 
 ### Fixed

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -21,9 +21,7 @@ interface PresenceChildProps {
 const PresenceChild = ({ children, exitProps }: PresenceChildProps) => {
     let context = useContext(MotionContext)
 
-    if (exitProps) {
-        context = { ...context, exitProps }
-    }
+    context = exitProps ? { ...context, exitProps } : { ...context }
 
     return (
         <MotionContext.Provider value={context}>

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -21,6 +21,8 @@ interface PresenceChildProps {
 const PresenceChild = ({ children, exitProps }: PresenceChildProps) => {
     let context = useContext(MotionContext)
 
+    // Create a new `value` in all instances to ensure `motion` children re-render
+    // and detect any layout changes that might have occurred.
     context = exitProps ? { ...context, exitProps } : { ...context }
 
     return (


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/257

## Context

`positionTransition` animates changes that happen as a result of a re-render.

In a previous implementation, `AnimatePresence` would `clone` every child, which would force them to re-render. If they were changing position because another item within `AnimatePresence` had been removed, this would allow them to detect that via `positionTransition`.

In a recent PR, I changed this implementation to instead wrap `AnimatePresence` children each in a context. The value of this context would only change if the child was exiting the tree, so all other components wouldn't re-render as a result. This meant that these components, if set to `positionTransition` wouldn't be able to detect this layout-changing render.