### PR TITLE
WIP: useElementScroll hook

### DIFF
--- a/src/value/use-element-scroll.ts
+++ b/src/value/use-element-scroll.ts
@@ -1,0 +1,32 @@
+import { motionValue } from '.';
+import { useCallback, useEffect, useRef } from 'react';
+
+const scrollTop = motionValue(0);
+
+export default function () {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const element = scrollRef?.current;
+  const elementInnerHeight = scrollRef?.current?.scrollHeight ?? 0;
+  
+  const updateScrollValues = useCallback(
+    (event: Event) => {
+      const el = event.target as HTMLDivElement;
+      scrollTop.set(el.scrollTop / elementInnerHeight);
+    },
+    [elementInnerHeight]
+  );
+  
+  useEffect(() => {
+    if (element) {
+      element.addEventListener('resize', updateScrollValues);
+      element.addEventListener('scroll', updateScrollValues, { passive: true });
+      
+      return () => {
+        element.removeEventListener('resize', updateScrollValues);
+        element.removeEventListener('scroll', updateScrollValues);
+      };
+    }
+    return () => true;
+  }, [element, updateScrollValues]);
+  return { scrollRef, scrollTop };
+}


### PR DESCRIPTION
I just made this for my personal project needs, but thought it might be useful to expose a hook like this in framer-motion? In essence at its present state it exposes ref that you can add to any scrollable div and `scrollTop` value which is just a motionValue, that can be used alongside something like `useTransform` hook.

I tested this on my mac and iOS device, everything seems to animate smoothly, even when animating content that has another looping motion animations nested within it.

If you are interested I can add all remaining bits to this, atm I see them as following:

- [ ] Utilise more versatile type instead of `HTMLDivElement` 
- [ ] Expose `scrollLeft` value
- [ ] Add documentation
- [ ] Add safeguards when making `el.scrollTop / elementInnerHeight` calculation