### PR TITLE
Momentum animations on external drag motion values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.9.0] Unreleased
+## [1.9.1] 2020-03-06
+
+### Fixed
+
+-   Ensuring drag momentum animations happen on `_dragValueX` and `_dragValueY` if provided. ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#473](https://github.com/framer/motion/pull/473))
+
+## [1.9.0] 2020-03-02
 
 ### Added
 

--- a/src/behaviours/__tests__/index.test.tsx
+++ b/src/behaviours/__tests__/index.test.tsx
@@ -227,6 +227,28 @@ describe("dragging", () => {
         expect(onDragTransitionEnd.promise).resolves.toBe(true)
     })
 
+    test("drag momentum is applied", async () => {
+        const x = motionValue(0)
+        const Component = () => (
+            <MockDrag>
+                <motion.div drag="x" style={{ x }} />
+            </MockDrag>
+        )
+
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        const pointer = await drag(container.firstChild).to(1, 1)
+        await pointer.to(50, 50)
+        pointer.end()
+
+        const checkPointer = new Promise(resolve => {
+            setTimeout(() => resolve(x.get()), 40)
+        })
+
+        return await expect(checkPointer).resolves.toBeGreaterThan(50)
+    })
+
     test("outputs to external values if provided", async () => {
         const externalX = motionValue(0)
         const externalY = motionValue(0)
@@ -261,6 +283,33 @@ describe("dragging", () => {
             externalX: 50,
             externalY: 50,
         })
+    })
+
+    test("drag momentum is applied to external values", async () => {
+        const x = motionValue(0)
+        const dragX = motionValue(0)
+        const Component = () => (
+            <MockDrag>
+                <motion.div drag="x" _dragValueX={dragX} style={{ x }} />
+            </MockDrag>
+        )
+
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
+
+        const pointer = await drag(container.firstChild).to(1, 1)
+        await pointer.to(50, 50)
+        pointer.end()
+
+        const checkPointer = new Promise(resolve => {
+            setTimeout(() => {
+                expect(dragX.get()).toBeGreaterThan(50)
+                expect(x.get()).toBe(0)
+                resolve()
+            }, 40)
+        })
+
+        return checkPointer
     })
 
     test("limit to x", async () => {


### PR DESCRIPTION
This PR ensures that when a draggable component is using external `_dragValueX` or `Y` motion values that momentum animations occur on that rather than the host component's `x`/`y` motion values.