### PR TITLE
Restoring default React behaviour for style tag when component isStatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.7] 2019-08-30
+
+## Fix
+
+-   Restoring React-style behaviour for transform `style` properties when a component `isStatic`.
+
 ## [1.6.6] 2019-08-29
 
 ## Fix

--- a/src/motion/__tests__/static-prop.test.tsx
+++ b/src/motion/__tests__/static-prop.test.tsx
@@ -37,6 +37,22 @@ describe("static prop", () => {
         )
     })
 
+    test("it removes unused styles", () => {
+        const { container, rerender } = render(
+            <motion.div static style={{ z: 100 }} />
+        )
+
+        expect(container.firstChild as Element).toHaveStyle(
+            "transform: translateZ(100px)"
+        )
+
+        rerender(<motion.div static style={{}} />)
+
+        expect(container.firstChild as Element).not.toHaveStyle(
+            "transform: translateZ(100px)"
+        )
+    })
+
     test("it doesn't respond to updates in `initial`", () => {
         const { container, rerender } = render(
             <motion.div initial={{ x: 100 }} />

--- a/src/motion/__tests__/style-prop.test.tsx
+++ b/src/motion/__tests__/style-prop.test.tsx
@@ -1,0 +1,22 @@
+import "../../../jest.setup"
+import { render } from "@testing-library/react"
+import { motion } from ".."
+import * as React from "react"
+
+describe("style prop", () => {
+    test("should remove non-set styles", () => {
+        const { container, rerender } = render(
+            <motion.div static style={{ position: "absolute" }} />
+        )
+
+        expect(container.firstChild as Element).toHaveStyle(
+            "position: absolute"
+        )
+
+        rerender(<motion.div static style={{}} />)
+
+        expect(container.firstChild as Element).not.toHaveStyle(
+            "position: absolute"
+        )
+    })
+})

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -53,6 +53,7 @@ export const createMotionComponent = <P extends {}>({
         const style = useMotionStyles(
             values,
             props.style,
+            isStatic,
             props.transformValues
         )
         const shouldInheritVariant = checkShouldInheritVariant(props)

--- a/src/motion/utils/use-styles.ts
+++ b/src/motion/utils/use-styles.ts
@@ -3,7 +3,7 @@ import { buildStyleProperty, isTransformProp } from "stylefire"
 import { resolveCurrent } from "../../value/utils/resolve-values"
 import { MotionValuesMap } from "./use-motion-values"
 import { MotionValue, motionValue } from "../../value"
-import { MotionStyle, CustomStyles } from "../types"
+import { MotionStyle } from "../types"
 import { isMotionValue } from "../../value/utils/is-motion-value"
 
 const transformOriginProps = new Set(["originX", "originY", "originZ"])
@@ -34,12 +34,10 @@ export const useMotionStyles = <V extends {} = {}>(
     isStatic: boolean,
     transformValues?: (values: V) => V
 ): CSSProperties => {
-    const style = useRef<CSSProperties & CustomStyles>({}).current
+    const style = {}
     const prevMotionStyles = useRef({}).current
-    const currentStyleKeys = new Set(Object.keys(style))
 
     for (const key in styleProp) {
-        currentStyleKeys.delete(key)
         const thisStyle = styleProp[key]
 
         if (isMotionValue(thisStyle)) {
@@ -72,8 +70,6 @@ export const useMotionStyles = <V extends {} = {}>(
             style[key] = thisStyle
         }
     }
-
-    currentStyleKeys.forEach(key => delete style[key])
 
     return transformValues ? transformValues(style as any) : style
 }

--- a/src/motion/utils/use-styles.ts
+++ b/src/motion/utils/use-styles.ts
@@ -25,15 +25,13 @@ export const buildStyleAttr = (
             : transformTemplate
     }
 
-    return {
-        ...styleProp,
-        ...buildStyleProperty(motionValueStyles, !isStatic),
-    }
+    return buildStyleProperty({ ...styleProp, ...motionValueStyles }, !isStatic)
 }
 
 export const useMotionStyles = <V extends {} = {}>(
     values: MotionValuesMap,
     styleProp: MotionStyle = {},
+    isStatic: boolean,
     transformValues?: (values: V) => V
 ): CSSProperties => {
     const style = useRef<CSSProperties & CustomStyles>({}).current
@@ -47,9 +45,17 @@ export const useMotionStyles = <V extends {} = {}>(
         if (isMotionValue(thisStyle)) {
             // If this is a motion value, add it to our MotionValuesMap
             values.set(key, thisStyle)
-        } else if (isTransformProp(key) || isTransformOriginProp(key)) {
+        } else if (
+            !isStatic &&
+            (isTransformProp(key) || isTransformOriginProp(key))
+        ) {
             // Or if it's a transform prop, create a motion value (or update an existing one)
             // to ensure Stylefire can reconcile all the transform values together.
+            // A further iteration on this would be to create a single styler per component that gets
+            // used in the DOM renderer's buildStyleAttr *and* animations, then we would only
+            // have to convert animating values to `MotionValues` (we could probably remove this entire function).
+            // The only architectural consideration is to allow Stylefire to have elements mounted after
+            // a styler is created.
             if (!values.has(key)) {
                 // If it doesn't exist as a motion value, create it
                 values.set(key, motionValue(thisStyle))


### PR DESCRIPTION
When a component `isStatic`, we now won't automatically create a `MotionValue` for `transform` and `transformOrigin` props. 