### PR TITLE
Fixing PresenceChild rerender bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.1] 2020-03-23
+
+### Fix
+
+-   Fixing `AnimatePresence` children not re-rendering when their exiting siblings have been removed from the tree (which broke siblings `positionTransition` and `layoutTransition`). ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#473](https://github.com/framer/motion/pull/473))
+-   Adding `null` check for `getTranslateFromMatrix` ([@JoyalJoyMadeckal](https://github.com/JoyalJoyMadeckal) in [#482](https://github.com/framer/motion/pull/482))
+
 ## [1.10.0] 2020-03-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fix
 
--   Fixing `AnimatePresence` children not re-rendering when their exiting siblings have been removed from the tree (which broke siblings `positionTransition` and `layoutTransition`). ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#473](https://github.com/framer/motion/pull/473))
+-   Fixing `AnimatePresence` children not re-rendering when their exiting siblings have been removed from the tree (which broke siblings `positionTransition` and `layoutTransition`). ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#489](https://github.com/framer/motion/pull/489))
 -   Adding `null` check for `getTranslateFromMatrix` ([@JoyalJoyMadeckal](https://github.com/JoyalJoyMadeckal) in [#482](https://github.com/framer/motion/pull/482))
 
 ## [1.10.0] 2020-03-19

--- a/dev/examples/notifications.tsx
+++ b/dev/examples/notifications.tsx
@@ -1,0 +1,144 @@
+import { motion, AnimatePresence } from "@framer"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "red",
+    opacity: 1,
+}
+
+export const App = () => {
+    const [notifications, setNotifications] = useState([0])
+
+    return (
+        <Container>
+            <ul>
+                <AnimatePresence initial={false}>
+                    {notifications.map(id => (
+                        <motion.li
+                            key={id}
+                            positionTransition
+                            initial={{ opacity: 0, y: 50, scale: 0.3 }}
+                            animate={{ opacity: 1, y: 0, scale: 1 }}
+                            exit={{
+                                opacity: 0,
+                                scale: 0.5,
+                                transition: { duration: 0.2 },
+                            }}
+                        >
+                            <CloseButton
+                                close={() =>
+                                    setNotifications(remove(notifications, id))
+                                }
+                            />
+                        </motion.li>
+                    ))}
+                </AnimatePresence>
+            </ul>
+            <button
+                className="add"
+                onClick={() => setNotifications(add(notifications))}
+            >
+                +
+            </button>
+        </Container>
+    )
+}
+
+const Path = props => (
+    <motion.path
+        fill="transparent"
+        strokeWidth="3"
+        stroke="hsl(0, 0%, 18%)"
+        strokeLinecap="round"
+        {...props}
+    />
+)
+
+export const CloseButton = ({ close }) => (
+    <button onClick={close} className="close">
+        <svg width="23" height="23" viewBox="0 0 23 23">
+            <Path d="M 3 16.5 L 17 2.5" />
+            <Path d="M 3 2.5 L 17 16.346" />
+        </svg>
+    </button>
+)
+
+const Container = styled.div`
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    flex-direction: column;
+
+    ul,
+    li {
+        padding: 0;
+        margin: 0;
+    }
+
+    ul {
+        position: fixed;
+        bottom: 0;
+        right: 0;
+        top: 0;
+        display: flex;
+        flex-direction: column;
+        list-style: none;
+        justify-content: flex-end;
+    }
+
+    li {
+        width: 300px;
+        background: white;
+        margin: 10px;
+        flex: 0 0 100px;
+        position: relative;
+        border-radius: 10px;
+    }
+
+    button {
+        outline: none;
+        -webkit-appearance: none;
+        cursor: pointer;
+    }
+
+    button.add {
+        position: fixed;
+        bottom: 10px;
+        left: 10px;
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        font-size: 28px;
+        border: none;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    button.close {
+        position: absolute;
+        top: 15px;
+        right: 10px;
+        background: white;
+        border: none;
+    }
+`
+
+const remove = (arr: number[], item: number) => {
+    const newArr = [...arr]
+    newArr.splice(
+        newArr.findIndex(i => i === item),
+        1
+    )
+    return newArr
+}
+
+let newIndex = 0
+export const add = (arr: number[]) => {
+    newIndex++
+    return [...arr, newIndex]
+}

--- a/src/components/AnimatePresence/PresenceChild.tsx
+++ b/src/components/AnimatePresence/PresenceChild.tsx
@@ -20,13 +20,16 @@ export const PresenceChild = ({
 }: PresenceChildProps) => {
     const numPresenceChildren = useRef(0)
 
-    const context = useMemo(() => {
+    const context = {
+        initial,
+        isPresent,
+        custom,
+    }
+
+    const lifecycle = useMemo(() => {
         let numExitComplete = 0
 
         return {
-            initial,
-            isPresent,
-            custom,
             onExitComplete: () => {
                 numExitComplete++
                 if (
@@ -41,10 +44,10 @@ export const PresenceChild = ({
                 return () => numPresenceChildren.current--
             },
         }
-    }, [isPresent, onExitComplete, initial, custom])
+    }, [isPresent, onExitComplete])
 
     return (
-        <PresenceContext.Provider value={context}>
+        <PresenceContext.Provider value={{ ...context, ...lifecycle }}>
             {children}
         </PresenceContext.Provider>
     )


### PR DESCRIPTION
Currently, `PresenceChild` doesn't get re-rendered unless it switches from `isPresent` -> false. This means that `positionTransition` and `layoutTransition` won't know when they've moved as a result of siblings being removed via `AnimatePresence`

Fixes https://github.com/framer/motion/issues/487