### PR TITLE
Adding type support for motion.custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.9] 2019-09-18
+
+## Fix
+
+-   Allow `motion.custom` to accept custom prop types.
+
 ## [1.6.8] 2019-08-30
 
 ## Fix

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -376,7 +376,7 @@ export const motion: {
     menuitem: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<HTMLAttributes<HTMLElement>, HTMLElement> & MotionProps & RefAttributes<HTMLElement>>;
     keygen: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<import("react").KeygenHTMLAttributes<HTMLElement>, HTMLElement> & MotionProps & RefAttributes<HTMLElement>>;
     webview: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<import("react").WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> & MotionProps & RefAttributes<HTMLWebViewElement>>;
-    custom: typeof custom;
+    custom: <Props>(Component: ComponentType<Props>) => ForwardRefExoticComponent<PropsWithoutRef<Props & MotionProps> & RefAttributes<Element>>;
 };
 
 // @public (undocumented)
@@ -731,10 +731,6 @@ export type Variants = {
     [key: string]: Variant;
 };
 
-
-// Warnings were encountered during analysis:
-// 
-// types/motion/index.d.ts:217:5 - (ae-forgotten-export) The symbol "custom" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -11,6 +11,7 @@ import { Easing as Easing_2 } from '@popmotion/easing';
 import { ForwardRefExoticComponent } from 'react';
 import { FunctionComponent } from 'react';
 import { HTMLAttributes } from 'react';
+import { PropsWithoutRef } from 'react';
 import * as React from 'react';
 import { ReactElement } from 'react';
 import { ReactHTML } from 'react';
@@ -375,7 +376,7 @@ export const motion: {
     menuitem: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<HTMLAttributes<HTMLElement>, HTMLElement> & MotionProps & RefAttributes<HTMLElement>>;
     keygen: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<import("react").KeygenHTMLAttributes<HTMLElement>, HTMLElement> & MotionProps & RefAttributes<HTMLElement>>;
     webview: ForwardRefExoticComponent<HTMLAttributesWithoutMotionProps<import("react").WebViewHTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> & MotionProps & RefAttributes<HTMLWebViewElement>>;
-    custom: (Component: ComponentType<any>) => ForwardRefExoticComponent<MotionProps & RefAttributes<Element>>;
+    custom: typeof custom;
 };
 
 // @public (undocumented)
@@ -730,6 +731,10 @@ export type Variants = {
     [key: string]: Variant;
 };
 
+
+// Warnings were encountered during analysis:
+// 
+// types/motion/index.d.ts:217:5 - (ae-forgotten-export) The symbol "custom" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -1,0 +1,25 @@
+import "../../../jest.setup"
+import { render } from "@testing-library/react"
+import { motion } from ".."
+import * as React from "react"
+import { RefObject } from "react"
+
+interface Props {
+    foo: boolean
+}
+
+describe("motion.custom", () => {
+    test("accepts custom types", () => {
+        const BaseComponent = React.forwardRef(
+            (_props: Props, ref: RefObject<HTMLDivElement>) => {
+                return <div ref={ref} />
+            }
+        )
+
+        const MotionComponent = motion.custom<Props>(BaseComponent)
+
+        const Component = () => <MotionComponent foo />
+
+        render(<Component />)
+    })
+})

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -43,6 +43,23 @@ export const svgMotionComponents: SVGMotionComponents = svgElements.reduce(
 )
 
 /**
+ * Convert a custom React component into a `motion` component.
+ *
+ * ```jsx
+ * const Component = React.forwardRef((props: Props, ref) => {
+ *   return <div ref={ref} />
+ * })
+ *
+ * const MotionComponent = motion.custom<Props>(Component)
+ * ```
+ *
+ * @param Component
+ */
+function custom<Props>(Component: ComponentType<Props>) {
+    return createMotionComponent<Props>(createDomMotionConfig(Component))
+}
+
+/**
  * HTML & SVG components, optimised for use with gestures and animation. These can be used as
  * drop-in replacements for any HTML & SVG component, all CSS & SVG properties are supported.
  *
@@ -62,9 +79,7 @@ export const svgMotionComponents: SVGMotionComponents = svgElements.reduce(
  * @public
  */
 export const motion = {
-    custom: (Component: ComponentType<any>) => {
-        return createMotionComponent(createDomMotionConfig(Component))
-    },
+    custom,
     ...htmlMotionComponents,
     ...svgMotionComponents,
 }

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -43,23 +43,6 @@ export const svgMotionComponents: SVGMotionComponents = svgElements.reduce(
 )
 
 /**
- * Convert a custom React component into a `motion` component.
- *
- * ```jsx
- * const Component = React.forwardRef((props: Props, ref) => {
- *   return <div ref={ref} />
- * })
- *
- * const MotionComponent = motion.custom<Props>(Component)
- * ```
- *
- * @param Component
- */
-function custom<Props>(Component: ComponentType<Props>) {
-    return createMotionComponent<Props>(createDomMotionConfig(Component))
-}
-
-/**
  * HTML & SVG components, optimised for use with gestures and animation. These can be used as
  * drop-in replacements for any HTML & SVG component, all CSS & SVG properties are supported.
  *
@@ -79,7 +62,22 @@ function custom<Props>(Component: ComponentType<Props>) {
  * @public
  */
 export const motion = {
-    custom,
+    /**
+     * Convert a custom React component into a `motion` component.
+     *
+     * ```jsx
+     * const Component = React.forwardRef((props: Props, ref) => {
+     *   return <div ref={ref} />
+     * })
+     *
+     * const MotionComponent = motion.custom<Props>(Component)
+     * ```
+     *
+     * @param Component
+     */
+    custom: function custom<Props>(Component: ComponentType<Props>) {
+        return createMotionComponent<Props>(createDomMotionConfig(Component))
+    },
     ...htmlMotionComponents,
     ...svgMotionComponents,
 }


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/290

Allows the ability to extend `MotionProps` with custom component props when using `motion.custom`.

```
motion.custom<Props>(Component)
```