### PR TITLE
Fixing value-specific delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.5] 2019-08-27
+
+## Fix
+
+-   Value-specific `delay`.
+
 ## [1.6.4] 2019-08-27
 
 ## Upgrade

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -72,7 +72,7 @@ const getTransitionDefinition = (
     to: ValueTarget,
     transitionDefinition?: Transition
 ): PopmotionTransitionProps => {
-    let delay = transitionDefinition ? transitionDefinition.delay : 0
+    const delay = transitionDefinition ? transitionDefinition.delay : 0
 
     // If no object, return default transition
     // A better way to handle this would be to deconstruct out all the shared Orchestration props
@@ -94,8 +94,9 @@ const getTransitionDefinition = (
 
     if (valueTransitionDefinition.type === false) {
         return {
-            delay,
-            ...(valueTransitionDefinition as any),
+            delay: valueTransitionDefinition.hasOwnProperty("delay")
+                ? valueTransitionDefinition.delay
+                : delay,
             to: isKeyframesTarget(to)
                 ? (to[to.length - 1] as string | number)
                 : to,

--- a/src/motion/__tests__/delay.test.tsx
+++ b/src/motion/__tests__/delay.test.tsx
@@ -24,6 +24,44 @@ describe("delay attr", () => {
 
         return expect(promise).resolves.toBe(0)
     })
+    test("value-specific delay on instant transition", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const Component = () => (
+                <motion.div
+                    animate={{ x: 10 }}
+                    transition={{ x: { delay: 1, type: false } }}
+                    style={{ x }}
+                />
+            )
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+
+        return expect(promise).resolves.toBe(0)
+    })
+    test("value-specific delay on animation", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const Component = () => (
+                <motion.div
+                    animate={{ x: 10 }}
+                    transition={{ x: { delay: 1 } }}
+                    style={{ x }}
+                />
+            )
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+
+        return expect(promise).resolves.toBe(0)
+    })
     test("in animate.transition", async () => {
         const promise = new Promise(resolve => {
             const x = motionValue(0)


### PR DESCRIPTION
Delays can be defined either on the base `transition`

```jsx
{ delay: 1 }
```

Or value-specific

```jsx
{ x: { delay: 1 } }
```

At some point the value-specific `delay` broke. This PR fixes it by returning the animation factory function and the animation options separately (rather than pre-bound) so we can overwrite any default `delay` with the value-specific one.