### PR TITLE
Remove excessive direct usage of act in tests

### DIFF
--- a/jest.setup.tsx
+++ b/jest.setup.tsx
@@ -2,10 +2,30 @@ import "jest-dom/extend-expect"
 // Get fireEvent from the native testing library
 // because @testing-library/react one switches out mouseEnter and mouseLeave
 import { fireEvent } from "@testing-library/dom"
-import { render as testRender } from "@testing-library/react"
+import { render as testRender, act } from "@testing-library/react"
 import * as React from "react"
 
-export const { mouseEnter, mouseLeave } = fireEvent
+export const click = (element: Element) =>
+    act(() => {
+        fireEvent.click(element)
+    })
+export const mouseEnter = (element: Element) =>
+    act(() => {
+        fireEvent.mouseEnter(element)
+    })
+export const mouseLeave = (element: Element) =>
+    act(() => {
+        fireEvent.mouseLeave(element)
+    })
+export const mouseDown = (element: Element) =>
+    act(() => {
+        fireEvent.mouseDown(element)
+    })
+export const mouseUp = (element: Element) =>
+    act(() => {
+        fireEvent.mouseUp(element)
+    })
+
 export const render = (children: any) => {
     const renderReturn = testRender(
         <React.StrictMode>{children}</React.StrictMode>

--- a/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -2,7 +2,6 @@ import { render } from "../../../../jest.setup"
 import * as React from "react"
 import { AnimatePresence, motion } from "../../.."
 import { motionValue } from "../../../value"
-import { act } from "react-dom/test-utils"
 
 describe("AnimatePresence", () => {
     test("Does nothing on initial render by default", async () => {
@@ -323,15 +322,9 @@ describe("AnimatePresence", () => {
                 )
             }
 
-            let rerender: any
+            const { rerender } = render(<Component isVisible />)
 
-            act(() => {
-                rerender = render(<Component isVisible />).rerender
-            })
-
-            act(() => {
-                rerender(<Component isVisible={false} />)
-            })
+            rerender(<Component isVisible={false} />)
 
             resolve(opacity.get())
         })

--- a/src/events/__tests__/use-pointer-events.test.tsx
+++ b/src/events/__tests__/use-pointer-events.test.tsx
@@ -6,7 +6,7 @@ import { enableTouchEvents, enablePointerEvents } from "./utils/event-helpers"
 import { fireCustomEvent } from "./utils/fire-event"
 
 function testEventsWithRef(fireFunctions: {
-    [key: string]: (element: Element) => boolean
+    [key: string]: (element: Element) => void
 }) {
     const ref = React.createRef<HTMLDivElement>()
     const handlers = {}

--- a/src/gestures/__tests__/hover.test.tsx
+++ b/src/gestures/__tests__/hover.test.tsx
@@ -5,7 +5,6 @@ import { fireEvent } from "@testing-library/react"
 import { motionValue } from "../../value"
 import { transformValues } from "../../motion/__tests__/util-transform-values"
 import sync from "framesync"
-import { act } from "react-dom/test-utils"
 
 describe("hover", () => {
     test("hover event listeners fire", () => {
@@ -15,10 +14,7 @@ describe("hover", () => {
             <motion.div onHoverStart={hoverIn} onHoverEnd={hoverOut} />
         )
 
-        let container: any
-        act(() => {
-            container = render(<Component />).container
-        })
+        const { container } = render(<Component />)
         mouseEnter(container.firstChild as Element)
         mouseLeave(container.firstChild as Element)
 
@@ -101,16 +97,10 @@ describe("hover", () => {
                 </motion.div>
             )
 
-            let container: any
-            act(() => {
-                const { container: componentContainer } = render(<Component />)
-                container = componentContainer
-            })
+            const { container } = render(<Component />)
 
-            act(() => {
-                mouseEnter(container.firstChild as Element)
-                resolve(opacity.get())
-            })
+            mouseEnter(container.firstChild as Element)
+            resolve(opacity.get())
         })
 
         return expect(promise).resolves.toBe(target)
@@ -136,21 +126,15 @@ describe("hover", () => {
                 />
             )
 
-            let container: any
-            act(() => {
-                const { container: componentContainer } = render(
-                    <Component onAnimationComplete={onComplete} />
-                )
-                container = componentContainer
-            })
+            const { container } = render(
+                <Component onAnimationComplete={onComplete} />
+            )
 
-            act(() => {
-                mouseEnter(container.firstChild as Element)
-                setTimeout(() => {
-                    hasMousedOut = true
-                    mouseLeave(container.firstChild as Element)
-                }, 10)
-            })
+            mouseEnter(container.firstChild as Element)
+            setTimeout(() => {
+                hasMousedOut = true
+                mouseLeave(container.firstChild as Element)
+            }, 10)
         })
 
         return expect(promise).resolves.toBe(1)

--- a/src/gestures/__tests__/tap.test.tsx
+++ b/src/gestures/__tests__/tap.test.tsx
@@ -2,10 +2,15 @@ import * as React from "react"
 import { motion } from "../../"
 import { fireEvent } from "@testing-library/dom"
 import { motionValue } from "../../value"
-import { mouseEnter, mouseLeave, render } from "../../../jest.setup"
+import {
+    mouseEnter,
+    mouseLeave,
+    mouseDown,
+    mouseUp,
+    render,
+} from "../../../jest.setup"
 import { drag, MockDrag } from "../../behaviours/__tests__/utils"
 import sync from "framesync"
-import { act } from "react-dom/test-utils"
 
 function mockWhenFirstArgumentIs(
     original: (...args: any[]) => any,
@@ -263,24 +268,17 @@ describe("tap", () => {
                 />
             )
 
-            let container: any
-            act(() => {
-                const { container: componentContainer } = render(<Component />)
-                container = componentContainer
-            })
+            const { container } = render(<Component />)
 
             logOpacity() // 0.5
 
-            act(() => {
-                // Trigger mouse down
-                fireEvent.mouseDown(container.firstChild as Element)
-            })
+            // Trigger mouse down
+            mouseDown(container.firstChild as Element)
+
             logOpacity() // 1
 
-            act(() => {
-                // Trigger mouse up
-                fireEvent.mouseUp(container.firstChild as Element)
-            })
+            // Trigger mouse up
+            mouseUp(container.firstChild as Element)
             logOpacity() // 0.5
 
             resolve(opacityHistory)
@@ -305,26 +303,17 @@ describe("tap", () => {
                 </motion.div>
             )
 
-            let getByTestId: any
-
-            act(() => {
-                const { getByTestId: byId } = render(<Component />)
-                getByTestId = byId
-            })
+            const { getByTestId } = render(<Component />)
 
             logOpacity() // 0.5
 
-            act(() => {
-                // Trigger mouse down
-                fireEvent.mouseDown(getByTestId("child") as Element)
-            })
+            // Trigger mouse down
+            mouseDown(getByTestId("child") as Element)
 
             logOpacity() // 1
 
-            act(() => {
-                // Trigger mouse up
-                fireEvent.mouseUp(getByTestId("child") as Element)
-            })
+            // Trigger mouse up
+            mouseUp(getByTestId("child") as Element)
             logOpacity() // 0.5
 
             resolve(opacityHistory)

--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent } from "@testing-library/react"
 import { motion } from "../"
 import * as React from "react"
 import styled from "styled-components"
-import { act } from "react-dom/test-utils"
 
 describe("motion component rendering and styles", () => {
     it("renders", () => {
@@ -337,18 +336,9 @@ describe("motion component rendering and styles", () => {
             return <motion.div animate={{ x: 100 }} initial={{ x: 0 }} />
         }
 
-        let container: any
-        let rerender: any
+        const { container, rerender } = render(<Test />)
 
-        act(() => {
-            const result = render(<Test />)
-            container = result.container
-            rerender = result.rerender
-        })
-
-        act(() => {
-            rerender(<Test />)
-        })
+        rerender(<Test />)
 
         expect(container.firstChild).toBeTruthy()
     })

--- a/src/motion/__tests__/variant.test.tsx
+++ b/src/motion/__tests__/variant.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../jest.setup"
-import { act } from "react-dom/test-utils"
 import { motion } from "../"
 import * as React from "react"
 import { Variants } from "../../types"
@@ -244,22 +243,17 @@ describe("animate prop as variant", () => {
                 },
             }
 
-            act(() => {
-                render(
-                    <motion.div
-                        variants={variants}
-                        initial="hidden"
-                        animate="visible"
-                    >
-                        <motion.div>
-                            <motion.div
-                                variants={variants}
-                                style={{ opacity }}
-                            />
-                        </motion.div>
+            render(
+                <motion.div
+                    variants={variants}
+                    initial="hidden"
+                    animate="visible"
+                >
+                    <motion.div>
+                        <motion.div variants={variants} style={{ opacity }} />
                     </motion.div>
-                )
-            })
+                </motion.div>
+            )
 
             setTimeout(() => resolve(opacity.get()), 200)
         })
@@ -276,24 +270,22 @@ describe("animate prop as variant", () => {
                 },
             }
 
-            act(() => {
-                render(
-                    <motion.div
-                        variants={variants}
-                        initial="hidden"
-                        animate="visible"
-                        transition={{ duration: 1, when: "afterChildren" }}
-                        style={{ opacity }}
-                    >
-                        <motion.div>
-                            <motion.div
-                                variants={variants}
-                                transition={{ duration: 1 }}
-                            />
-                        </motion.div>
+            render(
+                <motion.div
+                    variants={variants}
+                    initial="hidden"
+                    animate="visible"
+                    transition={{ duration: 1, when: "afterChildren" }}
+                    style={{ opacity }}
+                >
+                    <motion.div>
+                        <motion.div
+                            variants={variants}
+                            transition={{ duration: 1 }}
+                        />
                     </motion.div>
-                )
-            })
+                </motion.div>
+            )
 
             setTimeout(() => resolve(opacity.get()), 200)
         })

--- a/src/utils/__tests__/use-cycle.test.tsx
+++ b/src/utils/__tests__/use-cycle.test.tsx
@@ -1,6 +1,5 @@
-import { render } from "../../../jest.setup"
+import { render, click } from "../../../jest.setup"
 import { fireEvent } from "@testing-library/react"
-import { act } from "react-dom/test-utils"
 import * as React from "react"
 import { useCycle } from "../use-cycle"
 
@@ -22,18 +21,10 @@ describe("useCycle", () => {
 
         const { container } = render(<Component />)
 
-        act(() => {
-            fireEvent.click(container.firstChild as Element)
-        })
-        act(() => {
-            fireEvent.click(container.firstChild as Element)
-        })
-        act(() => {
-            fireEvent.click(container.firstChild as Element)
-        })
-        act(() => {
-            fireEvent.click(container.firstChild as Element)
-        })
+        click(container.firstChild as Element)
+        click(container.firstChild as Element)
+        click(container.firstChild as Element)
+        click(container.firstChild as Element)
 
         expect(results).toEqual([1, 2, 3, 4, 1])
     })

--- a/src/utils/__tests__/use-initial-or-every-render.test.tsx
+++ b/src/utils/__tests__/use-initial-or-every-render.test.tsx
@@ -1,7 +1,6 @@
 import { render } from "../../../jest.setup"
 import * as React from "react"
 import { useInitialOrEveryRender } from "../use-initial-or-every-render"
-import { act } from "@testing-library/react"
 
 describe("useInitialOrEveryRender", () => {
     test("to only run callback on initial render if isInitialOnly is true", () => {
@@ -26,19 +25,11 @@ describe("useInitialOrEveryRender", () => {
             return null
         }
 
-        let rerender: any
+        const { rerender } = render(<Component />)
 
-        act(() => {
-            rerender = render(<Component />).rerender
-        })
+        rerender(<Component />)
 
-        act(() => {
-            rerender(<Component />)
-        })
-
-        act(() => {
-            rerender(<Component />)
-        })
+        rerender(<Component />)
 
         expect(callbackHistory).toEqual([true, false, false])
     })
@@ -58,19 +49,11 @@ describe("useInitialOrEveryRender", () => {
             return null
         }
 
-        let rerender: any
+        const { rerender } = render(<Component />)
 
-        act(() => {
-            rerender = render(<Component />).rerender
-        })
+        rerender(<Component />)
 
-        act(() => {
-            rerender(<Component />)
-        })
-
-        act(() => {
-            rerender(<Component />)
-        })
+        rerender(<Component />)
 
         expect(callbackHistory).toEqual([true, true, true])
     })


### PR DESCRIPTION
`render` from `@testing-library/react` is already act-wrapped, so no need to wrap it again. Additionally, I've created act-wrapped version of some fireEvents in jest.setup.