### PR TITLE
Support dynamic custom props

### DIFF
--- a/src/animation/use-variants.ts
+++ b/src/animation/use-variants.ts
@@ -25,7 +25,8 @@ export function useVariants(
     initial: VariantLabels,
     animate: VariantLabels,
     inherit: boolean,
-    controls: ValueAnimationControls
+    controls: ValueAnimationControls,
+    custom: any
 ) {
     let targetVariants = resolveVariantLabels(animate)
     const context = useContext(MotionContext)
@@ -51,5 +52,5 @@ export function useVariants(
         shouldAnimate && controls.start(targetVariants)
 
         hasMounted.current = true
-    }, asDependencyList(targetVariants))
+    }, asDependencyList(targetVariants, custom))
 }

--- a/src/animation/utils/variant-resolvers.ts
+++ b/src/animation/utils/variant-resolvers.ts
@@ -28,6 +28,7 @@ export const resolveVariantLabels = (
  * When values in this array change, React re-runs the dependency. However if the array
  * contains a variable number of items, React throws an error.
  */
-export const asDependencyList = (list: VariantNameList): string[] => [
-    list.join(","),
-]
+export const asDependencyList = (
+    list: VariantNameList,
+    custom: any
+): [string, any] => [list.join(","), custom]

--- a/src/motion/functionality/animation.ts
+++ b/src/motion/functionality/animation.ts
@@ -17,6 +17,7 @@ interface AnimationFunctionalProps {
     controls: ValueAnimationControls
     values: MotionValuesMap
     inherit: boolean
+    custom?: any
 }
 
 export const AnimatePropComponents = {
@@ -41,12 +42,14 @@ export const AnimatePropComponents = {
             inherit = true,
             controls,
             initial,
+            custom,
         }: AnimationFunctionalProps) => {
             return useVariants(
                 initial as VariantLabels,
                 animate as VariantLabels,
                 inherit,
-                controls
+                controls,
+                custom
             )
         }
     ),

--- a/src/motion/functionality/dom.tsx
+++ b/src/motion/functionality/dom.tsx
@@ -102,6 +102,7 @@ export function createDomMotionConfig<P = MotionProps>(
                         variants={props.variants}
                         transition={props.transition}
                         controls={controls}
+                        custom={props.custom}
                         inherit={inherit}
                         values={values}
                     />


### PR DESCRIPTION
This PR is an example implementation that would add the feature described in #262 . 

**Pros**

By supporting dynamic `custom` props, users can leverage the declarative component API to perform animations based on "states" (like open/closed) **as well as** arbitrary values (using `custom`) at the same time.

**Cons**

Consumers passing non-primitives as `custom` would be required to `useMemo` them to prevent unnecessary calls to `controls.start()`, which could cause performance issues.

**Improvements that could be made to this PR**

Ideally, `custom` should only be considered as a dependency if one of the variants is defined as a function. Otherwise, it should be ignored. This would mitigate, but not completely resolve, the con described above.

---

Here are some CodeSandboxes showing why this might be useful.

1. [Using AnimationControls using the existing API](https://codesandbox.io/s/framer-motion-imperative-2-bdxo5)
Question: is it bad that you have to call `controls.start` twice in this example, or is that fine?

2. [Using two components to do this declaratively using the existing API](https://codesandbox.io/s/framer-motion-two-components-9exvt)
obviously not great; just including it here as another example

3. [The solution using the code from this PR](https://codesandbox.io/s/framer-motion-pr-solution-rkj7p)
With the code in this PR you can accomplish this using one component.