### PR TITLE
dragListener prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.8.4] 2020-02-05
+
+### Added
+
+-   `dragListener` prop to disable drag event listeners.
+
 ## [1.8.3] 2020-01-28
 
 ### Added

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -108,6 +108,7 @@ export interface DraggableProps extends DragHandlers {
     dragControls?: DragControls;
     dragDirectionLock?: boolean;
     dragElastic?: boolean | number;
+    dragListener?: boolean;
     dragMomentum?: boolean;
     dragOriginX?: MotionValue<number>;
     dragOriginY?: MotionValue<number>;

--- a/src/behaviours/ComponentDragControls.ts
+++ b/src/behaviours/ComponentDragControls.ts
@@ -524,7 +524,10 @@ export class ComponentDragControls {
         const stopPointerListener = addPointerEvent(
             element,
             "pointerdown",
-            event => this.props.drag && this.start(event)
+            event => {
+                const { drag, dragListener = true } = this.props
+                drag && dragListener && this.start(event)
+            }
         )
 
         const stopResizeListener = addDomEvent(window, "resize", () =>

--- a/src/behaviours/__tests__/index.test.tsx
+++ b/src/behaviours/__tests__/index.test.tsx
@@ -26,6 +26,28 @@ describe("dragging", () => {
         expect(onDragStart).toBeCalledTimes(1)
     })
 
+    test("dragStart doesn't fire if dragListener === false", async () => {
+        const onDragStart = jest.fn()
+        const Component = () => (
+            <MockDrag>
+                <motion.div
+                    drag
+                    dragListener={false}
+                    onDragStart={onDragStart}
+                />
+            </MockDrag>
+        )
+
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        const pointer = await drag(container.firstChild).to(100, 100)
+
+        pointer.end()
+
+        expect(onDragStart).toBeCalledTimes(0)
+    })
+
     test("dragEnd fires", async () => {
         const onDragEnd = jest.fn()
         const Component = () => (

--- a/src/behaviours/types.ts
+++ b/src/behaviours/types.ts
@@ -472,4 +472,54 @@ export interface DraggableProps extends DragHandlers {
      * ```
      */
     dragControls?: DragControls
+
+    /**
+     * By default, if `drag` is defined on a component then an event listener will be attached
+     * to automatically initiate dragging when a user presses down on it.
+     *
+     * By setting `dragListener` to `false`, this event listener will not be created.
+     *
+     * @library
+     *
+     * ```jsx
+     * const dragControls = useDragControls()
+     *
+     * function startDrag(event) {
+     *   dragControls.start(event, { snapToCursor: true })
+     * }
+     *
+     * return (
+     *   <>
+     *     <Frame onTapStart={startDrag} />
+     *     <Frame
+     *       drag="x"
+     *       dragControls={dragControls}
+     *       dragListener={false}
+     *     />
+     *   </>
+     * )
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * const dragControls = useDragControls()
+     *
+     * function startDrag(event) {
+     *   dragControls.start(event, { snapToCursor: true })
+     * }
+     *
+     * return (
+     *   <>
+     *     <div onMouseDown={startDrag} />
+     *     <motion.div
+     *       drag="x"
+     *       dragControls={dragControls}
+     *       dragListener={false}
+     *     />
+     *   </>
+     * )
+     * ```
+     */
+    dragListener?: boolean
 }

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -29,6 +29,8 @@ const validMotionProps = new Set<keyof MotionProps>([
     "onDirectionLock",
     "onDragTransitionEnd",
     "drag",
+    "dragControls",
+    "dragListener",
     "dragConstraints",
     "dragDirectionLock",
     "dragElastic",


### PR DESCRIPTION
In https://github.com/framer/motion/pull/446 we introduced `dragControls`. This allowed dragging to be manually initiated from a pointer event external to the draggable component.

However, dragging would still be automatically started from the draggable component. There are [use cases](https://github.com/framer/motion/issues/421) where it's desirable for dragging to *only* be initiated from an external component.

By setting `dragListener` to `false`, we won't start a drag on pointer down. 

Fixes https://github.com/framer/motion/issues/421

