### PR TITLE
Add TargetResolver to type of exit prop

### DIFF
--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -6,6 +6,7 @@ import {
     Target,
     Transition,
     TargetAndTransition,
+    TargetResolver,
     Omit,
     MakeCustomValueType,
 } from "../types"
@@ -201,7 +202,7 @@ export interface AnimationProps {
      * }
      * ```
      */
-    exit?: TargetAndTransition | VariantLabels
+    exit?: TargetAndTransition | VariantLabels | TargetResolver
 
     /**
      * Variants allow you to define animation states and organise them by name. They allow


### PR DESCRIPTION
This fixes #423.

I mentioned in the issue that this behavior was in the documentation, but now I can't find it. Is it intended to work this way?

If it is, should I add this type to the `initial` and `animate` props too?