### PR TITLE
Add failing test case for nested components inside StrictMode

### DIFF
--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -312,16 +312,14 @@ describe("motion component rendering and styles", () => {
                 <React.StrictMode>
                     <motion.div
                         animate="visible"
-                        exit="hidden"
                         initial="hidden"
                         variants={{
                             visible: { y: 0 },
                             hidden: { y: 5 },
                         }}
                     >
-                        <motion.div
+                        <motion.span
                             animate={useAnimation()}
-                            exit="hidden"
                             initial="hidden"
                             variants={{
                                 visible: { y: 0 },

--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -1,6 +1,7 @@
 import "../../../jest.setup"
 import { render, fireEvent } from "@testing-library/react"
 import { motion } from "../"
+import { useAnimation } from "../../animation/use-animation"
 import * as React from "react"
 import styled from "styled-components"
 
@@ -303,5 +304,36 @@ describe("motion component rendering and styles", () => {
     it("filters MotionProps from the DOM", () => {
         const { container } = render(<motion.div initial={{ opacity: 0 }} />)
         expect(container.firstChild).not.toHaveAttribute("initial")
+    })
+
+    fit("it can render nested components inside <StrictMode />", () => {
+        function Test() {
+            return (
+                <React.StrictMode>
+                    <motion.div
+                        animate="visible"
+                        exit="hidden"
+                        initial="hidden"
+                        variants={{
+                            visible: { y: 0 },
+                            hidden: { y: 5 },
+                        }}
+                    >
+                        <motion.div
+                            animate={useAnimation()}
+                            exit="hidden"
+                            initial="hidden"
+                            variants={{
+                                visible: { y: 0 },
+                                hidden: { y: 5 },
+                            }}
+                        />
+                    </motion.div>
+                </React.StrictMode>
+            )
+        }
+
+        const { container } = render(<Test />)
+        expect(container.firstChild).toBeTruthy()
     })
 })


### PR DESCRIPTION
I encountered an error in an app that I'm working on and isolated it to the test case in this PR.

When you run the test, you get this error:

```
Uncaught Error: No valid node provided. Node must be HTMLElement, SVGElement or window.
    at Object.exports.invariant (index.js:15)
    at createDOMStyler (index.js:536)
    at getStyler (index.js:541)
    at index (index.js:547)
    at checkAndConvertChangedValueTypes (framer-motion.cjs.js:3198)
    at unitConversion (framer-motion.cjs.js:3295)
    at ValueAnimationControls.eval [as makeTargetAnimatable] (framer-motion.cjs.js:3304)
    at ValueAnimationControls.animate (framer-motion.cjs.js:1269)
    at getAnimations (framer-motion.cjs.js:1313)
    at ValueAnimationControls.animateVariant (framer-motion.cjs.js:1337)
    at eval (framer-motion.cjs.js:1354)
    at Array.forEach (<anonymous>)
    at ValueAnimationControls.animateChildren (framer-motion.cjs.js:1353)
    at getChildrenAnimations (framer-motion.cjs.js:1317)
    at ValueAnimationControls.animateVariant (framer-motion.cjs.js:1337)
    at eval (framer-motion.cjs.js:1301)
    at Array.map (<anonymous>)
    at ValueAnimationControls.animateVariantLabels (framer-motion.cjs.js:1301)
    at ValueAnimationControls.start (framer-motion.cjs.js:1243)
    at eval (framer-motion.cjs.js:3785)
```

You can work around the error by:
1. Removing `StrictMode`.
2. Changing `animate={useAnimation()}` to `animate="visible"`.
3. Animating `opacity` instead of `y` in the inner component.

The stack trace goes into `stylefire`. I thought maybe you have an idea where the bug could originate from?

Maybe there's an [unexpected side effect](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects)? If so, it could be helpful to fix this in order to work with the upcoming concurrent mode of React.