### PR TITLE
Fixing clipPath in webkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.9] Unreleased
+
+## Fix
+
+-   Upgrade `stylefire@6.0.11` to fix `clipPath` in Webkit.
+
 ## [1.6.8] 2019-08-30
 
 ## Fix

--- a/yarn.lock
+++ b/yarn.lock
@@ -8392,9 +8392,9 @@ styled-components@^4.1.1:
     supports-color "^5.5.0"
 
 stylefire@^6.0.10:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.10.tgz#1100c63cf01b922f0db92e38a46297f3f1c2663d"
-  integrity sha512-SAJnUk4L9EKt/WSliztk1iZCzcNOJDR69xO8gblRjQwjybgMWONsY7KpcMBt65xU1UZaiyPDK5CoLf9wXLJldQ==
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.11.tgz#28112a91f880e8dd9844456fbae7630880c2e83a"
+  integrity sha512-KR5BPENxMWo+fgeuCXvME8Xym80w4ztLUizNm5npfi24rf2WQis09Z6jP9RfG72H3shft3AmHKroHrNbsAFfZQ==
   dependencies:
     "@popmotion/popcorn" "^0.4.2"
     framesync "^4.0.0"


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/319

Webkit incorrectly detects `element.style.clipPath` as supported, when it isn't. So an update to `stylefire` ensures the un-prefixed version doesn't take precedence.