### PR TITLE
Support clicks within draggable elements on iOS Safari

### DIFF
--- a/dev/examples/dragClickable.tsx
+++ b/dev/examples/dragClickable.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+import { motion } from "@framer"
+
+const style = {
+    display: "inline-block",
+    padding: 20,
+    background: "#eee",
+}
+
+export const App = () => {
+    function onClick() {
+        alert("click")
+    }
+
+    return (
+        <motion.div drag style={style}>
+            <p>Drag me</p>
+            <button onClick={onClick}>Click me</button>
+        </motion.div>
+    )
+}

--- a/src/behaviours/use-drag.ts
+++ b/src/behaviours/use-drag.ts
@@ -20,7 +20,7 @@ import {
 import { useMotionValue } from "../value/use-motion-value"
 import { DraggableProps, DragHandlers } from "./types"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
-import { supportsTouchEvents } from "../events/use-pointer-event"
+import { supportsTouchEvents } from "../events/utils"
 
 type DragDirection = "x" | "y"
 
@@ -388,6 +388,8 @@ export function useDrag(
             event.target &&
             !allowDefaultPointerDown.has((event.target as Element).tagName)
         ) {
+            // On iOS it's important to not `preventDefault` the `touchstart`
+            // event, as otherwise clicks won't fire inside the draggable element.
             if (!supportsTouchEvents()) {
                 // Prevent browser-specific behaviours like text selection or Chrome's image dragging.
                 event.preventDefault()

--- a/src/behaviours/use-drag.ts
+++ b/src/behaviours/use-drag.ts
@@ -20,6 +20,7 @@ import {
 import { useMotionValue } from "../value/use-motion-value"
 import { DraggableProps, DragHandlers } from "./types"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
+import { supportsTouchEvents } from "../events/use-pointer-event"
 
 type DragDirection = "x" | "y"
 
@@ -383,15 +384,18 @@ export function useDrag(
     }
 
     function onPanSessionStart(event: MouseEvent | TouchEvent | PointerEvent) {
-        // Prevent browser-specific behaviours like text selection or Chrome's image dragging.
         if (
             event.target &&
             !allowDefaultPointerDown.has((event.target as Element).tagName)
         ) {
-            event.preventDefault()
-            // Make sure input elements loose focus when we prevent the default.
-            if (document.activeElement instanceof HTMLElement) {
-                document.activeElement.blur()
+            if (!supportsTouchEvents()) {
+                // Prevent browser-specific behaviours like text selection or Chrome's image dragging.
+                event.preventDefault()
+
+                // Make sure input elements loose focus when we prevent the default.
+                if (document.activeElement instanceof HTMLElement) {
+                    document.activeElement.blur()
+                }
             }
         }
 

--- a/src/behaviours/utils/block-viewport-scroll.ts
+++ b/src/behaviours/utils/block-viewport-scroll.ts
@@ -2,7 +2,7 @@ let isViewportScrollBlocked = false
 const isBrowser = typeof window !== "undefined"
 
 if (isBrowser) {
-    window.addEventListener(
+    document.addEventListener(
         "touchmove",
         (event: TouchEvent) => {
             if (isViewportScrollBlocked) {

--- a/src/events/use-pointer-event.ts
+++ b/src/events/use-pointer-event.ts
@@ -1,13 +1,11 @@
 import { RefObject } from "react"
 import { useDomEvent, addDomEvent } from "./use-dom-event"
 import { wrapHandler, EventListenerWithPointInfo } from "./event-info"
-
-// We check for event support via functions in case they've been mocked by a testing suite.
-const isBrowser = typeof window !== "undefined"
-const supportsPointerEvents = () => isBrowser && window.onpointerdown === null
-export const supportsTouchEvents = () =>
-    isBrowser && window.ontouchstart === null
-const supportsMouseEvents = () => isBrowser && window.onmousedown === null
+import {
+    supportsPointerEvents,
+    supportsTouchEvents,
+    supportsMouseEvents,
+} from "./utils"
 
 interface PointerNameMap {
     pointerdown: string

--- a/src/events/use-pointer-event.ts
+++ b/src/events/use-pointer-event.ts
@@ -5,7 +5,8 @@ import { wrapHandler, EventListenerWithPointInfo } from "./event-info"
 // We check for event support via functions in case they've been mocked by a testing suite.
 const isBrowser = typeof window !== "undefined"
 const supportsPointerEvents = () => isBrowser && window.onpointerdown === null
-const supportsTouchEvents = () => isBrowser && window.ontouchstart === null
+export const supportsTouchEvents = () =>
+    isBrowser && window.ontouchstart === null
 const supportsMouseEvents = () => isBrowser && window.onmousedown === null
 
 interface PointerNameMap {

--- a/src/events/utils.ts
+++ b/src/events/utils.ts
@@ -1,0 +1,9 @@
+const isBrowser = typeof window !== "undefined"
+
+// We check for event support via functions in case they've been mocked by a testing suite.
+export const supportsPointerEvents = () =>
+    isBrowser && window.onpointerdown === null
+export const supportsTouchEvents = () =>
+    isBrowser && window.ontouchstart === null
+export const supportsMouseEvents = () =>
+    isBrowser && window.onmousedown === null


### PR DESCRIPTION
Fixes #322 .

I found out that when you don't `preventDefault` the `touchstart` event, Safari will try to scroll the window. I found your `blockViewportScroll` utility, but it didn't seem to work. Apparently you need to register the event handler on `document` instead of `window`. Now it works properly in my simulator. Not sure if there's a case for also handling events from `window`?

For the check if the device supports touch events, I used the existing function in `use-pointer-event`. Is that ok?