### PR TITLE
Support custom attributes in controls .set()

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -36,7 +36,7 @@ export interface AnimatePresenceProps {
 export class AnimationControls {
     // @internal
     mount(): void;
-    set(definition: VariantLabels | TargetAndTransition): void;
+    set(definition: AnimationDefinition): void;
     // @internal
     setDefaultTransition(transition: Transition): void;
     // @internal

--- a/src/animation/AnimationControls.ts
+++ b/src/animation/AnimationControls.ts
@@ -1,9 +1,8 @@
-import { Variants, Transition, TargetAndTransition } from "../types"
+import { Variants, Transition } from "../types"
 import {
     ValueAnimationControls,
     AnimationDefinition,
 } from "./ValueAnimationControls"
-import { VariantLabels } from "../motion/types"
 import { invariant } from "hey-listen"
 
 type PendingAnimations = {
@@ -160,7 +159,7 @@ export class AnimationControls {
      *
      * @public
      */
-    set(definition: VariantLabels | TargetAndTransition) {
+    set(definition: AnimationDefinition) {
         invariant(
             this.hasMounted,
             "controls.set() should only be called after a component has mounted. Consider calling within a useEffect hook."

--- a/src/animation/__tests__/index.test.tsx
+++ b/src/animation/__tests__/index.test.tsx
@@ -279,6 +279,43 @@ describe("useAnimation", () => {
         return await expect(promise).resolves.toEqual([1, 1])
     })
 
+    test(".set accepts state depending on custom attribute", async () => {
+        const promise = new Promise(resolve => {
+            const Component = () => {
+                const xa = useMotionValue(0)
+                const xb = useMotionValue(0)
+                const controls = useAnimation()
+
+                useEffect(() => {
+                    controls.set(custom => {
+                        return { x: 1 * custom }
+                    })
+                    resolve([xa.get(), xb.get()])
+                })
+
+                return (
+                    <>
+                        <motion.div
+                            animate={controls}
+                            custom={1}
+                            style={{ x: xa }}
+                        />
+                        <motion.div
+                            animate={controls}
+                            custom={2}
+                            style={{ x: xb }}
+                        />
+                    </>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        return await expect(promise).resolves.toEqual([1, 2])
+    })
+
     test(".set updates variants throughout a tree", async () => {
         const promise = new Promise(resolve => {
             const Component = () => {


### PR DESCRIPTION
**Feature description**
This is the PR for #356 
It makes `controls.set` function accept a method that 's based on custom props.

**Separate PRs**
- No need for a separate PR. 
.set() method docs will be updated thanks to the typescript class changes.