### PR TITLE
Replacing the drag pointerdown `e.preventDefault()` with CSS and HTML attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fix
 
--   Attaching pan event handlers to `document` instead of `window`. ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#495](https://github.com/framer/motion/pull/495))
+-   Replacing the functionality of `DragControls` `e.preventDefault()` with CSS and HTML attributes. ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#495](https://github.com/framer/motion/pull/495))
 
 ## [1.10.2] 2020-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.3] 2020-03-23
+
+### Fix
+
+-   Attaching pan event handlers to `document` instead of `window`. ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#490](https://github.com/framer/motion/pull/490))
+
 ## [1.10.2] 2020-03-23
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fix
 
--   Attaching pan event handlers to `document` instead of `window`. ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#490](https://github.com/framer/motion/pull/490))
+-   Attaching pan event handlers to `document` instead of `window`. ([@inventingwithmonster](https://github.com/inventingwithmonster) in [#495](https://github.com/framer/motion/pull/495))
 
 ## [1.10.2] 2020-03-23
 

--- a/src/behaviours/ComponentDragControls.ts
+++ b/src/behaviours/ComponentDragControls.ts
@@ -8,7 +8,6 @@ import {
 } from "./utils/block-viewport-scroll"
 import { Point } from "../events/types"
 import { ValueAnimationControls, MotionValuesMap } from "../motion"
-import { supportsTouchEvents } from "../events/utils"
 import { isRefObject } from "../utils/is-ref-object"
 import { addPointerEvent } from "../events/use-pointer-event"
 import { PanSession, AnyPointerEvent, PanInfo } from "../gestures/PanSession"
@@ -55,11 +54,6 @@ interface BBox {
     x: number
     y: number
 }
-
-/**
- * Don't block the default pointerdown behaviour of these elements.
- */
-const allowDefaultPointerDown = new Set(["INPUT", "TEXTAREA", "SELECT"])
 
 export class ComponentDragControls {
     /**

--- a/src/behaviours/ComponentDragControls.ts
+++ b/src/behaviours/ComponentDragControls.ts
@@ -178,24 +178,7 @@ export class ComponentDragControls {
     ) {
         snapToCursor && this.snapToCursor(originEvent)
 
-        const onSessionStart = (event: AnyPointerEvent) => {
-            // Prevent browser-specific behaviours like text selection or Chrome's image dragging.
-            if (
-                event.target &&
-                !allowDefaultPointerDown.has((event.target as Element).tagName)
-            ) {
-                // On iOS it's important to not `preventDefault` the `touchstart`
-                // event, as otherwise clicks won't fire inside the draggable element.
-                if (!supportsTouchEvents()) {
-                    event.preventDefault()
-
-                    // Make sure input elements loose focus when we prevent the default.
-                    if (document.activeElement instanceof HTMLElement) {
-                        document.activeElement.blur()
-                    }
-                }
-            }
-
+        const onSessionStart = () => {
             // Initiate viewport scroll blocking on touch start. This is a very aggressive approach
             // which has come out of the difficulty in us being able to do this once a scroll gesture
             // has initiated in mobile browsers. This means if there's a horizontally-scrolling carousel

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -223,12 +223,12 @@ export class PanSession {
             onSessionStart(event, getPanInfo(initialInfo, this.history))
 
         const removeOnPointerMove = addPointerEvent(
-            window,
+            document,
             "pointermove",
             (event, info) => this.handlePointerMove(event, info)
         )
         const removeOnPointerUp = addPointerEvent(
-            window,
+            document,
             "pointerup",
             (event, info) => this.handlePointerUp(event, info)
         )

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -223,12 +223,12 @@ export class PanSession {
             onSessionStart(event, getPanInfo(initialInfo, this.history))
 
         const removeOnPointerMove = addPointerEvent(
-            document,
+            window,
             "pointermove",
             (event, info) => this.handlePointerMove(event, info)
         )
         const removeOnPointerUp = addPointerEvent(
-            document,
+            window,
             "pointerup",
             (event, info) => this.handlePointerUp(event, info)
         )

--- a/src/motion/functionality/dom.tsx
+++ b/src/motion/functionality/dom.tsx
@@ -58,6 +58,28 @@ function filterValidProps(props: MotionProps) {
     return domProps
 }
 
+const buildHTMLProps = (
+    values: MotionValuesMap,
+    style: CSSProperties,
+    isStatic?: boolean,
+    isDrag?: boolean
+) => {
+    // The `any` isn't ideal but it is the type of createElement props argument
+    const props: any = {
+        style: buildStyleAttr(values, style, isStatic),
+    }
+
+    if (isDrag) {
+        // Disable text selection
+        props.style.userSelect = "none"
+
+        // Disable the ghost element when a user drags
+        props.draggable = false
+    }
+
+    return props
+}
+
 const buildSVGProps = (values: MotionValuesMap, style: CSSProperties) => {
     const motionValueStyles = resolveCurrent(values)
     const props = buildSVGAttrs(
@@ -87,12 +109,12 @@ export function createDomMotionConfig<P = MotionProps>(
     const isSVG = isDOM && svgElements.indexOf(Component as any) !== -1
 
     return {
-        renderComponent: (ref, style, values, props, isStatic) => {
+        renderComponent: (ref, style, values, props: MotionProps, isStatic) => {
             const forwardedProps = isDOM ? filterValidProps(props) : props
 
             const staticVisualStyles = isSVG
                 ? buildSVGProps(values, style)
-                : { style: buildStyleAttr(values, style, isStatic) }
+                : buildHTMLProps(values, style, isStatic, !!props.drag)
 
             return createElement<any>(Component, {
                 ...forwardedProps,


### PR DESCRIPTION
Calling `e.preventDefault()` from `pointerdown` disables mouse tracking outside of iframes.