### PR TITLE
Fixing hydration of ref during mount useLayoutEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.16] 2019-10-31
+
+### Fixes
+
+-   Fixing `ref` hydration in `useLayoutEffect`. (Note: This release effectively reverts `1.6.10`. Each child of `AnimatePresence` with a unique `key` should be given a unique `ref`).
+
 ## [1.6.15] 2019-10-24
 
 ### Added

--- a/dev/examples/positionTransition.tsx
+++ b/dev/examples/positionTransition.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+import { useState, useEffect } from "react"
+import { motion } from "@framer"
+import { clamp } from "@popmotion/popcorn"
+
+export const App = () => {
+    const [colors, setColors] = useState(initialColors)
+    const [widths, setWidths] = useState(initialWidths)
+
+    useEffect(() => {
+        setTimeout(() => {
+            setWidths({
+                "#FF008C": 200,
+                "#D309E1": 300,
+                "#9C1AFF": 100,
+                "#7700FF": 150,
+            })
+        }, 2000)
+    }, [])
+
+    return (
+        <ul className="items">
+            {colors.map((color, i) => (
+                <motion.li
+                    key={color}
+                    style={{
+                        background: color,
+                        width: widths[color],
+                        float: widths["#7700FF"] === 150 ? "right" : "left",
+                    }}
+                    layoutTransition={{ duration: 2 }}
+                />
+            ))}
+            <style>{`
+      
+        ul,
+        li {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+        }
+        
+        ul {
+          position: absolute;
+          width: 300px;
+          top: 100px;
+          flex-wrap: wrap;
+        }
+        
+        li {
+          display: block;
+          
+          border-radius: 10px;
+          margin-bottom: 10px;
+          margin-right: 10px;
+          height: 140px;
+          transform-origin: 50% 50%;
+        }
+        
+                
+                `}</style>
+        </ul>
+    )
+}
+
+const onTop = { zIndex: 1 }
+const flat = {
+    zIndex: 0,
+    transition: { delay: 0.3 },
+}
+
+const height = 80
+const marginBottom = 10
+const totalHeight = height + marginBottom
+const findIndex = (i, y) => {
+    // Could use a ref with offsetTop
+    const baseY = totalHeight * i
+    const totalY = baseY + y
+    return clamp(0, initialColors.length - 1, Math.round(totalY / totalHeight))
+}
+
+const initialColors = ["#FF008C", "#D309E1", "#9C1AFF", "#7700FF"]
+const initialWidths = {
+    "#FF008C": 200,
+    "#D309E1": 200,
+    "#9C1AFF": 200,
+    "#7700FF": 200,
+}

--- a/dev/examples/ref.tsx
+++ b/dev/examples/ref.tsx
@@ -1,0 +1,27 @@
+import { motion } from "@framer"
+import * as React from "react"
+import { useRef, useLayoutEffect, useEffect } from "react"
+
+export const App = () => {
+    const vanillaRef = useRef(null)
+    const motionRef = useRef(null)
+
+    useLayoutEffect(() => {
+        console.log("useLayoutEffect =======")
+        console.log("vanilla ref", vanillaRef.current)
+        console.log("motion ref", motionRef.current)
+    })
+
+    useEffect(() => {
+        console.log("useEffect =======")
+        console.log("vanilla ref", vanillaRef.current)
+        console.log("motion ref", motionRef.current)
+    })
+
+    return (
+        <>
+            <div ref={vanillaRef} />
+            <motion.div ref={motionRef} />
+        </>
+    )
+}

--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -34,6 +34,32 @@ describe("motion component rendering and styles", () => {
         expect(container.firstChild).toBeTruthy()
     })
 
+    it("hydrates a provided ref by the time useLayoutEffect has fired", () => {
+        let hasVanillaRef = false
+        let hasMotionRef = false
+
+        const Component = () => {
+            const vanillaRef = React.useRef<HTMLDivElement>(null)
+            const motionRef = React.useRef<HTMLDivElement>(null)
+
+            React.useLayoutEffect(() => {
+                if (vanillaRef.current !== null) hasVanillaRef = true
+                if (motionRef.current !== null) hasMotionRef = true
+            })
+
+            return (
+                <>
+                    <div ref={vanillaRef} />
+                    <motion.div ref={motionRef} />
+                </>
+            )
+        }
+
+        render(<Component />)
+        expect(hasVanillaRef).toBe(true)
+        expect(hasMotionRef).toBe(true)
+    })
+
     it("renders child", () => {
         const { getByTestId } = render(
             <motion.div>

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
-import { useContext, forwardRef, useRef, Ref, RefObject } from "react"
+import { useContext, forwardRef, Ref, RefObject } from "react"
 import { useMotionValues, MotionValuesMap } from "./utils/use-motion-values"
-import { MountRef } from "./utils/MountRef"
+import { Mount } from "./utils/Mount"
 import { useMotionStyles } from "./utils/use-styles"
 import { useValueAnimationControls } from "../animation/use-value-animation-controls"
 import { MotionContext, useMotionContext } from "./context/MotionContext"
@@ -13,6 +13,7 @@ import {
 import { checkShouldInheritVariant } from "./utils/should-inherit-variant"
 import { ValueAnimationConfig } from "../animation/ValueAnimationControls"
 import { useConstant } from "../utils/use-constant"
+import { useExternalRef } from "./utils/use-external-ref"
 export { MotionProps }
 
 export interface MotionComponentConfig {
@@ -36,7 +37,7 @@ export const createMotionComponent = <P extends {}>({
         props: P & MotionProps,
         externalRef?: Ref<Element>
     ) {
-        const ref = useRef(null)
+        const ref = useExternalRef(externalRef)
         const parentContext = useContext(MotionContext)
 
         const isStatic = parentContext.static || props.static || false
@@ -88,12 +89,7 @@ export const createMotionComponent = <P extends {}>({
 
         return (
             <>
-                <MountRef
-                    ref={ref}
-                    externalRef={externalRef}
-                    values={values}
-                    isStatic={isStatic}
-                />
+                <Mount innerRef={ref} values={values} isStatic={isStatic} />
                 {functionality}
                 <MotionContext.Provider value={context}>
                     {renderedComponent}

--- a/src/motion/utils/Mount.tsx
+++ b/src/motion/utils/Mount.tsx
@@ -1,27 +1,21 @@
 import { MotionValuesMap } from "./use-motion-values"
 import { syncRenderSession } from "../../dom/sync-render-session"
-import { useExternalRef } from "./use-external-ref"
-import { RefObject, Ref, useEffect, forwardRef, memo } from "react"
+import { RefObject, useEffect, memo } from "react"
 import { invariant } from "hey-listen"
 import styler from "stylefire"
+
+interface MountProps {
+    innerRef: RefObject<Element>
+    values: MotionValuesMap
+    isStatic: boolean
+}
 
 /**
  * `useEffect` gets resolved bottom-up. We defer some optional functionality to child
  * components, so to ensure everything runs correctly we export the ref-binding logic
  * to a new component rather than in `useMotionValues`.
  */
-const MountRefComponent = (
-    {
-        values,
-        isStatic,
-        externalRef,
-    }: {
-        values: MotionValuesMap
-        isStatic: boolean
-        externalRef?: Ref<Element>
-    },
-    ref: RefObject<Element>
-) => {
+const MountComponent = ({ innerRef: ref, values, isStatic }: MountProps) => {
     useEffect(() => {
         invariant(
             ref.current instanceof Element,
@@ -44,9 +38,7 @@ const MountRefComponent = (
         return () => values.unmount()
     }, [])
 
-    useExternalRef(ref, externalRef)
-
     return null
 }
 
-export const MountRef = memo(forwardRef(MountRefComponent))
+export const Mount = memo(MountComponent)


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/360
Fixes https://github.com/framer/motion/issues/366

Un-fixes https://github.com/framer/motion/issues/341

## Background

In issue [#341](https://github.com/framer/motion/issues/341) there was a bug where Motion would blow up if we provided a single `ref` to the single child of `AnimatePresence`. This is because each component would use that externally-created `ref` to store a reference to the DOM node that they're animating.

To fix this, in PR [#352](https://github.com/framer/motion/pull/352) I made a change whereby every component always created its own `ref` and manually hydrated any externally-provided `ref`s via a `useEffect`. This meant we could guarantee that each component had a reference to its own underlying DOM node.

## The unforeseen consequence

The issues that this PR fixes is this:

```jsx
const MyComponent = () => {
  const ref = useRef(null)
  useLayoutEffect(() => {
    ref.current === null // This should be a DOM node
  })
  return <motion.div ref={ref} />
}
```

Because we're hydrating external refs with a `useEffect`, if a user wants to access the underlying node during a `useLayoutEffect`, the ref is still `null`.

## The fix

One approach would be to hydrate the ref using `useLayoutEffect`. However:
1. `useLayoutEffect` is render-blocking. This would have performance implications in Framer and on user's sites.
2. It'd have implications with SSR sites as React (IMO incorrectly) throws warnings for every component it encounters that uses `useLayoutEffect` in a server-rendered setting.

Instead, this PR reverts to the previous behaviour where external refs are, if present, used as the component's ref. On one hand this reintroduces the bug we were trying to fix. However, there's a counter-point in that this bug is valid and expected behaviour. When we provide a single `ref` to multiple components that exist simultaneously, this is a bug waiting to happen. Consider a `ref` function:

```jsx
<motion.div ref={() => {}} />
```

It's obvious when this should fire with an element, but when should it fire with `null`? IMO when the node is removed from the DOM, when the component *really* unmounts. So when this same `ref` is provided to a component that can switch out for another (for instance via `key` change), without some mind-bending logic and edge-case handling this `ref` will fire with the exiting component's `null` *after* the incoming component fires it with its DOM node. This logic holds for a normal ref:

```jsx
const MyComponent = ({ isOpen }) => {
  const ref = useRef(null)

  return (
    <AnimatePresence>
      <motion.div ref={ref} key={isOpen ? "a" : "b"} exit={{ opacity: 0 }} />
    </AnimatePresence>
  )
}
```

When should this `ref` represent "a", and when should it represent "b"? These time periods overlap. We shouldn't be trying to fix this and the previous PR was a mistake.