### PR TITLE
Fixing cancelling exit animations on AnimatePresence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ### Fix
 
 -   Exit variant propagation.
+-   Cancelling exit animations.
 
 ## [1.6.8] 2019-10-02
 

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -24,7 +24,7 @@ const PresenceChild = ({ children, exitProps }: PresenceChildProps) => {
 
     // Create a new `value` in all instances to ensure `motion` children re-render
     // and detect any layout changes that might have occurred.
-    context = exitProps ? { ...context, exitProps } : { ...context }
+    context = { ...context, exitProps: exitProps || {} }
 
     return (
         <MotionContext.Provider value={context}>

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -24,7 +24,9 @@ describe("ssr", () => {
             <AnimatePresence>
                 <motion.div
                     initial={{ x: 100 }}
+                    animate={{ x: 50 }}
                     style={{ y }}
+                    exit={{ x: 0 }}
                     positionTransition
                 />
             </AnimatePresence>

--- a/src/motion/functionality/animation.ts
+++ b/src/motion/functionality/animation.ts
@@ -1,6 +1,6 @@
 import { ComponentType } from "react"
 import { MotionProps, AnimatePropType, VariantLabels } from "../types"
-import { makeHookComponent } from "../utils/make-hook-component"
+import { makeRenderlessComponent } from "../utils/make-renderless-component"
 import { useAnimateProp } from "../../animation/use-animate-prop"
 import { useVariants } from "../../animation/use-variants"
 import { useAnimationGroupSubscription } from "../../animation/use-animation-group-subscription"
@@ -20,7 +20,7 @@ interface AnimationFunctionalProps {
 }
 
 export const AnimatePropComponents = {
-    [AnimatePropType.Target]: makeHookComponent<AnimationFunctionalProps>(
+    [AnimatePropType.Target]: makeRenderlessComponent<AnimationFunctionalProps>(
         ({
             animate,
             controls,
@@ -35,7 +35,9 @@ export const AnimatePropComponents = {
             )
         }
     ),
-    [AnimatePropType.VariantLabel]: makeHookComponent<AnimationFunctionalProps>(
+    [AnimatePropType.VariantLabel]: makeRenderlessComponent<
+        AnimationFunctionalProps
+    >(
         ({
             animate,
             inherit = true,
@@ -50,7 +52,7 @@ export const AnimatePropComponents = {
             )
         }
     ),
-    [AnimatePropType.AnimationSubscription]: makeHookComponent<
+    [AnimatePropType.AnimationSubscription]: makeRenderlessComponent<
         AnimationFunctionalProps
     >(({ animate, controls }: AnimationFunctionalProps) => {
         return useAnimationGroupSubscription(

--- a/src/motion/functionality/drag.ts
+++ b/src/motion/functionality/drag.ts
@@ -1,12 +1,12 @@
 import { MotionProps } from "../types"
 import { useDrag } from "../../behaviours/use-drag"
-import { makeHookComponent } from "../utils/make-hook-component"
+import { makeRenderlessComponent } from "../utils/make-renderless-component"
 import { FunctionalProps, FunctionalComponentDefinition } from "./types"
 
 export const Drag: FunctionalComponentDefinition = {
     key: "drag",
     shouldRender: (props: MotionProps) => !!props.drag,
-    Component: makeHookComponent(
+    Component: makeRenderlessComponent(
         ({ innerRef, values, controls, ...props }: FunctionalProps) => {
             return useDrag(props, innerRef, values, controls)
         }

--- a/src/motion/functionality/gestures.ts
+++ b/src/motion/functionality/gestures.ts
@@ -1,7 +1,7 @@
 import { MotionProps } from "../types"
 import { useGestures } from "../../gestures"
 import { FunctionalProps, FunctionalComponentDefinition } from "./types"
-import { makeHookComponent } from "../utils/make-hook-component"
+import { makeRenderlessComponent } from "../utils/make-renderless-component"
 
 export const gestureProps = [
     "drag",
@@ -23,7 +23,9 @@ export const Gestures: FunctionalComponentDefinition = {
     shouldRender: (props: MotionProps) => {
         return gestureProps.some(key => props.hasOwnProperty(key))
     },
-    Component: makeHookComponent(({ innerRef, ...props }: FunctionalProps) => {
-        useGestures(props, innerRef)
-    }),
+    Component: makeRenderlessComponent(
+        ({ innerRef, ...props }: FunctionalProps) => {
+            useGestures(props, innerRef)
+        }
+    ),
 }

--- a/src/motion/functionality/layout.ts
+++ b/src/motion/functionality/layout.ts
@@ -1,7 +1,7 @@
 import { RefObject, useContext } from "react"
 import { invariant } from "hey-listen"
 import { MotionProps, AnimationProps, ResolveLayoutTransition } from "../types"
-import { makeHookComponent } from "../utils/make-hook-component"
+import { makeRenderlessComponent } from "../utils/make-renderless-component"
 import { FunctionalProps, FunctionalComponentDefinition } from "./types"
 import { ValueAnimationControls } from "../../animation/ValueAnimationControls"
 import { MotionValuesMap } from "../utils/use-motion-values"
@@ -271,7 +271,7 @@ export const Layout: FunctionalComponentDefinition = {
             !!(positionTransition || layoutTransition)
         )
     },
-    Component: makeHookComponent(
+    Component: makeRenderlessComponent(
         ({
             innerRef,
             controls,

--- a/src/motion/utils/make-hook-component.ts
+++ b/src/motion/utils/make-hook-component.ts
@@ -1,8 +1,0 @@
-import { FunctionalProps } from "../functionality/types"
-
-export const makeHookComponent = <P = FunctionalProps>(hook: Function) => (
-    props: P
-) => {
-    hook(props)
-    return null
-}

--- a/src/motion/utils/make-renderless-component.ts
+++ b/src/motion/utils/make-renderless-component.ts
@@ -1,0 +1,8 @@
+import { FunctionalProps } from "../functionality/types"
+
+export const makeRenderlessComponent = <P = FunctionalProps>(
+    hook: Function
+) => (props: P) => {
+    hook(props)
+    return null
+}


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/347

In a [previous PR](https://github.com/framer/motion/pull/303) we changed the way the `exit` prop was resolved by `motion` components. Previously, if a component was exiting the React tree, it'd internally overwrite the `animate` prop with the contents of `exit`. It was kind of a hack approach that brought its own problems. To fix these we started handling the `exit` prop explicitly.

However this introduced a bug where, if an exit animation was cancelled (by re-inserting a node before it finished animating out), it wouldn't animate back in. This is because the contents of `animate` were still the same. In this PR we add the capability for the exit functionality to detect when an exit animation was being cancelled and it manually starts the re-entry animation by calling `controls.start(props.animate)`.