### PR TITLE
Detecting an anchor point for layoutTransition

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,3 @@
 {
-    "sandboxes": ["fz7cz"]
+    "sandboxes": ["fz7cz", "ecgc2", "bviz6", "3myb9", "3fix0"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.14] 2019-10-14
+
+### Fix
+
+-   Measuring position from the top left of an element when in `positionOnly` mode to prevent position transitions when only width/height have changed.
+
 ## [1.6.13] 2019-10-14
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fix
 
--   Measuring position from the top left of an element when in `positionOnly` mode to prevent position transitions when only width/height have changed.
+-   Making position change detection more intelligent.
 
 ## [1.6.13] 2019-10-14
 

--- a/src/motion/functionality/layout.ts
+++ b/src/motion/functionality/layout.ts
@@ -82,7 +82,7 @@ interface YLabels {
     origin: "originY"
 }
 
-const dimensionLabels: { x: XLabels; y: YLabels } = {
+const axisLabels: { x: XLabels; y: YLabels } = {
     x: {
         id: "x",
         size: "width",
@@ -103,9 +103,9 @@ function centerOf(min: number, max: number) {
     return (min + max) / 2
 }
 
-function calcDimensionDelta(prev: Layout, next: Layout, names: XLabels): XDelta
-function calcDimensionDelta(prev: Layout, next: Layout, names: YLabels): YDelta
-function calcDimensionDelta(
+function calcAxisDelta(prev: Layout, next: Layout, names: XLabels): XDelta
+function calcAxisDelta(prev: Layout, next: Layout, names: YLabels): YDelta
+function calcAxisDelta(
     prev: Layout,
     next: Layout,
     names: XLabels | YLabels
@@ -113,6 +113,9 @@ function calcDimensionDelta(
     const sizeDelta = prev[names.size] - next[names.size]
     let origin = 0.5
 
+    // If the element has changed size we want to check whether either side is in
+    // the same position before/after the layout transition. If so, we can anchor
+    // the element to that position and only animate its size.
     if (sizeDelta) {
         if (prev[names.min] === next[names.min]) {
             origin = 0
@@ -125,6 +128,7 @@ function calcDimensionDelta(
         [names.size]: sizeDelta,
         [names.origin]: origin,
         [names.id]:
+            // Only measure a position delta if we haven't anchored to one side
             origin === 0.5
                 ? centerOf(prev[names.min], prev[names.max]) -
                   centerOf(next[names.min], next[names.max])
@@ -136,8 +140,8 @@ function calcDimensionDelta(
 
 function calcDelta(prev: Layout, next: Layout): LayoutDelta {
     const delta = {
-        ...calcDimensionDelta(prev, next, dimensionLabels.x),
-        ...calcDimensionDelta(prev, next, dimensionLabels.y),
+        ...calcAxisDelta(prev, next, axisLabels.x),
+        ...calcAxisDelta(prev, next, axisLabels.y),
     }
 
     return delta as LayoutDelta

--- a/src/motion/functionality/layout.ts
+++ b/src/motion/functionality/layout.ts
@@ -114,7 +114,7 @@ function calcDimensionDelta(
     let origin = 0.5
 
     if (sizeDelta) {
-        if (prev[names.min] === next[names.max]) {
+        if (prev[names.min] === next[names.min]) {
             origin = 0
         } else if (prev[names.max] === next[names.max]) {
             origin = 1

--- a/src/motion/functionality/layout.ts
+++ b/src/motion/functionality/layout.ts
@@ -66,7 +66,23 @@ function isResolver(
     return typeof transition === "function"
 }
 
-const dimensionLabels = {
+interface XLabels {
+    id: "x"
+    size: "width"
+    min: "left"
+    max: "right"
+    origin: "originX"
+}
+
+interface YLabels {
+    id: "y"
+    size: "height"
+    min: "top"
+    max: "bottom"
+    origin: "originY"
+}
+
+const dimensionLabels: { x: XLabels; y: YLabels } = {
     x: {
         id: "x",
         size: "width",
@@ -87,21 +103,13 @@ function centerOf(min: number, max: number) {
     return (min + max) / 2
 }
 
+function calcDimensionDelta(prev: Layout, next: Layout, names: XLabels): XDelta
+function calcDimensionDelta(prev: Layout, next: Layout, names: YLabels): YDelta
 function calcDimensionDelta(
     prev: Layout,
     next: Layout,
-    names: typeof dimensionLabels.x
-): XDelta
-function calcDimensionDelta(
-    prev: Layout,
-    next: Layout,
-    names: typeof dimensionLabels.y
-): YDelta
-function calcDimensionDelta(
-    prev: Layout,
-    next: Layout,
-    names: typeof dimensionLabels.x | typeof dimensionLabels.y
-) {
+    names: XLabels | YLabels
+): XDelta | YDelta {
     const sizeDelta = prev[names.size] - next[names.size]
     let origin = 0.5
 
@@ -123,7 +131,7 @@ function calcDimensionDelta(
                 : 0,
     }
 
-    return delta
+    return delta as any
 }
 
 function calcDelta(prev: Layout, next: Layout): LayoutDelta {


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/359

The problem is that previously we were measuring position delta by looking at the change in center point. Which meant as a component changed size, the center point moved even if the component hadn't:

```
|---*---|

// This has moved! Apparently.
|-*-|
```

This PR looks at what exactly has changed and if the size has changed it checks to see if either edge has *not* moved and, if so, uses that to "anchor" the animations. The component will then not be considered to have moved:

```
|*------|

// Hasn't moved - don't animate position
|*--|
```