### PR TITLE
Fixing external ref with single-child AnimatePresence

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-    "sandboxes": ["fz7cz", "7o4i4"]
+    "sandboxes": ["fz7cz"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-  "sandboxes": ["fz7cz"]
+    "sandboxes": ["fz7cz", "7o4i4"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.10] Unreleased
+
+### Fix
+
+-   Fixing the use of externally-provided `ref`s with single-child `AnimatePresence` components.
+
 ## [1.6.9] 2019-10-08
 
 ### Fix

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -674,7 +674,7 @@ export function useDomEvent(ref: RefObject<Element>, eventName: string, handler?
 // Warning: (ae-internal-missing-underscore) The name "useExternalRef" should be prefixed with an underscore because the declaration is marked as @internal
 // 
 // @internal
-export function useExternalRef<E = Element>(external?: Ref<E>): RefObject<E>;
+export function useExternalRef<E = Element>(internalRef: RefObject<E>, externalRef?: Ref<E>): void;
 
 // @public
 export function useGestures<GestureHandlers>(props: GestureHandlers, ref: RefObject<Element>): void;

--- a/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -333,6 +333,41 @@ describe("AnimatePresence", () => {
 
         return await expect(promise).resolves.toBe(0)
     })
+
+    test("Handles external refs on a single child", async () => {
+        const promise = new Promise(resolve => {
+            const ref = React.createRef<HTMLDivElement>()
+            const Component = ({ id }: { id: number }) => {
+                return (
+                    <AnimatePresence initial={false}>
+                        <motion.div
+                            data-id={id}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            key={id}
+                            ref={ref}
+                        />
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component id={0} />)
+            rerender(<Component id={0} />)
+
+            setTimeout(() => {
+                rerender(<Component id={1} />)
+                rerender(<Component id={1} />)
+                rerender(<Component id={2} />)
+                rerender(<Component id={2} />)
+
+                resolve(ref.current)
+            }, 30)
+        })
+
+        const result = await promise
+        return expect(result).toHaveAttribute("data-id", "2")
+    })
 })
 
 describe("AnimatePresence with custom components", () => {

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -1,11 +1,7 @@
 import * as React from "react"
-import { useContext, forwardRef, Ref, RefObject } from "react"
-import { useExternalRef } from "./utils/use-external-ref"
-import {
-    useMotionValues,
-    MountMotionValues,
-    MotionValuesMap,
-} from "./utils/use-motion-values"
+import { useContext, forwardRef, useRef, Ref, RefObject } from "react"
+import { useMotionValues, MotionValuesMap } from "./utils/use-motion-values"
+import { MountRef } from "./utils/MountRef"
 import { useMotionStyles } from "./utils/use-styles"
 import { useValueAnimationControls } from "../animation/use-value-animation-controls"
 import { MotionContext, useMotionContext } from "./context/MotionContext"
@@ -40,7 +36,7 @@ export const createMotionComponent = <P extends {}>({
         props: P & MotionProps,
         externalRef?: Ref<Element>
     ) {
-        const ref = useExternalRef(externalRef)
+        const ref = useRef(null)
         const parentContext = useContext(MotionContext)
 
         const isStatic = parentContext.static || props.static || false
@@ -92,8 +88,9 @@ export const createMotionComponent = <P extends {}>({
 
         return (
             <>
-                <MountMotionValues
+                <MountRef
                     ref={ref}
+                    externalRef={externalRef}
                     values={values}
                     isStatic={isStatic}
                 />

--- a/src/motion/utils/MountRef.tsx
+++ b/src/motion/utils/MountRef.tsx
@@ -1,0 +1,52 @@
+import { MotionValuesMap } from "./use-motion-values"
+import { syncRenderSession } from "../../dom/sync-render-session"
+import { useExternalRef } from "./use-external-ref"
+import { RefObject, Ref, useEffect, forwardRef, memo } from "react"
+import { invariant } from "hey-listen"
+import styler from "stylefire"
+
+/**
+ * `useEffect` gets resolved bottom-up. We defer some optional functionality to child
+ * components, so to ensure everything runs correctly we export the ref-binding logic
+ * to a new component rather than in `useMotionValues`.
+ */
+const MountRefComponent = (
+    {
+        values,
+        isStatic,
+        externalRef,
+    }: {
+        values: MotionValuesMap
+        isStatic: boolean
+        externalRef?: Ref<Element>
+    },
+    ref: RefObject<Element>
+) => {
+    useEffect(() => {
+        invariant(
+            ref.current instanceof Element,
+            "No `ref` found. Ensure components created with `motion.custom` forward refs using `React.forwardRef`"
+        )
+
+        const domStyler = styler(ref.current as Element, {
+            preparseOutput: false,
+            enableHardwareAcceleration: !isStatic,
+        })
+
+        values.mount((key, value) => {
+            domStyler.set(key, value)
+
+            if (syncRenderSession.isOpen()) {
+                syncRenderSession.push(domStyler)
+            }
+        })
+
+        return () => values.unmount()
+    }, [])
+
+    useExternalRef(ref, externalRef)
+
+    return null
+}
+
+export const MountRef = memo(forwardRef(MountRefComponent))

--- a/src/motion/utils/use-external-ref.ts
+++ b/src/motion/utils/use-external-ref.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, Ref, RefObject, MutableRefObject } from "react"
+import { useEffect, Ref, RefObject, MutableRefObject } from "react"
 import { isRefObject } from "../../utils/is-ref-object"
 
 /**
@@ -6,35 +6,34 @@ import { isRefObject } from "../../utils/is-ref-object"
  * @param external - External ref
  * @internal
  */
-export function useExternalRef<E = Element>(external?: Ref<E>): RefObject<E> {
-    const ref = useRef<E>(null)
-
+export function useExternalRef<E = Element>(
+    internalRef: RefObject<E>,
+    externalRef?: Ref<E>
+): void {
     useEffect(() => {
         // If there's no external ref, we don't need to handle it in a special way
-        if (!external) return
+        if (!externalRef) return
 
-        if (typeof external === "function") {
-            external(ref.current)
+        if (typeof externalRef === "function") {
+            externalRef(internalRef.current)
 
-            return () => external(null)
-        } else if (isRefObject(external)) {
-            const mutableExternal = external as MutableRefObject<E | null>
+            return () => externalRef(null)
+        } else if (isRefObject(externalRef)) {
+            const mutableExternal = externalRef as MutableRefObject<E | null>
 
             // If we've been provided a RefObject, we need to assign its current with our
             // current on mount
-            mutableExternal.current = ref.current
+            mutableExternal.current = internalRef.current
 
             return () => {
                 // We only set our external ref value to null on unmount if it still contains the
                 // same element as our internal ref. This is because the component might be a child
                 // of `AnimatePresence` where we might be in a situation where a user is providing
                 // the same ref to multiple components.
-                if (external.current === ref.current) {
+                if (externalRef.current === internalRef.current) {
                     mutableExternal.current = null
                 }
             }
         }
     }, [])
-
-    return ref
 }

--- a/src/motion/utils/use-motion-values.ts
+++ b/src/motion/utils/use-motion-values.ts
@@ -1,11 +1,8 @@
-import { forwardRef, useEffect, memo, RefObject } from "react"
 import { MotionValue } from "../../value"
-import styler, { createStylerFactory, Styler } from "stylefire"
+import { createStylerFactory, Styler } from "stylefire"
 import { OnUpdate, MotionProps, TransformTemplate } from "../types"
-import { invariant } from "hey-listen"
 import { useConstant } from "../../utils/use-constant"
 import { isMotionValue } from "../../value/utils/is-motion-value"
-import { syncRenderSession } from "../../dom/sync-render-session"
 
 // Creating a styler factory for the `onUpdate` prop allows all values
 // to fire and the `onUpdate` prop will only fire once per frame
@@ -144,39 +141,3 @@ export const useMotionValues = (props: MotionProps) => {
 
     return motionValues
 }
-
-/**
- * `useEffect` gets resolved bottom-up. We defer some optional functionality to child
- * components, so to ensure everything runs correctly we export the ref-binding logic
- * to a new component rather than in `useMotionValues`.
- */
-const MountMotionValuesComponent = (
-    { values, isStatic }: { values: MotionValuesMap; isStatic: boolean },
-    ref: RefObject<Element>
-) => {
-    useEffect(() => {
-        invariant(
-            ref.current instanceof Element,
-            "No `ref` found. Ensure components created with `motion.custom` forward refs using `React.forwardRef`"
-        )
-
-        const domStyler = styler(ref.current as Element, {
-            preparseOutput: false,
-            enableHardwareAcceleration: !isStatic,
-        })
-
-        values.mount((key, value) => {
-            domStyler.set(key, value)
-
-            if (syncRenderSession.isOpen()) {
-                syncRenderSession.push(domStyler)
-            }
-        })
-
-        return () => values.unmount()
-    }, [])
-
-    return null
-}
-
-export const MountMotionValues = memo(forwardRef(MountMotionValuesComponent))


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/341

For a `motion` component to work, we need to maintain a `ref` to the component's rendered HTML/SVG element. This is because we animate outside the React render cycle, directly on the element itself.

Previously, we used a hook called `useExternalRef` to use an externally-provided `ref` if it existed, or one created internally in the `motion` component if it wasn't. This way users could provide their own `ref`s.

This led to a problem with `AnimatePresence` where it might be used to render one component at a time:

```jsx
<AnimatePresence>
  <motion.div ref={ref} key={id} />
</AnimatePresence>
```

In the above code, by changing `key`, we are actually creating new components. This is useful, for instance, when creating a slideshow. We can animate through the slides while only rendering one "canonical" slide (the current slide), rather than keeping track of incoming/outgoing slides.

However this led to a situation, the specifics around are unclear but the gist is when a user provided this component a ref, it would technically be possible for two or more components to all share the same ref as new components were added as old ones animated out. This created race conditions where outgoing components might set this ref to `null` while another component was still using it.

To fix this, this PR changes things so every component has its own `ref` and on mount/unmount defensively updates an external ref if it's provided.