### PR TITLE
Make x/y consistent across HTML and SVG attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.11] 2019-10-09
+
+### Fix
+
+-   Inconsistency in handling `x`/`y` between SVG and HTML. Now always a shorthand for `translateX` and `translateY`.
+
 ## [1.6.10] 2019-10-09
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/framer-motion" target="_blank">
-    <img src="https://img.shields.io/npm/v/framer-motion.svg?style=flat-squar" />
+    <img src="https://img.shields.io/npm/v/framer-motion.svg?style=flat-square" />
   </a>
   <a href="https://www.npmjs.com/package/framer-motion" target="_blank">
   <img src="https://img.shields.io/npm/dm/framer-motion.svg?style=flat-square" />

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "hey-listen": "^1.0.8",
         "popmotion": "9.0.0-beta-8",
         "style-value-types": "^3.1.6",
-        "stylefire": "^6.0.10",
+        "stylefire": "^7.0.0",
         "tslib": "^1.10.0"
     },
     "optionalDependencies": {

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -48,13 +48,12 @@ describe("ssr", () => {
                     background: "#fff",
                     pathLength,
                     x: 100,
-                    translateX: 100,
                 }}
             />
         )
 
         expect(circle).toBe(
-            '<circle cx="100" style="background:#fff;transform:translateX(100px);transform-origin:0px 0px" stroke-width="10" x="100"></circle>'
+            '<circle cx="100" style="background:#fff;transform:translateX(100px);transform-origin:0px 0px" stroke-width="10"></circle>'
         )
     })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8391,10 +8391,10 @@ styled-components@^4.1.1:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-stylefire@^6.0.10:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-6.0.11.tgz#28112a91f880e8dd9844456fbae7630880c2e83a"
-  integrity sha512-KR5BPENxMWo+fgeuCXvME8Xym80w4ztLUizNm5npfi24rf2WQis09Z6jP9RfG72H3shft3AmHKroHrNbsAFfZQ==
+stylefire@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/stylefire/-/stylefire-7.0.0.tgz#2ae16a97f41b8664f2501252ee40c19baba0ea22"
+  integrity sha512-Ea1knZTN5KmbUKSilTsjFEtHcGs+Vl+cQWNnvWQwqRVG+W6J/WgkWjo620hf4II/PTH8uSIF17vGrkpHC41nAA==
   dependencies:
     "@popmotion/popcorn" "^0.4.2"
     framesync "^4.0.0"


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/344

This PR upgrades `stylefire` to `7.0.0` which changed its behaviour to treat SVG `x` and `y` elements as `translateX` and `translateY` respectively: https://github.com/Popmotion/popmotion/pull/839/files#diff-1734860cf394ce48efe4992634e89d13L51

This means that it won't be possible to animate `x` and `y` SVG attributes but these only exist on a handful of elements which has been causing confusion and perceived bugs. We're going to keep an ear to the ground if this is functionality that people want but in the meantime we've decided to prefer animating transforms over layout. Given the number of bug reports and behaviour I've run into myself this is considered a bug rather than a breaking change.