### PR TITLE
Multi-Presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.0] 2020-03-19
+
+### Added
+
+-   `AnimatePresence` now supports multiple `usePresence` children within a given sub-tree.
+
 ## [1.9.1] 2020-03-06
 
 ### Fixed

--- a/dev/examples/animateExitParallel.tsx
+++ b/dev/examples/animateExitParallel.tsx
@@ -1,0 +1,49 @@
+import { motion, AnimatePresence } from "@framer"
+import * as React from "react"
+import { useState } from "react"
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "red",
+    opacity: 1,
+}
+
+export const App = () => {
+    const [isVisible, setVisible] = useState(true)
+
+    React.useEffect(() => {
+        setTimeout(() => {
+            setVisible(!isVisible)
+        }, 3000)
+    })
+
+    return (
+        <AnimatePresence initial={false} onRest={() => console.log("rest")}>
+            {isVisible && (
+                <>
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 1 }}
+                        style={style}
+                    />
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 2 }}
+                        style={{ ...style, background: "green" }}
+                    />
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 2 }}
+                        style={{ ...style, background: "blue" }}
+                    />
+                </>
+            )}
+        </AnimatePresence>
+    )
+}

--- a/src/animation/use-value-animation-controls.ts
+++ b/src/animation/use-value-animation-controls.ts
@@ -31,7 +31,7 @@ export function useValueAnimationControls<P>(
     const controls = useConstant(() => new ValueAnimationControls<P>(config))
 
     // Reset and resubscribe children every render to ensure stagger order is correct
-    if (presenceContext && presenceContext.isPresent) {
+    if (!presenceContext || presenceContext.isPresent) {
         controls.resetChildren()
         controls.setProps(props)
         controls.setVariants(variants)

--- a/src/animation/use-value-animation-controls.ts
+++ b/src/animation/use-value-animation-controls.ts
@@ -4,11 +4,9 @@ import {
 } from "./ValueAnimationControls"
 import { useContext, useEffect } from "react"
 import { MotionProps } from "../motion/types"
-import {
-    MotionContext,
-    MotionContextProps,
-} from "../motion/context/MotionContext"
+import { MotionContext } from "../motion/context/MotionContext"
 import { useConstant } from "../utils/use-constant"
+import { PresenceContext } from "../components/AnimatePresence/PresenceContext"
 
 /**
  * Creates an imperative set of controls to trigger animations.
@@ -25,19 +23,15 @@ import { useConstant } from "../utils/use-constant"
 export function useValueAnimationControls<P>(
     config: ValueAnimationConfig,
     props: P & MotionProps,
-    subscribeToParentControls: boolean,
-    parentContext?: MotionContextProps
+    subscribeToParentControls: boolean
 ) {
     const { variants, transition } = props
     const parentControls = useContext(MotionContext).controls
+    const presenceContext = useContext(PresenceContext)
     const controls = useConstant(() => new ValueAnimationControls<P>(config))
 
     // Reset and resubscribe children every render to ensure stagger order is correct
-    if (
-        !parentContext ||
-        !parentContext.exitProps ||
-        !parentContext.exitProps.isExiting
-    ) {
+    if (presenceContext && presenceContext.isPresent) {
         controls.resetChildren()
         controls.setProps(props)
         controls.setVariants(variants)

--- a/src/components/AnimatePresence/PresenceChild.tsx
+++ b/src/components/AnimatePresence/PresenceChild.tsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import { useEffect, useMemo, useRef } from "react"
+import { PresenceContextProps, PresenceContext } from "./PresenceContext"
+
+type PresenceChildProps = PresenceContextProps & {
+    children: React.ReactElement<any>
+}
+
+export const PresenceChild = ({
+    children,
+    initial,
+    isExiting,
+    onExitComplete,
+    custom,
+}: PresenceChildProps) => {
+    const totalExitingChildren = useRef(0)
+
+    useEffect(() => {
+        totalExitingChildren.current = 0
+    }, [isExiting])
+
+    const context = useMemo(() => {
+        let numExitComplete = 0
+
+        const allExitComplete = () => {
+            numExitComplete++
+
+            if (numExitComplete >= totalExitingChildren.current) {
+                onExitComplete()
+            }
+        }
+
+        return {
+            initial,
+            isExiting,
+            onExitComplete: allExitComplete,
+            custom,
+            register: () => totalExitingChildren.current++,
+        }
+    }, [isExiting, initial, custom])
+
+    return (
+        <PresenceContext.Provider value={context}>
+            {children}
+        </PresenceContext.Provider>
+    )
+}

--- a/src/components/AnimatePresence/PresenceContext.ts
+++ b/src/components/AnimatePresence/PresenceContext.ts
@@ -1,19 +1,12 @@
 import { createContext } from "react"
 import { VariantLabels } from "../../motion/types"
 
-export type ExitingProps = {
-    isExiting: true
-    initial?: false | VariantLabels
-    onExitComplete: () => void
-    custom?: any
-}
-
-export type PresentProps = {
-    isExiting: false
+export interface PresenceContextProps {
+    isPresent: boolean
+    register: () => () => void
+    onExitComplete?: () => void
     initial?: false | VariantLabels
     custom?: any
 }
-
-export type PresenceContextProps = PresentProps | ExitingProps
 
 export const PresenceContext = createContext<PresenceContextProps | null>(null)

--- a/src/components/AnimatePresence/PresenceContext.ts
+++ b/src/components/AnimatePresence/PresenceContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react"
+import { VariantLabels } from "../../motion/types"
+
+export type ExitingProps = {
+    isExiting: true
+    initial?: false | VariantLabels
+    onExitComplete: () => void
+    custom?: any
+}
+
+export type PresentProps = {
+    isExiting: false
+    initial?: false | VariantLabels
+    custom?: any
+}
+
+export type PresenceContextProps = PresentProps | ExitingProps
+
+export const PresenceContext = createContext<PresenceContextProps | null>(null)

--- a/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from "../../.."
 import { motionValue } from "../../../value"
 
 describe("AnimatePresence", () => {
-    test("Does nothing on initial render by default", async () => {
+    test("Allows initial animation if no `initial` prop defined", async () => {
         const promise = new Promise(resolve => {
             const x = motionValue(0)
             const Component = () => {
@@ -29,579 +29,579 @@ describe("AnimatePresence", () => {
         expect(x).not.toBe(100)
     })
 
-    test("Suppresses initial animation if `initial={false}`", async () => {
-        const promise = new Promise(resolve => {
-            const Component = () => {
-                return (
-                    <AnimatePresence initial={false}>
-                        <motion.div
-                            initial={{ x: 0 }}
-                            animate={{ x: 100 }}
-                            exit={{ opacity: 0 }}
-                        />
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component />)
-            rerender(<Component />)
-
-            setTimeout(() => {
-                resolve(container.firstChild as Element)
-            }, 50)
-        })
-
-        const element = await promise
-        expect(element).toHaveStyle(
-            "transform: translateX(100px) translateZ(0)"
-        )
-    })
-
-    test("Animates out a component when its removed", async () => {
-        const promise = new Promise<Element | null>(resolve => {
-            const opacity = motionValue(1)
-            const Component = ({ isVisible }: { isVisible: boolean }) => {
-                return (
-                    <AnimatePresence>
-                        {isVisible && (
-                            <motion.div
-                                exit={{ opacity: 0 }}
-                                transition={{ duration: 0.1 }}
-                                style={{ opacity }}
-                            />
-                        )}
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-            rerender(<Component isVisible={false} />)
-            rerender(<Component isVisible={false} />)
-
-            // Check it's animating out
-            setTimeout(() => {
-                expect(opacity.get()).not.toBe(1)
-                expect(opacity.get()).not.toBe(0)
-            }, 50)
-
-            // Check it's gone
-            setTimeout(() => {
-                resolve(container.firstChild as Element | null)
-            }, 150)
-        })
-
-        const child = await promise
-        expect(child).toBeFalsy()
-    })
-
-    test("Animates a component back in if it's re-added before animating out", async () => {
-        const promise = new Promise<Element | null>(resolve => {
-            const Component = ({ isVisible }: { isVisible: boolean }) => {
-                return (
-                    <AnimatePresence>
-                        {isVisible && (
-                            <motion.div
-                                animate={{ opacity: 1 }}
-                                exit={{ opacity: 0 }}
-                                transition={{ duration: 0.1 }}
-                            />
-                        )}
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-
-            setTimeout(() => {
-                rerender(<Component isVisible={false} />)
-                rerender(<Component isVisible={false} />)
-
-                setTimeout(() => {
-                    rerender(<Component isVisible />)
-                    rerender(<Component isVisible />)
-
-                    setTimeout(() => {
-                        resolve(container.firstChild as Element | null)
-                    }, 150)
-                }, 50)
-            }, 50)
-        })
-
-        const child = await promise
-        expect(child).toHaveStyle("opacity: 1;")
-    })
-
-    test("Animates a component out after having an animation cancelled", async () => {
-        const promise = new Promise<Element | null>(resolve => {
-            const opacity = motionValue(1)
-            const Component = ({ isVisible }: { isVisible: boolean }) => {
-                return (
-                    <AnimatePresence>
-                        {isVisible && (
-                            <motion.div
-                                exit={{ opacity: 0 }}
-                                transition={{ duration: 0.1 }}
-                                style={{ opacity }}
-                            />
-                        )}
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-            rerender(<Component isVisible={false} />)
-            rerender(<Component isVisible={false} />)
-            rerender(<Component isVisible />)
-            rerender(<Component isVisible />)
-            rerender(<Component isVisible={false} />)
-            rerender(<Component isVisible={false} />)
-
-            // Check it's animating out
-            setTimeout(() => {
-                expect(opacity.get()).not.toBe(1)
-                expect(opacity.get()).not.toBe(0)
-            }, 50)
-
-            // Check it's gone
-            setTimeout(() => {
-                resolve(container.firstChild as Element | null)
-            }, 300)
-        })
-
-        const child = await promise
-        expect(child).toBeFalsy()
-    })
-
-    test("Can cycle through multiple components", async () => {
-        const promise = new Promise<number>(resolve => {
-            const Component = ({ i }: { i: number }) => {
-                return (
-                    <AnimatePresence>
-                        <motion.div
-                            key={i}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            transition={{ duration: 0.5 }}
-                        />
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component i={0} />)
-            rerender(<Component i={0} />)
-            setTimeout(() => {
-                rerender(<Component i={1} />)
-                rerender(<Component i={1} />)
-            }, 50)
-            setTimeout(() => {
-                rerender(<Component i={2} />)
-                rerender(<Component i={2} />)
-                resolve(container.childElementCount)
-            }, 400)
-        })
-
-        return await expect(promise).resolves.toBe(3)
-    })
-
-    test("Only renders one child at a time if exitBeforeEnter={true}", async () => {
-        const promise = new Promise<number>(resolve => {
-            const Component = ({ i }: { i: number }) => {
-                return (
-                    <AnimatePresence exitBeforeEnter>
-                        <motion.div
-                            key={i}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            transition={{ duration: 0.5 }}
-                        />
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component i={0} />)
-            rerender(<Component i={0} />)
-            setTimeout(() => {
-                rerender(<Component i={1} />)
-                rerender(<Component i={1} />)
-            }, 50)
-            setTimeout(() => {
-                rerender(<Component i={2} />)
-                rerender(<Component i={2} />)
-                resolve(container.childElementCount)
-            }, 150)
-        })
-
-        return await expect(promise).resolves.toBe(1)
-    })
-
-    test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
-        const variants = {
-            enter: { x: 0, transition: { type: false } },
-            exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
-        }
-        const promise = new Promise(resolve => {
-            const x = motionValue(0)
-            const Component = ({
-                isVisible,
-                onAnimationComplete,
-            }: {
-                isVisible: boolean
-                onAnimationComplete?: () => void
-            }) => {
-                return (
-                    <AnimatePresence
-                        custom={2}
-                        onExitComplete={onAnimationComplete}
-                    >
-                        {isVisible && (
-                            <motion.div
-                                custom={1}
-                                variants={variants}
-                                initial="exit"
-                                animate="enter"
-                                exit="exit"
-                                style={{ x }}
-                            />
-                        )}
-                    </AnimatePresence>
-                )
-            }
-
-            const { rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-
-            rerender(
-                <Component
-                    isVisible={false}
-                    onAnimationComplete={() => resolve(x.get())}
-                />
-            )
-
-            rerender(
-                <Component
-                    isVisible={false}
-                    onAnimationComplete={() => resolve(x.get())}
-                />
-            )
-        })
-
-        const resolvedX = await promise
-        expect(resolvedX).toBe(200)
-    })
-
-    test("Exit propagates through variants", async () => {
-        const variants = {
-            enter: { opacity: 1, transition: { type: false } },
-            exit: { opacity: 0, transition: { type: false } },
-        }
-
-        const promise = new Promise<number>(resolve => {
-            const opacity = motionValue(1)
-            const Component = ({ isVisible }: { isVisible: boolean }) => {
-                return (
-                    <AnimatePresence>
-                        {isVisible && (
-                            <motion.div
-                                initial="enter"
-                                animate="enter"
-                                exit="exit"
-                                variants={variants}
-                            >
-                                <motion.div variants={variants}>
-                                    <motion.div
-                                        variants={variants}
-                                        style={{ opacity }}
-                                    />
-                                </motion.div>
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
-                )
-            }
-
-            const { rerender } = render(<Component isVisible />)
-
-            rerender(<Component isVisible={false} />)
-
-            resolve(opacity.get())
-        })
-
-        return await expect(promise).resolves.toBe(0)
-    })
-
-    test("Handles external refs on a single child", async () => {
-        const promise = new Promise(resolve => {
-            const ref = React.createRef<HTMLDivElement>()
-            const Component = ({ id }: { id: number }) => {
-                return (
-                    <AnimatePresence initial={false}>
-                        <motion.div
-                            data-id={id}
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            key={id}
-                            ref={ref}
-                        />
-                    </AnimatePresence>
-                )
-            }
-
-            const { rerender } = render(<Component id={0} />)
-            rerender(<Component id={0} />)
-
-            setTimeout(() => {
-                rerender(<Component id={1} />)
-                rerender(<Component id={1} />)
-                rerender(<Component id={2} />)
-                rerender(<Component id={2} />)
-
-                resolve(ref.current)
-            }, 30)
-        })
-
-        const result = await promise
-        return expect(result).toHaveAttribute("data-id", "2")
-    })
-})
-
-describe("AnimatePresence with custom components", () => {
-    test("Does nothing on initial render by default", async () => {
-        const promise = new Promise(resolve => {
-            const x = motionValue(0)
-
-            const CustomComponent = () => (
-                <motion.div
-                    animate={{ x: 100 }}
-                    style={{ x }}
-                    exit={{ x: 0 }}
-                />
-            )
-
-            const Component = () => {
-                setTimeout(() => resolve(x.get()), 75)
-                return (
-                    <AnimatePresence>
-                        <CustomComponent />
-                    </AnimatePresence>
-                )
-            }
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        const x = await promise
-        expect(x).not.toBe(0)
-        expect(x).not.toBe(100)
-    })
-
-    test("Suppresses initial animation if `initial={false}`", async () => {
-        const promise = new Promise(resolve => {
-            const CustomComponent = () => (
-                <motion.div
-                    initial={{ x: 0 }}
-                    animate={{ x: 100 }}
-                    exit={{ x: 0 }}
-                />
-            )
-
-            const Component = () => {
-                return (
-                    <AnimatePresence initial={false}>
-                        <CustomComponent />
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component />)
-            rerender(<Component />)
-
-            setTimeout(() => {
-                resolve(container.firstChild as Element)
-            }, 50)
-        })
-
-        const element = await promise
-        expect(element).toHaveStyle(
-            "transform: translateX(100px) translateZ(0)"
-        )
-    })
-
-    test("Animates out a component when its removed", async () => {
-        const promise = new Promise<Element | null>(resolve => {
-            const opacity = motionValue(1)
-
-            const CustomComponent = () => (
-                <motion.div
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.1 }}
-                    style={{ opacity }}
-                />
-            )
-            const Component = ({ isVisible }: { isVisible: boolean }) => {
-                return (
-                    <AnimatePresence>
-                        {isVisible && <CustomComponent />}
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-            rerender(<Component isVisible={false} />)
-            rerender(<Component isVisible={false} />)
-
-            // Check it's animating out
-            setTimeout(() => {
-                expect(opacity.get()).not.toBe(1)
-                expect(opacity.get()).not.toBe(0)
-            }, 50)
-
-            // Check it's gone
-            setTimeout(() => {
-                resolve(container.firstChild as Element | null)
-            }, 150)
-        })
-
-        const child = await promise
-        expect(child).toBeFalsy()
-    })
-
-    test("Can cycle through multiple components", async () => {
-        const promise = new Promise<number>(resolve => {
-            const CustomComponent = ({ i }: any) => (
-                <motion.div
-                    key={i}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 1 }}
-                />
-            )
-            const Component = ({ i }: { i: number }) => {
-                return (
-                    <AnimatePresence>
-                        <CustomComponent key={i} i={i} />
-                    </AnimatePresence>
-                )
-            }
-
-            const { container, rerender } = render(<Component i={0} />)
-            rerender(<Component i={0} />)
-            setTimeout(() => {
-                rerender(<Component i={1} />)
-                rerender(<Component i={1} />)
-            }, 50)
-            setTimeout(() => {
-                rerender(<Component i={2} />)
-                rerender(<Component i={2} />)
-            }, 200)
-
-            setTimeout(() => {
-                resolve(container.childElementCount)
-            }, 500)
-        })
-
-        return await expect(promise).resolves.toBe(3)
-    })
-
-    test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
-        const variants = {
-            enter: { x: 0, transition: { type: false } },
-            exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
-        }
-        const x = motionValue(0)
-        const promise = new Promise(resolve => {
-            const CustomComponent = () => (
-                <motion.div
-                    custom={1}
-                    variants={variants}
-                    initial="exit"
-                    animate="enter"
-                    exit="exit"
-                    style={{ x }}
-                />
-            )
-            const Component = ({
-                isVisible,
-                onAnimationComplete,
-            }: {
-                isVisible: boolean
-                onAnimationComplete?: () => void
-            }) => {
-                return (
-                    <AnimatePresence
-                        custom={2}
-                        onExitComplete={onAnimationComplete}
-                    >
-                        {isVisible && <CustomComponent />}
-                    </AnimatePresence>
-                )
-            }
-
-            const { rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-
-            rerender(
-                <Component
-                    isVisible={false}
-                    onAnimationComplete={() => resolve(x.get())}
-                />
-            )
-
-            rerender(
-                <Component
-                    isVisible={false}
-                    onAnimationComplete={() => resolve(x.get())}
-                />
-            )
-        })
-
-        const element = await promise
-        expect(element).toBe(200)
-    })
-
-    test("Exit propagates through variants", async () => {
-        const variants = {
-            enter: { opacity: 1 },
-            exit: { opacity: 0 },
-        }
-
-        const promise = new Promise<number>(resolve => {
-            const opacity = motionValue(1)
-            const Component = ({ isVisible }: { isVisible: boolean }) => {
-                return (
-                    <AnimatePresence>
-                        {isVisible && (
-                            <motion.div
-                                initial="exit"
-                                animate="enter"
-                                exit="exit"
-                                variants={variants}
-                            >
-                                <motion.div variants={variants}>
-                                    <motion.div
-                                        variants={variants}
-                                        style={{ opacity }}
-                                    />
-                                </motion.div>
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
-                )
-            }
-
-            const { rerender } = render(<Component isVisible />)
-            rerender(<Component isVisible />)
-            rerender(<Component isVisible={false} />)
-            rerender(<Component isVisible={false} />)
-
-            resolve(opacity.get())
-        })
-
-        return await expect(promise).resolves.toBe(0)
-    })
+    //     test("Suppresses initial animation if `initial={false}`", async () => {
+    //         const promise = new Promise(resolve => {
+    //             const Component = () => {
+    //                 return (
+    //                     <AnimatePresence initial={false}>
+    //                         <motion.div
+    //                             initial={{ x: 0 }}
+    //                             animate={{ x: 100 }}
+    //                             exit={{ opacity: 0 }}
+    //                         />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component />)
+    //             rerender(<Component />)
+
+    //             setTimeout(() => {
+    //                 resolve(container.firstChild as Element)
+    //             }, 50)
+    //         })
+
+    //         const element = await promise
+    //         expect(element).toHaveStyle(
+    //             "transform: translateX(100px) translateZ(0)"
+    //         )
+    //     })
+
+    //     test("Animates out a component when its removed", async () => {
+    //         const promise = new Promise<Element | null>(resolve => {
+    //             const opacity = motionValue(1)
+    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         {isVisible && (
+    //                             <motion.div
+    //                                 exit={{ opacity: 0 }}
+    //                                 transition={{ duration: 0.1 }}
+    //                                 style={{ opacity }}
+    //                             />
+    //                         )}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+    //             rerender(<Component isVisible={false} />)
+    //             rerender(<Component isVisible={false} />)
+
+    //             // Check it's animating out
+    //             setTimeout(() => {
+    //                 expect(opacity.get()).not.toBe(1)
+    //                 expect(opacity.get()).not.toBe(0)
+    //             }, 50)
+
+    //             // Check it's gone
+    //             setTimeout(() => {
+    //                 resolve(container.firstChild as Element | null)
+    //             }, 150)
+    //         })
+
+    //         const child = await promise
+    //         expect(child).toBeFalsy()
+    //     })
+
+    //     test("Animates a component back in if it's re-added before animating out", async () => {
+    //         const promise = new Promise<Element | null>(resolve => {
+    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         {isVisible && (
+    //                             <motion.div
+    //                                 animate={{ opacity: 1 }}
+    //                                 exit={{ opacity: 0 }}
+    //                                 transition={{ duration: 0.1 }}
+    //                             />
+    //                         )}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+
+    //             setTimeout(() => {
+    //                 rerender(<Component isVisible={false} />)
+    //                 rerender(<Component isVisible={false} />)
+
+    //                 setTimeout(() => {
+    //                     rerender(<Component isVisible />)
+    //                     rerender(<Component isVisible />)
+
+    //                     setTimeout(() => {
+    //                         resolve(container.firstChild as Element | null)
+    //                     }, 150)
+    //                 }, 50)
+    //             }, 50)
+    //         })
+
+    //         const child = await promise
+    //         expect(child).toHaveStyle("opacity: 1;")
+    //     })
+
+    //     test("Animates a component out after having an animation cancelled", async () => {
+    //         const promise = new Promise<Element | null>(resolve => {
+    //             const opacity = motionValue(1)
+    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         {isVisible && (
+    //                             <motion.div
+    //                                 exit={{ opacity: 0 }}
+    //                                 transition={{ duration: 0.1 }}
+    //                                 style={{ opacity }}
+    //                             />
+    //                         )}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+    //             rerender(<Component isVisible={false} />)
+    //             rerender(<Component isVisible={false} />)
+    //             rerender(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+    //             rerender(<Component isVisible={false} />)
+    //             rerender(<Component isVisible={false} />)
+
+    //             // Check it's animating out
+    //             setTimeout(() => {
+    //                 expect(opacity.get()).not.toBe(1)
+    //                 expect(opacity.get()).not.toBe(0)
+    //             }, 50)
+
+    //             // Check it's gone
+    //             setTimeout(() => {
+    //                 resolve(container.firstChild as Element | null)
+    //             }, 300)
+    //         })
+
+    //         const child = await promise
+    //         expect(child).toBeFalsy()
+    //     })
+
+    //     test("Can cycle through multiple components", async () => {
+    //         const promise = new Promise<number>(resolve => {
+    //             const Component = ({ i }: { i: number }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         <motion.div
+    //                             key={i}
+    //                             animate={{ opacity: 1 }}
+    //                             exit={{ opacity: 0 }}
+    //                             transition={{ duration: 0.5 }}
+    //                         />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component i={0} />)
+    //             rerender(<Component i={0} />)
+    //             setTimeout(() => {
+    //                 rerender(<Component i={1} />)
+    //                 rerender(<Component i={1} />)
+    //             }, 50)
+    //             setTimeout(() => {
+    //                 rerender(<Component i={2} />)
+    //                 rerender(<Component i={2} />)
+    //                 resolve(container.childElementCount)
+    //             }, 400)
+    //         })
+
+    //         return await expect(promise).resolves.toBe(3)
+    //     })
+
+    //     test("Only renders one child at a time if exitBeforeEnter={true}", async () => {
+    //         const promise = new Promise<number>(resolve => {
+    //             const Component = ({ i }: { i: number }) => {
+    //                 return (
+    //                     <AnimatePresence exitBeforeEnter>
+    //                         <motion.div
+    //                             key={i}
+    //                             animate={{ opacity: 1 }}
+    //                             exit={{ opacity: 0 }}
+    //                             transition={{ duration: 0.5 }}
+    //                         />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component i={0} />)
+    //             rerender(<Component i={0} />)
+    //             setTimeout(() => {
+    //                 rerender(<Component i={1} />)
+    //                 rerender(<Component i={1} />)
+    //             }, 50)
+    //             setTimeout(() => {
+    //                 rerender(<Component i={2} />)
+    //                 rerender(<Component i={2} />)
+    //                 resolve(container.childElementCount)
+    //             }, 150)
+    //         })
+
+    //         return await expect(promise).resolves.toBe(1)
+    //     })
+
+    //     test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
+    //         const variants = {
+    //             enter: { x: 0, transition: { type: false } },
+    //             exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
+    //         }
+    //         const promise = new Promise(resolve => {
+    //             const x = motionValue(0)
+    //             const Component = ({
+    //                 isVisible,
+    //                 onAnimationComplete,
+    //             }: {
+    //                 isVisible: boolean
+    //                 onAnimationComplete?: () => void
+    //             }) => {
+    //                 return (
+    //                     <AnimatePresence
+    //                         custom={2}
+    //                         onExitComplete={onAnimationComplete}
+    //                     >
+    //                         {isVisible && (
+    //                             <motion.div
+    //                                 custom={1}
+    //                                 variants={variants}
+    //                                 initial="exit"
+    //                                 animate="enter"
+    //                                 exit="exit"
+    //                                 style={{ x }}
+    //                             />
+    //                         )}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+
+    //             rerender(
+    //                 <Component
+    //                     isVisible={false}
+    //                     onAnimationComplete={() => resolve(x.get())}
+    //                 />
+    //             )
+
+    //             rerender(
+    //                 <Component
+    //                     isVisible={false}
+    //                     onAnimationComplete={() => resolve(x.get())}
+    //                 />
+    //             )
+    //         })
+
+    //         const resolvedX = await promise
+    //         expect(resolvedX).toBe(200)
+    //     })
+
+    //     test("Exit propagates through variants", async () => {
+    //         const variants = {
+    //             enter: { opacity: 1, transition: { type: false } },
+    //             exit: { opacity: 0, transition: { type: false } },
+    //         }
+
+    //         const promise = new Promise<number>(resolve => {
+    //             const opacity = motionValue(1)
+    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         {isVisible && (
+    //                             <motion.div
+    //                                 initial="enter"
+    //                                 animate="enter"
+    //                                 exit="exit"
+    //                                 variants={variants}
+    //                             >
+    //                                 <motion.div variants={variants}>
+    //                                     <motion.div
+    //                                         variants={variants}
+    //                                         style={{ opacity }}
+    //                                     />
+    //                                 </motion.div>
+    //                             </motion.div>
+    //                         )}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { rerender } = render(<Component isVisible />)
+
+    //             rerender(<Component isVisible={false} />)
+
+    //             resolve(opacity.get())
+    //         })
+
+    //         return await expect(promise).resolves.toBe(0)
+    //     })
+
+    //     test("Handles external refs on a single child", async () => {
+    //         const promise = new Promise(resolve => {
+    //             const ref = React.createRef<HTMLDivElement>()
+    //             const Component = ({ id }: { id: number }) => {
+    //                 return (
+    //                     <AnimatePresence initial={false}>
+    //                         <motion.div
+    //                             data-id={id}
+    //                             initial={{ opacity: 0 }}
+    //                             animate={{ opacity: 1 }}
+    //                             exit={{ opacity: 0 }}
+    //                             key={id}
+    //                             ref={ref}
+    //                         />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { rerender } = render(<Component id={0} />)
+    //             rerender(<Component id={0} />)
+
+    //             setTimeout(() => {
+    //                 rerender(<Component id={1} />)
+    //                 rerender(<Component id={1} />)
+    //                 rerender(<Component id={2} />)
+    //                 rerender(<Component id={2} />)
+
+    //                 resolve(ref.current)
+    //             }, 30)
+    //         })
+
+    //         const result = await promise
+    //         return expect(result).toHaveAttribute("data-id", "2")
+    //     })
+    // })
+
+    // describe("AnimatePresence with custom components", () => {
+    //     test("Does nothing on initial render by default", async () => {
+    //         const promise = new Promise(resolve => {
+    //             const x = motionValue(0)
+
+    //             const CustomComponent = () => (
+    //                 <motion.div
+    //                     animate={{ x: 100 }}
+    //                     style={{ x }}
+    //                     exit={{ x: 0 }}
+    //                 />
+    //             )
+
+    //             const Component = () => {
+    //                 setTimeout(() => resolve(x.get()), 75)
+    //                 return (
+    //                     <AnimatePresence>
+    //                         <CustomComponent />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { rerender } = render(<Component />)
+    //             rerender(<Component />)
+    //         })
+
+    //         const x = await promise
+    //         expect(x).not.toBe(0)
+    //         expect(x).not.toBe(100)
+    //     })
+
+    //     test("Suppresses initial animation if `initial={false}`", async () => {
+    //         const promise = new Promise(resolve => {
+    //             const CustomComponent = () => (
+    //                 <motion.div
+    //                     initial={{ x: 0 }}
+    //                     animate={{ x: 100 }}
+    //                     exit={{ x: 0 }}
+    //                 />
+    //             )
+
+    //             const Component = () => {
+    //                 return (
+    //                     <AnimatePresence initial={false}>
+    //                         <CustomComponent />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component />)
+    //             rerender(<Component />)
+
+    //             setTimeout(() => {
+    //                 resolve(container.firstChild as Element)
+    //             }, 50)
+    //         })
+
+    //         const element = await promise
+    //         expect(element).toHaveStyle(
+    //             "transform: translateX(100px) translateZ(0)"
+    //         )
+    //     })
+
+    //     test("Animates out a component when its removed", async () => {
+    //         const promise = new Promise<Element | null>(resolve => {
+    //             const opacity = motionValue(1)
+
+    //             const CustomComponent = () => (
+    //                 <motion.div
+    //                     exit={{ opacity: 0 }}
+    //                     transition={{ duration: 0.1 }}
+    //                     style={{ opacity }}
+    //                 />
+    //             )
+    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         {isVisible && <CustomComponent />}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+    //             rerender(<Component isVisible={false} />)
+    //             rerender(<Component isVisible={false} />)
+
+    //             // Check it's animating out
+    //             setTimeout(() => {
+    //                 expect(opacity.get()).not.toBe(1)
+    //                 expect(opacity.get()).not.toBe(0)
+    //             }, 50)
+
+    //             // Check it's gone
+    //             setTimeout(() => {
+    //                 resolve(container.firstChild as Element | null)
+    //             }, 150)
+    //         })
+
+    //         const child = await promise
+    //         expect(child).toBeFalsy()
+    //     })
+
+    //     test("Can cycle through multiple components", async () => {
+    //         const promise = new Promise<number>(resolve => {
+    //             const CustomComponent = ({ i }: any) => (
+    //                 <motion.div
+    //                     key={i}
+    //                     animate={{ opacity: 1 }}
+    //                     exit={{ opacity: 0 }}
+    //                     transition={{ duration: 1 }}
+    //                 />
+    //             )
+    //             const Component = ({ i }: { i: number }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         <CustomComponent key={i} i={i} />
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { container, rerender } = render(<Component i={0} />)
+    //             rerender(<Component i={0} />)
+    //             setTimeout(() => {
+    //                 rerender(<Component i={1} />)
+    //                 rerender(<Component i={1} />)
+    //             }, 50)
+    //             setTimeout(() => {
+    //                 rerender(<Component i={2} />)
+    //                 rerender(<Component i={2} />)
+    //             }, 200)
+
+    //             setTimeout(() => {
+    //                 resolve(container.childElementCount)
+    //             }, 500)
+    //         })
+
+    //         return await expect(promise).resolves.toBe(3)
+    //     })
+
+    //     test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
+    //         const variants = {
+    //             enter: { x: 0, transition: { type: false } },
+    //             exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
+    //         }
+    //         const x = motionValue(0)
+    //         const promise = new Promise(resolve => {
+    //             const CustomComponent = () => (
+    //                 <motion.div
+    //                     custom={1}
+    //                     variants={variants}
+    //                     initial="exit"
+    //                     animate="enter"
+    //                     exit="exit"
+    //                     style={{ x }}
+    //                 />
+    //             )
+    //             const Component = ({
+    //                 isVisible,
+    //                 onAnimationComplete,
+    //             }: {
+    //                 isVisible: boolean
+    //                 onAnimationComplete?: () => void
+    //             }) => {
+    //                 return (
+    //                     <AnimatePresence
+    //                         custom={2}
+    //                         onExitComplete={onAnimationComplete}
+    //                     >
+    //                         {isVisible && <CustomComponent />}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+
+    //             rerender(
+    //                 <Component
+    //                     isVisible={false}
+    //                     onAnimationComplete={() => resolve(x.get())}
+    //                 />
+    //             )
+
+    //             rerender(
+    //                 <Component
+    //                     isVisible={false}
+    //                     onAnimationComplete={() => resolve(x.get())}
+    //                 />
+    //             )
+    //         })
+
+    //         const element = await promise
+    //         expect(element).toBe(200)
+    //     })
+
+    //     test("Exit propagates through variants", async () => {
+    //         const variants = {
+    //             enter: { opacity: 1 },
+    //             exit: { opacity: 0 },
+    //         }
+
+    //         const promise = new Promise<number>(resolve => {
+    //             const opacity = motionValue(1)
+    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
+    //                 return (
+    //                     <AnimatePresence>
+    //                         {isVisible && (
+    //                             <motion.div
+    //                                 initial="exit"
+    //                                 animate="enter"
+    //                                 exit="exit"
+    //                                 variants={variants}
+    //                             >
+    //                                 <motion.div variants={variants}>
+    //                                     <motion.div
+    //                                         variants={variants}
+    //                                         style={{ opacity }}
+    //                                     />
+    //                                 </motion.div>
+    //                             </motion.div>
+    //                         )}
+    //                     </AnimatePresence>
+    //                 )
+    //             }
+
+    //             const { rerender } = render(<Component isVisible />)
+    //             rerender(<Component isVisible />)
+    //             rerender(<Component isVisible={false} />)
+    //             rerender(<Component isVisible={false} />)
+
+    //             resolve(opacity.get())
+    //         })
+
+    //         return await expect(promise).resolves.toBe(0)
+    //     })
 })

--- a/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -29,579 +29,579 @@ describe("AnimatePresence", () => {
         expect(x).not.toBe(100)
     })
 
-    //     test("Suppresses initial animation if `initial={false}`", async () => {
-    //         const promise = new Promise(resolve => {
-    //             const Component = () => {
-    //                 return (
-    //                     <AnimatePresence initial={false}>
-    //                         <motion.div
-    //                             initial={{ x: 0 }}
-    //                             animate={{ x: 100 }}
-    //                             exit={{ opacity: 0 }}
-    //                         />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component />)
-    //             rerender(<Component />)
-
-    //             setTimeout(() => {
-    //                 resolve(container.firstChild as Element)
-    //             }, 50)
-    //         })
-
-    //         const element = await promise
-    //         expect(element).toHaveStyle(
-    //             "transform: translateX(100px) translateZ(0)"
-    //         )
-    //     })
-
-    //     test("Animates out a component when its removed", async () => {
-    //         const promise = new Promise<Element | null>(resolve => {
-    //             const opacity = motionValue(1)
-    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         {isVisible && (
-    //                             <motion.div
-    //                                 exit={{ opacity: 0 }}
-    //                                 transition={{ duration: 0.1 }}
-    //                                 style={{ opacity }}
-    //                             />
-    //                         )}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-    //             rerender(<Component isVisible={false} />)
-    //             rerender(<Component isVisible={false} />)
-
-    //             // Check it's animating out
-    //             setTimeout(() => {
-    //                 expect(opacity.get()).not.toBe(1)
-    //                 expect(opacity.get()).not.toBe(0)
-    //             }, 50)
-
-    //             // Check it's gone
-    //             setTimeout(() => {
-    //                 resolve(container.firstChild as Element | null)
-    //             }, 150)
-    //         })
-
-    //         const child = await promise
-    //         expect(child).toBeFalsy()
-    //     })
-
-    //     test("Animates a component back in if it's re-added before animating out", async () => {
-    //         const promise = new Promise<Element | null>(resolve => {
-    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         {isVisible && (
-    //                             <motion.div
-    //                                 animate={{ opacity: 1 }}
-    //                                 exit={{ opacity: 0 }}
-    //                                 transition={{ duration: 0.1 }}
-    //                             />
-    //                         )}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-
-    //             setTimeout(() => {
-    //                 rerender(<Component isVisible={false} />)
-    //                 rerender(<Component isVisible={false} />)
-
-    //                 setTimeout(() => {
-    //                     rerender(<Component isVisible />)
-    //                     rerender(<Component isVisible />)
-
-    //                     setTimeout(() => {
-    //                         resolve(container.firstChild as Element | null)
-    //                     }, 150)
-    //                 }, 50)
-    //             }, 50)
-    //         })
-
-    //         const child = await promise
-    //         expect(child).toHaveStyle("opacity: 1;")
-    //     })
-
-    //     test("Animates a component out after having an animation cancelled", async () => {
-    //         const promise = new Promise<Element | null>(resolve => {
-    //             const opacity = motionValue(1)
-    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         {isVisible && (
-    //                             <motion.div
-    //                                 exit={{ opacity: 0 }}
-    //                                 transition={{ duration: 0.1 }}
-    //                                 style={{ opacity }}
-    //                             />
-    //                         )}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-    //             rerender(<Component isVisible={false} />)
-    //             rerender(<Component isVisible={false} />)
-    //             rerender(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-    //             rerender(<Component isVisible={false} />)
-    //             rerender(<Component isVisible={false} />)
-
-    //             // Check it's animating out
-    //             setTimeout(() => {
-    //                 expect(opacity.get()).not.toBe(1)
-    //                 expect(opacity.get()).not.toBe(0)
-    //             }, 50)
-
-    //             // Check it's gone
-    //             setTimeout(() => {
-    //                 resolve(container.firstChild as Element | null)
-    //             }, 300)
-    //         })
-
-    //         const child = await promise
-    //         expect(child).toBeFalsy()
-    //     })
-
-    //     test("Can cycle through multiple components", async () => {
-    //         const promise = new Promise<number>(resolve => {
-    //             const Component = ({ i }: { i: number }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         <motion.div
-    //                             key={i}
-    //                             animate={{ opacity: 1 }}
-    //                             exit={{ opacity: 0 }}
-    //                             transition={{ duration: 0.5 }}
-    //                         />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component i={0} />)
-    //             rerender(<Component i={0} />)
-    //             setTimeout(() => {
-    //                 rerender(<Component i={1} />)
-    //                 rerender(<Component i={1} />)
-    //             }, 50)
-    //             setTimeout(() => {
-    //                 rerender(<Component i={2} />)
-    //                 rerender(<Component i={2} />)
-    //                 resolve(container.childElementCount)
-    //             }, 400)
-    //         })
-
-    //         return await expect(promise).resolves.toBe(3)
-    //     })
-
-    //     test("Only renders one child at a time if exitBeforeEnter={true}", async () => {
-    //         const promise = new Promise<number>(resolve => {
-    //             const Component = ({ i }: { i: number }) => {
-    //                 return (
-    //                     <AnimatePresence exitBeforeEnter>
-    //                         <motion.div
-    //                             key={i}
-    //                             animate={{ opacity: 1 }}
-    //                             exit={{ opacity: 0 }}
-    //                             transition={{ duration: 0.5 }}
-    //                         />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component i={0} />)
-    //             rerender(<Component i={0} />)
-    //             setTimeout(() => {
-    //                 rerender(<Component i={1} />)
-    //                 rerender(<Component i={1} />)
-    //             }, 50)
-    //             setTimeout(() => {
-    //                 rerender(<Component i={2} />)
-    //                 rerender(<Component i={2} />)
-    //                 resolve(container.childElementCount)
-    //             }, 150)
-    //         })
-
-    //         return await expect(promise).resolves.toBe(1)
-    //     })
-
-    //     test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
-    //         const variants = {
-    //             enter: { x: 0, transition: { type: false } },
-    //             exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
-    //         }
-    //         const promise = new Promise(resolve => {
-    //             const x = motionValue(0)
-    //             const Component = ({
-    //                 isVisible,
-    //                 onAnimationComplete,
-    //             }: {
-    //                 isVisible: boolean
-    //                 onAnimationComplete?: () => void
-    //             }) => {
-    //                 return (
-    //                     <AnimatePresence
-    //                         custom={2}
-    //                         onExitComplete={onAnimationComplete}
-    //                     >
-    //                         {isVisible && (
-    //                             <motion.div
-    //                                 custom={1}
-    //                                 variants={variants}
-    //                                 initial="exit"
-    //                                 animate="enter"
-    //                                 exit="exit"
-    //                                 style={{ x }}
-    //                             />
-    //                         )}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-
-    //             rerender(
-    //                 <Component
-    //                     isVisible={false}
-    //                     onAnimationComplete={() => resolve(x.get())}
-    //                 />
-    //             )
-
-    //             rerender(
-    //                 <Component
-    //                     isVisible={false}
-    //                     onAnimationComplete={() => resolve(x.get())}
-    //                 />
-    //             )
-    //         })
-
-    //         const resolvedX = await promise
-    //         expect(resolvedX).toBe(200)
-    //     })
-
-    //     test("Exit propagates through variants", async () => {
-    //         const variants = {
-    //             enter: { opacity: 1, transition: { type: false } },
-    //             exit: { opacity: 0, transition: { type: false } },
-    //         }
-
-    //         const promise = new Promise<number>(resolve => {
-    //             const opacity = motionValue(1)
-    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         {isVisible && (
-    //                             <motion.div
-    //                                 initial="enter"
-    //                                 animate="enter"
-    //                                 exit="exit"
-    //                                 variants={variants}
-    //                             >
-    //                                 <motion.div variants={variants}>
-    //                                     <motion.div
-    //                                         variants={variants}
-    //                                         style={{ opacity }}
-    //                                     />
-    //                                 </motion.div>
-    //                             </motion.div>
-    //                         )}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { rerender } = render(<Component isVisible />)
-
-    //             rerender(<Component isVisible={false} />)
-
-    //             resolve(opacity.get())
-    //         })
-
-    //         return await expect(promise).resolves.toBe(0)
-    //     })
-
-    //     test("Handles external refs on a single child", async () => {
-    //         const promise = new Promise(resolve => {
-    //             const ref = React.createRef<HTMLDivElement>()
-    //             const Component = ({ id }: { id: number }) => {
-    //                 return (
-    //                     <AnimatePresence initial={false}>
-    //                         <motion.div
-    //                             data-id={id}
-    //                             initial={{ opacity: 0 }}
-    //                             animate={{ opacity: 1 }}
-    //                             exit={{ opacity: 0 }}
-    //                             key={id}
-    //                             ref={ref}
-    //                         />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { rerender } = render(<Component id={0} />)
-    //             rerender(<Component id={0} />)
-
-    //             setTimeout(() => {
-    //                 rerender(<Component id={1} />)
-    //                 rerender(<Component id={1} />)
-    //                 rerender(<Component id={2} />)
-    //                 rerender(<Component id={2} />)
-
-    //                 resolve(ref.current)
-    //             }, 30)
-    //         })
-
-    //         const result = await promise
-    //         return expect(result).toHaveAttribute("data-id", "2")
-    //     })
-    // })
-
-    // describe("AnimatePresence with custom components", () => {
-    //     test("Does nothing on initial render by default", async () => {
-    //         const promise = new Promise(resolve => {
-    //             const x = motionValue(0)
-
-    //             const CustomComponent = () => (
-    //                 <motion.div
-    //                     animate={{ x: 100 }}
-    //                     style={{ x }}
-    //                     exit={{ x: 0 }}
-    //                 />
-    //             )
-
-    //             const Component = () => {
-    //                 setTimeout(() => resolve(x.get()), 75)
-    //                 return (
-    //                     <AnimatePresence>
-    //                         <CustomComponent />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { rerender } = render(<Component />)
-    //             rerender(<Component />)
-    //         })
-
-    //         const x = await promise
-    //         expect(x).not.toBe(0)
-    //         expect(x).not.toBe(100)
-    //     })
-
-    //     test("Suppresses initial animation if `initial={false}`", async () => {
-    //         const promise = new Promise(resolve => {
-    //             const CustomComponent = () => (
-    //                 <motion.div
-    //                     initial={{ x: 0 }}
-    //                     animate={{ x: 100 }}
-    //                     exit={{ x: 0 }}
-    //                 />
-    //             )
-
-    //             const Component = () => {
-    //                 return (
-    //                     <AnimatePresence initial={false}>
-    //                         <CustomComponent />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component />)
-    //             rerender(<Component />)
-
-    //             setTimeout(() => {
-    //                 resolve(container.firstChild as Element)
-    //             }, 50)
-    //         })
-
-    //         const element = await promise
-    //         expect(element).toHaveStyle(
-    //             "transform: translateX(100px) translateZ(0)"
-    //         )
-    //     })
-
-    //     test("Animates out a component when its removed", async () => {
-    //         const promise = new Promise<Element | null>(resolve => {
-    //             const opacity = motionValue(1)
-
-    //             const CustomComponent = () => (
-    //                 <motion.div
-    //                     exit={{ opacity: 0 }}
-    //                     transition={{ duration: 0.1 }}
-    //                     style={{ opacity }}
-    //                 />
-    //             )
-    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         {isVisible && <CustomComponent />}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-    //             rerender(<Component isVisible={false} />)
-    //             rerender(<Component isVisible={false} />)
-
-    //             // Check it's animating out
-    //             setTimeout(() => {
-    //                 expect(opacity.get()).not.toBe(1)
-    //                 expect(opacity.get()).not.toBe(0)
-    //             }, 50)
-
-    //             // Check it's gone
-    //             setTimeout(() => {
-    //                 resolve(container.firstChild as Element | null)
-    //             }, 150)
-    //         })
-
-    //         const child = await promise
-    //         expect(child).toBeFalsy()
-    //     })
-
-    //     test("Can cycle through multiple components", async () => {
-    //         const promise = new Promise<number>(resolve => {
-    //             const CustomComponent = ({ i }: any) => (
-    //                 <motion.div
-    //                     key={i}
-    //                     animate={{ opacity: 1 }}
-    //                     exit={{ opacity: 0 }}
-    //                     transition={{ duration: 1 }}
-    //                 />
-    //             )
-    //             const Component = ({ i }: { i: number }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         <CustomComponent key={i} i={i} />
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { container, rerender } = render(<Component i={0} />)
-    //             rerender(<Component i={0} />)
-    //             setTimeout(() => {
-    //                 rerender(<Component i={1} />)
-    //                 rerender(<Component i={1} />)
-    //             }, 50)
-    //             setTimeout(() => {
-    //                 rerender(<Component i={2} />)
-    //                 rerender(<Component i={2} />)
-    //             }, 200)
-
-    //             setTimeout(() => {
-    //                 resolve(container.childElementCount)
-    //             }, 500)
-    //         })
-
-    //         return await expect(promise).resolves.toBe(3)
-    //     })
-
-    //     test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
-    //         const variants = {
-    //             enter: { x: 0, transition: { type: false } },
-    //             exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
-    //         }
-    //         const x = motionValue(0)
-    //         const promise = new Promise(resolve => {
-    //             const CustomComponent = () => (
-    //                 <motion.div
-    //                     custom={1}
-    //                     variants={variants}
-    //                     initial="exit"
-    //                     animate="enter"
-    //                     exit="exit"
-    //                     style={{ x }}
-    //                 />
-    //             )
-    //             const Component = ({
-    //                 isVisible,
-    //                 onAnimationComplete,
-    //             }: {
-    //                 isVisible: boolean
-    //                 onAnimationComplete?: () => void
-    //             }) => {
-    //                 return (
-    //                     <AnimatePresence
-    //                         custom={2}
-    //                         onExitComplete={onAnimationComplete}
-    //                     >
-    //                         {isVisible && <CustomComponent />}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-
-    //             rerender(
-    //                 <Component
-    //                     isVisible={false}
-    //                     onAnimationComplete={() => resolve(x.get())}
-    //                 />
-    //             )
-
-    //             rerender(
-    //                 <Component
-    //                     isVisible={false}
-    //                     onAnimationComplete={() => resolve(x.get())}
-    //                 />
-    //             )
-    //         })
-
-    //         const element = await promise
-    //         expect(element).toBe(200)
-    //     })
-
-    //     test("Exit propagates through variants", async () => {
-    //         const variants = {
-    //             enter: { opacity: 1 },
-    //             exit: { opacity: 0 },
-    //         }
-
-    //         const promise = new Promise<number>(resolve => {
-    //             const opacity = motionValue(1)
-    //             const Component = ({ isVisible }: { isVisible: boolean }) => {
-    //                 return (
-    //                     <AnimatePresence>
-    //                         {isVisible && (
-    //                             <motion.div
-    //                                 initial="exit"
-    //                                 animate="enter"
-    //                                 exit="exit"
-    //                                 variants={variants}
-    //                             >
-    //                                 <motion.div variants={variants}>
-    //                                     <motion.div
-    //                                         variants={variants}
-    //                                         style={{ opacity }}
-    //                                     />
-    //                                 </motion.div>
-    //                             </motion.div>
-    //                         )}
-    //                     </AnimatePresence>
-    //                 )
-    //             }
-
-    //             const { rerender } = render(<Component isVisible />)
-    //             rerender(<Component isVisible />)
-    //             rerender(<Component isVisible={false} />)
-    //             rerender(<Component isVisible={false} />)
-
-    //             resolve(opacity.get())
-    //         })
-
-    //         return await expect(promise).resolves.toBe(0)
-    //     })
+    test("Suppresses initial animation if `initial={false}`", async () => {
+        const promise = new Promise(resolve => {
+            const Component = () => {
+                return (
+                    <AnimatePresence initial={false}>
+                        <motion.div
+                            initial={{ x: 0 }}
+                            animate={{ x: 100 }}
+                            exit={{ opacity: 0 }}
+                        />
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+
+            setTimeout(() => {
+                resolve(container.firstChild as Element)
+            }, 50)
+        })
+
+        const element = await promise
+        expect(element).toHaveStyle(
+            "transform: translateX(100px) translateZ(0)"
+        )
+    })
+
+    test("Animates out a component when its removed", async () => {
+        const promise = new Promise<Element | null>(resolve => {
+            const opacity = motionValue(1)
+            const Component = ({ isVisible }: { isVisible: boolean }) => {
+                return (
+                    <AnimatePresence>
+                        {isVisible && (
+                            <motion.div
+                                exit={{ opacity: 0 }}
+                                transition={{ duration: 0.1 }}
+                                style={{ opacity }}
+                            />
+                        )}
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+            rerender(<Component isVisible={false} />)
+            rerender(<Component isVisible={false} />)
+
+            // Check it's animating out
+            setTimeout(() => {
+                expect(opacity.get()).not.toBe(1)
+                expect(opacity.get()).not.toBe(0)
+            }, 50)
+
+            // Check it's gone
+            setTimeout(() => {
+                resolve(container.firstChild as Element | null)
+            }, 150)
+        })
+
+        const child = await promise
+        expect(child).toBeFalsy()
+    })
+
+    test("Animates a component back in if it's re-added before animating out", async () => {
+        const promise = new Promise<Element | null>(resolve => {
+            const Component = ({ isVisible }: { isVisible: boolean }) => {
+                return (
+                    <AnimatePresence>
+                        {isVisible && (
+                            <motion.div
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={{ duration: 0.1 }}
+                            />
+                        )}
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+
+            setTimeout(() => {
+                rerender(<Component isVisible={false} />)
+                rerender(<Component isVisible={false} />)
+
+                setTimeout(() => {
+                    rerender(<Component isVisible />)
+                    rerender(<Component isVisible />)
+
+                    setTimeout(() => {
+                        resolve(container.firstChild as Element | null)
+                    }, 150)
+                }, 50)
+            }, 50)
+        })
+
+        const child = await promise
+        expect(child).toHaveStyle("opacity: 1;")
+    })
+
+    test("Animates a component out after having an animation cancelled", async () => {
+        const promise = new Promise<Element | null>(resolve => {
+            const opacity = motionValue(1)
+            const Component = ({ isVisible }: { isVisible: boolean }) => {
+                return (
+                    <AnimatePresence>
+                        {isVisible && (
+                            <motion.div
+                                exit={{ opacity: 0 }}
+                                transition={{ duration: 0.1 }}
+                                style={{ opacity }}
+                            />
+                        )}
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+            rerender(<Component isVisible={false} />)
+            rerender(<Component isVisible={false} />)
+            rerender(<Component isVisible />)
+            rerender(<Component isVisible />)
+            rerender(<Component isVisible={false} />)
+            rerender(<Component isVisible={false} />)
+
+            // Check it's animating out
+            setTimeout(() => {
+                expect(opacity.get()).not.toBe(1)
+                expect(opacity.get()).not.toBe(0)
+            }, 50)
+
+            // Check it's gone
+            setTimeout(() => {
+                resolve(container.firstChild as Element | null)
+            }, 300)
+        })
+
+        const child = await promise
+        expect(child).toBeFalsy()
+    })
+
+    test("Can cycle through multiple components", async () => {
+        const promise = new Promise<number>(resolve => {
+            const Component = ({ i }: { i: number }) => {
+                return (
+                    <AnimatePresence>
+                        <motion.div
+                            key={i}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ duration: 0.5 }}
+                        />
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component i={0} />)
+            rerender(<Component i={0} />)
+            setTimeout(() => {
+                rerender(<Component i={1} />)
+                rerender(<Component i={1} />)
+            }, 50)
+            setTimeout(() => {
+                rerender(<Component i={2} />)
+                rerender(<Component i={2} />)
+                resolve(container.childElementCount)
+            }, 400)
+        })
+
+        return await expect(promise).resolves.toBe(3)
+    })
+
+    test("Only renders one child at a time if exitBeforeEnter={true}", async () => {
+        const promise = new Promise<number>(resolve => {
+            const Component = ({ i }: { i: number }) => {
+                return (
+                    <AnimatePresence exitBeforeEnter>
+                        <motion.div
+                            key={i}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ duration: 0.5 }}
+                        />
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component i={0} />)
+            rerender(<Component i={0} />)
+            setTimeout(() => {
+                rerender(<Component i={1} />)
+                rerender(<Component i={1} />)
+            }, 50)
+            setTimeout(() => {
+                rerender(<Component i={2} />)
+                rerender(<Component i={2} />)
+                resolve(container.childElementCount)
+            }, 150)
+        })
+
+        return await expect(promise).resolves.toBe(1)
+    })
+
+    test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
+        const variants = {
+            enter: { x: 0, transition: { type: false } },
+            exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
+        }
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const Component = ({
+                isVisible,
+                onAnimationComplete,
+            }: {
+                isVisible: boolean
+                onAnimationComplete?: () => void
+            }) => {
+                return (
+                    <AnimatePresence
+                        custom={2}
+                        onExitComplete={onAnimationComplete}
+                    >
+                        {isVisible && (
+                            <motion.div
+                                custom={1}
+                                variants={variants}
+                                initial="exit"
+                                animate="enter"
+                                exit="exit"
+                                style={{ x }}
+                            />
+                        )}
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+
+            rerender(
+                <Component
+                    isVisible={false}
+                    onAnimationComplete={() => resolve(x.get())}
+                />
+            )
+
+            rerender(
+                <Component
+                    isVisible={false}
+                    onAnimationComplete={() => resolve(x.get())}
+                />
+            )
+        })
+
+        const resolvedX = await promise
+        expect(resolvedX).toBe(200)
+    })
+
+    test("Exit propagates through variants", async () => {
+        const variants = {
+            enter: { opacity: 1, transition: { type: false } },
+            exit: { opacity: 0, transition: { type: false } },
+        }
+
+        const promise = new Promise<number>(resolve => {
+            const opacity = motionValue(1)
+            const Component = ({ isVisible }: { isVisible: boolean }) => {
+                return (
+                    <AnimatePresence>
+                        {isVisible && (
+                            <motion.div
+                                initial="enter"
+                                animate="enter"
+                                exit="exit"
+                                variants={variants}
+                            >
+                                <motion.div variants={variants}>
+                                    <motion.div
+                                        variants={variants}
+                                        style={{ opacity }}
+                                    />
+                                </motion.div>
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component isVisible />)
+
+            rerender(<Component isVisible={false} />)
+
+            resolve(opacity.get())
+        })
+
+        return await expect(promise).resolves.toBe(0)
+    })
+
+    test("Handles external refs on a single child", async () => {
+        const promise = new Promise(resolve => {
+            const ref = React.createRef<HTMLDivElement>()
+            const Component = ({ id }: { id: number }) => {
+                return (
+                    <AnimatePresence initial={false}>
+                        <motion.div
+                            data-id={id}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            key={id}
+                            ref={ref}
+                        />
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component id={0} />)
+            rerender(<Component id={0} />)
+
+            setTimeout(() => {
+                rerender(<Component id={1} />)
+                rerender(<Component id={1} />)
+                rerender(<Component id={2} />)
+                rerender(<Component id={2} />)
+
+                resolve(ref.current)
+            }, 30)
+        })
+
+        const result = await promise
+        return expect(result).toHaveAttribute("data-id", "2")
+    })
+})
+
+describe("AnimatePresence with custom components", () => {
+    test("Does nothing on initial render by default", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+
+            const CustomComponent = () => (
+                <motion.div
+                    animate={{ x: 100 }}
+                    style={{ x }}
+                    exit={{ x: 0 }}
+                />
+            )
+
+            const Component = () => {
+                setTimeout(() => resolve(x.get()), 75)
+                return (
+                    <AnimatePresence>
+                        <CustomComponent />
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        const x = await promise
+        expect(x).not.toBe(0)
+        expect(x).not.toBe(100)
+    })
+
+    test("Suppresses initial animation if `initial={false}`", async () => {
+        const promise = new Promise(resolve => {
+            const CustomComponent = () => (
+                <motion.div
+                    initial={{ x: 0 }}
+                    animate={{ x: 100 }}
+                    exit={{ x: 0 }}
+                />
+            )
+
+            const Component = () => {
+                return (
+                    <AnimatePresence initial={false}>
+                        <CustomComponent />
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+
+            setTimeout(() => {
+                resolve(container.firstChild as Element)
+            }, 50)
+        })
+
+        const element = await promise
+        expect(element).toHaveStyle(
+            "transform: translateX(100px) translateZ(0)"
+        )
+    })
+
+    test("Animates out a component when its removed", async () => {
+        const promise = new Promise<Element | null>(resolve => {
+            const opacity = motionValue(1)
+
+            const CustomComponent = () => (
+                <motion.div
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.1 }}
+                    style={{ opacity }}
+                />
+            )
+            const Component = ({ isVisible }: { isVisible: boolean }) => {
+                return (
+                    <AnimatePresence>
+                        {isVisible && <CustomComponent />}
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+            rerender(<Component isVisible={false} />)
+            rerender(<Component isVisible={false} />)
+
+            // Check it's animating out
+            setTimeout(() => {
+                expect(opacity.get()).not.toBe(1)
+                expect(opacity.get()).not.toBe(0)
+            }, 50)
+
+            // Check it's gone
+            setTimeout(() => {
+                resolve(container.firstChild as Element | null)
+            }, 150)
+        })
+
+        const child = await promise
+        expect(child).toBeFalsy()
+    })
+
+    test("Can cycle through multiple components", async () => {
+        const promise = new Promise<number>(resolve => {
+            const CustomComponent = ({ i }: any) => (
+                <motion.div
+                    key={i}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 1 }}
+                />
+            )
+            const Component = ({ i }: { i: number }) => {
+                return (
+                    <AnimatePresence>
+                        <CustomComponent key={i} i={i} />
+                    </AnimatePresence>
+                )
+            }
+
+            const { container, rerender } = render(<Component i={0} />)
+            rerender(<Component i={0} />)
+            setTimeout(() => {
+                rerender(<Component i={1} />)
+                rerender(<Component i={1} />)
+            }, 50)
+            setTimeout(() => {
+                rerender(<Component i={2} />)
+                rerender(<Component i={2} />)
+            }, 200)
+
+            setTimeout(() => {
+                resolve(container.childElementCount)
+            }, 500)
+        })
+
+        return await expect(promise).resolves.toBe(3)
+    })
+
+    test("Exit variants are triggered with `AnimatePresence.custom`, not that of the element.", async () => {
+        const variants = {
+            enter: { x: 0, transition: { type: false } },
+            exit: (i: number) => ({ x: i * 100, transition: { type: false } }),
+        }
+        const x = motionValue(0)
+        const promise = new Promise(resolve => {
+            const CustomComponent = () => (
+                <motion.div
+                    custom={1}
+                    variants={variants}
+                    initial="exit"
+                    animate="enter"
+                    exit="exit"
+                    style={{ x }}
+                />
+            )
+            const Component = ({
+                isVisible,
+                onAnimationComplete,
+            }: {
+                isVisible: boolean
+                onAnimationComplete?: () => void
+            }) => {
+                return (
+                    <AnimatePresence
+                        custom={2}
+                        onExitComplete={onAnimationComplete}
+                    >
+                        {isVisible && <CustomComponent />}
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+
+            rerender(
+                <Component
+                    isVisible={false}
+                    onAnimationComplete={() => resolve(x.get())}
+                />
+            )
+
+            rerender(
+                <Component
+                    isVisible={false}
+                    onAnimationComplete={() => resolve(x.get())}
+                />
+            )
+        })
+
+        const element = await promise
+        expect(element).toBe(200)
+    })
+
+    test("Exit propagates through variants", async () => {
+        const variants = {
+            enter: { opacity: 1 },
+            exit: { opacity: 0 },
+        }
+
+        const promise = new Promise<number>(resolve => {
+            const opacity = motionValue(1)
+            const Component = ({ isVisible }: { isVisible: boolean }) => {
+                return (
+                    <AnimatePresence>
+                        {isVisible && (
+                            <motion.div
+                                initial="exit"
+                                animate="enter"
+                                exit="exit"
+                                variants={variants}
+                            >
+                                <motion.div variants={variants}>
+                                    <motion.div
+                                        variants={variants}
+                                        style={{ opacity }}
+                                    />
+                                </motion.div>
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                )
+            }
+
+            const { rerender } = render(<Component isVisible />)
+            rerender(<Component isVisible />)
+            rerender(<Component isVisible={false} />)
+            rerender(<Component isVisible={false} />)
+
+            resolve(opacity.get())
+        })
+
+        return await expect(promise).resolves.toBe(0)
+    })
 })

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -111,6 +111,10 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  *
  * You can sequence exit animations throughout a tree using variants.
  *
+ * If a child contains multiple `motion` components with `exit` props, it will only unmount the child
+ * once all `motion` components have finished animating out. Likewise, any components using
+ * `usePresence` all need to call `safeToRemove`.
+ *
  * @public
  */
 export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -1,7 +1,6 @@
 import {
     useContext,
     useRef,
-    useMemo,
     isValidElement,
     cloneElement,
     Children,
@@ -10,10 +9,10 @@ import {
     FunctionComponent,
 } from "react"
 import * as React from "react"
-import { PresenceContext, PresenceContextProps } from "./PresenceContext"
 import { AnimatePresenceProps } from "./types"
 import { SyncLayoutContext } from "../../components/SyncLayout"
 import { useForceUpdate } from "../../utils/use-force-update"
+import { PresenceChild } from "./PresenceChild"
 
 type ComponentKey = string | number
 
@@ -155,7 +154,8 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
                 {filteredChildren.map(child => (
                     <PresenceChild
                         key={getChildKey(child)}
-                        exitProps={initial ? undefined : { initial: false }}
+                        isPresent
+                        initial={initial ? undefined : false}
                     >
                         {child}
                     </PresenceChild>
@@ -218,16 +218,15 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
             }
         }
 
-        const exitProps = {
-            custom,
-            isExiting: true,
-            onExitComplete: onExit,
-        }
-
         childrenToRender.splice(
             insertionIndex,
             0,
-            <PresenceChild key={getChildKey(child)} exitProps={exitProps}>
+            <PresenceChild
+                key={getChildKey(child)}
+                isPresent={false}
+                onExitComplete={onExit}
+                custom={custom}
+            >
                 {child}
             </PresenceChild>
         )
@@ -240,7 +239,9 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
         return exiting.has(key) ? (
             child
         ) : (
-            <PresenceChild key={getChildKey(child)}>{child}</PresenceChild>
+            <PresenceChild key={getChildKey(child)} isPresent>
+                {child}
+            </PresenceChild>
         )
     })
 

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -1,6 +1,7 @@
 import {
     useContext,
     useRef,
+    useMemo,
     isValidElement,
     cloneElement,
     Children,
@@ -9,29 +10,10 @@ import {
     FunctionComponent,
 } from "react"
 import * as React from "react"
+import { PresenceContext, PresenceContextProps } from "./PresenceContext"
 import { AnimatePresenceProps } from "./types"
-import { MotionContext, ExitProps } from "../../motion/context/MotionContext"
 import { SyncLayoutContext } from "../../components/SyncLayout"
 import { useForceUpdate } from "../../utils/use-force-update"
-
-interface PresenceChildProps {
-    children: ReactElement<any>
-    exitProps?: ExitProps | undefined
-}
-
-const PresenceChild = ({ children, exitProps }: PresenceChildProps) => {
-    let context = useContext(MotionContext)
-
-    // Create a new `value` in all instances to ensure `motion` children re-render
-    // and detect any layout changes that might have occurred.
-    context = { ...context, exitProps: exitProps || {} }
-
-    return (
-        <MotionContext.Provider value={context}>
-            {children}
-        </MotionContext.Provider>
-    )
-}
 
 type ComponentKey = string | number
 

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -56,18 +56,14 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
 }
 
 /**
- * The `AnimatePresence` component enables the use of the `exit` prop to animate components
- * when they're removed from the component tree.
+ * `AnimatePresence` enables the animation of components that have been removed from the tree.
  *
- * When adding/removing more than a single child component, every component
- * **must** be given a unique `key` prop.
- *
- * You can propagate exit animations throughout a tree by using variants.
+ * When adding/removing more than a single child, every child **must** be given a unique `key` prop.
  *
  * @library
  *
- * You can use any component(s) within `AnimatePresence`, but the first `Frame` in each should
- * have an `exit` property defined.
+ * Any `Frame` components that have an `exit` property defined will animate out when removed from
+ * the tree.
  *
  * ```jsx
  * import { Frame, AnimatePresence } from 'framer'
@@ -89,10 +85,12 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  * }
  * ```
  *
+ * You can sequence exit animations throughout a tree using variants.
+ *
  * @motion
  *
- * You can use any component(s) within `AnimatePresence`, but the first `motion` component in each should
- * have an `exit` property defined.
+ * Any `motion` components that have an `exit` property defined will animate out when removed from
+ * the tree.
  *
  * ```jsx
  * import { motion, AnimatePresence } from 'framer-motion'
@@ -110,6 +108,8 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  *   </AnimatePresence>
  * )
  * ```
+ *
+ * You can sequence exit animations throughout a tree using variants.
  *
  * @public
  */

--- a/src/components/AnimatePresence/use-presence.ts
+++ b/src/components/AnimatePresence/use-presence.ts
@@ -7,24 +7,25 @@ type Present = [true]
 type NotPresent = [false, () => void]
 
 /**
- * When a component is the child of an `AnimatePresence` component, it has access to
- * information about whether it's still present the React tree. `usePresence` can be
- * used to access that data and perform operations before the component can be considered
- * safe to remove.
- *
- * It returns two values. `isPresent` is a boolean that is `true` when the component
- * is present within the React tree. It is `false` when it's been removed, but still visible.
- *
- * When `isPresent` is `false`, the `safeToRemove` callback can be used to tell `AnimatePresence`
- * that it's safe to remove the component from the DOM, for instance after a animation has completed.
+ * When a component is the child of `AnimatePresence`, it can use `usePresence`
+ * to access information about whether it's still present in the React tree.
  *
  * ```jsx
- * const [isPresent, safeToRemove] = usePresence()
+ * import { usePresence } from "framer-motion"
  *
- * useEffect(() => {
- *   !isPresent setTimeout(safeToRemove, 1000)
- * }, [isPresent])
+ * export const Component = () => {
+ *   const [isPresent, safeToRemove] = usePresence()
+ *
+ *   useEffect(() => {
+ *     !isPresent setTimeout(safeToRemove, 1000)
+ *   }, [isPresent])
+ *
+ *   return <div />
+ * }
  * ```
+ *
+ * If `isPresent` is `false`, it means that a component has been removed the tree, but
+ * `AnimatePresence` won't really remove it until `safeToRemove` has been called.
  *
  * @public
  */

--- a/src/components/AnimatePresence/use-presence.ts
+++ b/src/components/AnimatePresence/use-presence.ts
@@ -1,5 +1,6 @@
-import { useContext } from "react"
-import { MotionContext } from "../../motion/context/MotionContext"
+import { useContext, useEffect } from "react"
+import { PresenceContext } from "./PresenceContext"
+import { warning } from "hey-listen"
 
 type Present = [true]
 
@@ -28,10 +29,16 @@ type NotPresent = [false, () => void]
  * @public
  */
 export function usePresence(): Present | NotPresent {
-    const { exitProps } = useContext(MotionContext)
+    const context = useContext(PresenceContext)
 
-    if (!exitProps) return [true]
+    warning(
+        context !== null,
+        "Component attempting to use presence outside of a AnimatePresence component. It will be removed from the tree without transition."
+    )
+    if (context === null) return [true]
+    const { isPresent, onExitComplete, register } = context
 
-    const { isExiting, onExitComplete } = exitProps
-    return isExiting && onExitComplete ? [false, onExitComplete] : [true]
+    useEffect(register, [])
+
+    return !isPresent && onExitComplete ? [false, onExitComplete] : [true]
 }

--- a/src/motion/component.tsx
+++ b/src/motion/component.tsx
@@ -56,8 +56,7 @@ export const createMotionComponent = <P extends {}>({
         const controls = useValueAnimationControls(
             controlsConfig,
             props,
-            shouldInheritVariant,
-            parentContext
+            shouldInheritVariant
         )
 
         const context = useMotionContext(

--- a/src/motion/context/MotionContext.ts
+++ b/src/motion/context/MotionContext.ts
@@ -1,11 +1,12 @@
 import * as React from "react"
-import { useMemo, useRef, useEffect, RefObject } from "react"
+import { useMemo, useRef, useEffect, RefObject, useContext } from "react"
 import { ValueAnimationControls } from "../../animation/ValueAnimationControls"
 import { VariantLabels, MotionProps } from "../types"
 import { useInitialOrEveryRender } from "../../utils/use-initial-or-every-render"
 import { AnimationControls } from "../../animation/AnimationControls"
 import { Target } from "../../types"
 import { MotionValuesMap } from "../utils/use-motion-values"
+import { PresenceContext } from "../../components/AnimatePresence/PresenceContext"
 
 export interface MotionContextProps {
     controls?: ValueAnimationControls
@@ -14,7 +15,6 @@ export interface MotionContextProps {
     animate?: VariantLabels
     static?: boolean
     hasMounted?: RefObject<boolean>
-    exitProps?: ExitProps
     isReducedMotion?: boolean | undefined
 }
 
@@ -47,12 +47,11 @@ export const useMotionContext = (
     isStatic: boolean = false,
     { initial, animate, variants, whileTap, whileHover }: MotionProps
 ) => {
+    const presenceContext = useContext(PresenceContext)
     // Override initial with that from a parent context, if defined
-    if (
-        parentContext.exitProps &&
-        parentContext.exitProps.initial !== undefined
-    ) {
-        initial = parentContext.exitProps.initial
+    if (presenceContext?.initial !== undefined) {
+        console.log("overwriting initial")
+        initial = presenceContext.initial
     }
 
     let initialState: Target | VariantLabels | undefined

--- a/src/motion/context/MotionContext.ts
+++ b/src/motion/context/MotionContext.ts
@@ -50,7 +50,6 @@ export const useMotionContext = (
     const presenceContext = useContext(PresenceContext)
     // Override initial with that from a parent context, if defined
     if (presenceContext?.initial !== undefined) {
-        console.log("overwriting initial")
         initial = presenceContext.initial
     }
 

--- a/src/motion/context/MotionContext.ts
+++ b/src/motion/context/MotionContext.ts
@@ -7,13 +7,6 @@ import { AnimationControls } from "../../animation/AnimationControls"
 import { Target } from "../../types"
 import { MotionValuesMap } from "../utils/use-motion-values"
 
-export interface ExitProps {
-    initial?: false | VariantLabels
-    isExiting?: boolean
-    onExitComplete?: () => void
-    custom?: any
-}
-
 export interface MotionContextProps {
     controls?: ValueAnimationControls
     values?: MotionValuesMap

--- a/src/motion/functionality/exit.ts
+++ b/src/motion/functionality/exit.ts
@@ -1,22 +1,12 @@
 import { useRef, useEffect } from "react"
-import { invariant } from "hey-listen"
 import { makeRenderlessComponent } from "../utils/make-renderless-component"
 import { FunctionalProps, FunctionalComponentDefinition } from "./types"
 import { AnimationControls } from "../../animation/AnimationControls"
+import { checkShouldInheritVariant } from "../utils/should-inherit-variant"
 
 export const Exit: FunctionalComponentDefinition = {
     key: "exit",
-    shouldRender: ({ exit }, { exitProps }) => {
-        const hasExitProps = !!exitProps
-        const hasExitAnimation = !!exit
-
-        invariant(
-            !hasExitProps || (hasExitProps && hasExitAnimation),
-            "No exit prop defined on a child of AnimatePresence."
-        )
-
-        return hasExitProps && hasExitAnimation
-    },
+    shouldRender: props => !!props.exit && !checkShouldInheritVariant(props),
     Component: makeRenderlessComponent((props: FunctionalProps) => {
         const { animate, controls, parentContext, exit } = props
         const { exitProps } = parentContext
@@ -27,32 +17,28 @@ export const Exit: FunctionalComponentDefinition = {
 
         const { isExiting, custom, onExitComplete } = exitProps
 
-        useEffect(
-            () => {
-                if (isExiting) {
-                    if (!isPlayingExitAnimation.current && exit) {
-                        controls.setProps({
-                            ...props,
-                            custom:
-                                custom !== undefined ? custom : props.custom,
-                        })
-                        controls.start(exit).then(onExitComplete)
-                    }
-
-                    isPlayingExitAnimation.current = true
-                } else if (
-                    isPlayingExitAnimation.current &&
-                    animate &&
-                    !(animate instanceof AnimationControls)
-                ) {
-                    controls.start(animate)
+        useEffect(() => {
+            if (isExiting) {
+                if (!isPlayingExitAnimation.current && exit) {
+                    controls.setProps({
+                        ...props,
+                        custom: custom !== undefined ? custom : props.custom,
+                    })
+                    controls.start(exit).then(onExitComplete)
                 }
 
-                if (!isExiting) {
-                    isPlayingExitAnimation.current = false
-                }
-            },
-            [isExiting]
-        )
+                isPlayingExitAnimation.current = true
+            } else if (
+                isPlayingExitAnimation.current &&
+                animate &&
+                !(animate instanceof AnimationControls)
+            ) {
+                controls.start(animate)
+            }
+
+            if (!isExiting) {
+                isPlayingExitAnimation.current = false
+            }
+        }, [isExiting])
     }),
 }


### PR DESCRIPTION
Currently, each child of `AnimatePresence` must have, somewhere in the tree, a single top-level `motion` child with an `exit` prop.

Valid:

```
<AnimatePresence>
  <motion.div exit={{ x: 0 }} />
</AnimatePresence>
```

Invalid (the tree would be removed when the first animation completes):

```
<AnimatePresence>
  <>
    <motion.div exit={{ x: 0 }} transition={{duration: 2 }} />
    <motion.div exit={{ x: 0 }} />
  </>
</AnimatePresence>
```

This PR changes this behaviour so that for any given sub-tree, `AnimatePresence` tracks the number of potential exiting children and only considers a tree safe to remove once all children have fired the `onExitComplete` callback.