### PR TITLE
Use Proxy for motion component generation

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -194,12 +194,7 @@ export class DragControls {
 // @public (undocumented)
 export interface DraggableProps extends DragHandlers {
     drag?: boolean | "x" | "y";
-    dragConstraints?: false | {
-        top?: number;
-        right?: number;
-        bottom?: number;
-        left?: number;
-    } | RefObject<Element>;
+    dragConstraints?: false | Partial<BoundingBox2D> | RefObject<Element>;
     dragControls?: DragControls;
     dragDirectionLock?: boolean;
     dragElastic?: boolean | number;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -21,6 +21,9 @@ import { SpringProps } from 'popmotion';
 import { Styler } from 'stylefire';
 import { SVGAttributes } from 'react';
 
+// @public
+export const AnimatePresence: React.FunctionComponent<AnimatePresenceProps>;
+
 // @public (undocumented)
 export interface AnimatePresenceProps {
     custom?: any;
@@ -28,6 +31,38 @@ export interface AnimatePresenceProps {
     exitBeforeEnter?: boolean;
     initial?: boolean;
     onExitComplete?: () => void;
+}
+
+// Warning: (ae-forgotten-export) The symbol "SharedLayoutProps" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SharedLayoutTree" needs to be exported by the entry point index.d.ts
+// 
+// @public (undocumented)
+export class AnimateSharedLayout extends React.Component<SharedLayoutProps, SharedLayoutTree> {
+    addChild(child: Auto): () => void;
+    // (undocumented)
+    addChildToStack(child: Auto): void;
+    // (undocumented)
+    componentDidMount(): void;
+    componentDidUpdate(): void;
+    getSnapshotBeforeUpdate(): null;
+    // Warning: (ae-forgotten-export) The symbol "LayoutStack" needs to be exported by the entry point index.d.ts
+    getStack(id: string): LayoutStack<Auto>;
+    // (undocumented)
+    removeChild(child: Auto): void;
+    // (undocumented)
+    removeChildFromStack(child: Auto): void;
+    // (undocumented)
+    render(): JSX.Element;
+    setRootDepth(child: Auto): void;
+    shouldComponentUpdate(nextProps: SharedLayoutProps, nextState: SharedLayoutTree): boolean;
+    // (undocumented)
+    startAnimation(): void;
+    // (undocumented)
+    state: {
+        forceRender: () => void;
+        register: (child: Auto) => () => void;
+        move: (child: Auto) => void;
+    };
 }
 
 // @public
@@ -500,7 +535,6 @@ export type ResolveLayoutTransition = (info: RelayoutInfo) => Transition | boole
 export function resolveMotionValue(value?: string | number | CustomValueType | MotionValue): string | number;
 
 // Warning: (ae-forgotten-export) The symbol "SharedBatchTree" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "SharedLayoutTree" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "SharedLayoutContext" should be prefixed with an underscore because the declaration is marked as @internal
 // 
 // @internal (undocumented)
@@ -678,6 +712,10 @@ export type Variants = {
     [key: string]: Variant;
 };
 
+
+// Warnings were encountered during analysis:
+// 
+// types/components/AnimateSharedLayout/index.d.ts:55:9 - (ae-forgotten-export) The symbol "Auto" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -4,18 +4,15 @@
 
 ```ts
 
-import { ComponentType } from 'react';
 import * as CSS from 'csstype';
 import { CSSProperties } from 'react';
 import { DetailedHTMLFactory } from 'react';
 import { Easing as Easing_2 } from '@popmotion/easing';
 import { ForwardRefExoticComponent } from 'react';
-import { FunctionComponent } from 'react';
 import { HTMLAttributes } from 'react';
 import { PropsWithoutRef } from 'react';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { ReactElement } from 'react';
 import { ReactHTML } from 'react';
 import { Ref } from 'react';
 import { RefAttributes } from 'react';
@@ -24,9 +21,6 @@ import { SpringProps } from 'popmotion';
 import { Styler } from 'stylefire';
 import { SVGAttributes } from 'react';
 
-// @public
-export const AnimatePresence: FunctionComponent<AnimatePresenceProps>;
-
 // @public (undocumented)
 export interface AnimatePresenceProps {
     custom?: any;
@@ -34,38 +28,6 @@ export interface AnimatePresenceProps {
     exitBeforeEnter?: boolean;
     initial?: boolean;
     onExitComplete?: () => void;
-}
-
-// Warning: (ae-forgotten-export) The symbol "SharedLayoutProps" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "SharedLayoutTree" needs to be exported by the entry point index.d.ts
-// 
-// @public (undocumented)
-export class AnimateSharedLayout extends React.Component<SharedLayoutProps, SharedLayoutTree> {
-    addChild(child: Auto): () => void;
-    // (undocumented)
-    addChildToStack(child: Auto): void;
-    // (undocumented)
-    componentDidMount(): void;
-    componentDidUpdate(): void;
-    getSnapshotBeforeUpdate(): null;
-    // Warning: (ae-forgotten-export) The symbol "LayoutStack" needs to be exported by the entry point index.d.ts
-    getStack(id: string): LayoutStack<Auto>;
-    // (undocumented)
-    removeChild(child: Auto): void;
-    // (undocumented)
-    removeChildFromStack(child: Auto): void;
-    // (undocumented)
-    render(): JSX.Element;
-    setRootDepth(child: Auto): void;
-    shouldComponentUpdate(nextProps: SharedLayoutProps, nextState: SharedLayoutTree): boolean;
-    // (undocumented)
-    startAnimation(): void;
-    // (undocumented)
-    state: {
-        forceRender: () => void;
-        register: (child: Auto) => () => void;
-        move: (child: Auto) => void;
-    };
 }
 
 // @public
@@ -339,179 +301,10 @@ export interface Keyframes {
 // @public (undocumented)
 export type KeyframesTarget = ResolvedKeyframesTarget | [null, ...CustomValueType[]] | CustomValueType[];
 
+// Warning: (ae-forgotten-export) The symbol "Motion" needs to be exported by the entry point index.d.ts
+// 
 // @public
-export const motion: {
-    symbol: ForwardRefComponent<SVGSymbolElement, SVGMotionProps<SVGSymbolElement>>;
-    clipPath: ForwardRefComponent<SVGClipPathElement, SVGMotionProps<SVGClipPathElement>>;
-    filter: ForwardRefComponent<SVGFilterElement, SVGMotionProps<SVGFilterElement>>;
-    mask: ForwardRefComponent<SVGMaskElement, SVGMotionProps<SVGMaskElement>>;
-    marker: ForwardRefComponent<SVGMarkerElement, SVGMotionProps<SVGMarkerElement>>;
-    image: ForwardRefComponent<SVGImageElement, SVGMotionProps<SVGImageElement>>;
-    text: ForwardRefComponent<SVGTextElement, SVGMotionProps<SVGTextElement>>;
-    circle: ForwardRefComponent<SVGCircleElement, SVGMotionProps<SVGCircleElement>>;
-    animate: ForwardRefComponent<SVGElement, SVGMotionProps<SVGElement>>;
-    svg: ForwardRefComponent<SVGSVGElement, SVGMotionProps<SVGSVGElement>>;
-    defs: ForwardRefComponent<SVGDefsElement, SVGMotionProps<SVGDefsElement>>;
-    desc: ForwardRefComponent<SVGDescElement, SVGMotionProps<SVGDescElement>>;
-    ellipse: ForwardRefComponent<SVGEllipseElement, SVGMotionProps<SVGEllipseElement>>;
-    feBlend: ForwardRefComponent<SVGFEBlendElement, SVGMotionProps<SVGFEBlendElement>>;
-    feColorMatrix: ForwardRefComponent<SVGFEColorMatrixElement, SVGMotionProps<SVGFEColorMatrixElement>>;
-    feComponentTransfer: ForwardRefComponent<SVGFEComponentTransferElement, SVGMotionProps<SVGFEComponentTransferElement>>;
-    feComposite: ForwardRefComponent<SVGFECompositeElement, SVGMotionProps<SVGFECompositeElement>>;
-    feConvolveMatrix: ForwardRefComponent<SVGFEConvolveMatrixElement, SVGMotionProps<SVGFEConvolveMatrixElement>>;
-    feDiffuseLighting: ForwardRefComponent<SVGFEDiffuseLightingElement, SVGMotionProps<SVGFEDiffuseLightingElement>>;
-    feDisplacementMap: ForwardRefComponent<SVGFEDisplacementMapElement, SVGMotionProps<SVGFEDisplacementMapElement>>;
-    feDistantLight: ForwardRefComponent<SVGFEDistantLightElement, SVGMotionProps<SVGFEDistantLightElement>>;
-    feDropShadow: ForwardRefComponent<SVGFEDropShadowElement, SVGMotionProps<SVGFEDropShadowElement>>;
-    feFlood: ForwardRefComponent<SVGFEFloodElement, SVGMotionProps<SVGFEFloodElement>>;
-    feFuncA: ForwardRefComponent<SVGFEFuncAElement, SVGMotionProps<SVGFEFuncAElement>>;
-    feFuncB: ForwardRefComponent<SVGFEFuncBElement, SVGMotionProps<SVGFEFuncBElement>>;
-    feFuncG: ForwardRefComponent<SVGFEFuncGElement, SVGMotionProps<SVGFEFuncGElement>>;
-    feFuncR: ForwardRefComponent<SVGFEFuncRElement, SVGMotionProps<SVGFEFuncRElement>>;
-    feGaussianBlur: ForwardRefComponent<SVGFEGaussianBlurElement, SVGMotionProps<SVGFEGaussianBlurElement>>;
-    feImage: ForwardRefComponent<SVGFEImageElement, SVGMotionProps<SVGFEImageElement>>;
-    feMerge: ForwardRefComponent<SVGFEMergeElement, SVGMotionProps<SVGFEMergeElement>>;
-    feMergeNode: ForwardRefComponent<SVGFEMergeNodeElement, SVGMotionProps<SVGFEMergeNodeElement>>;
-    feMorphology: ForwardRefComponent<SVGFEMorphologyElement, SVGMotionProps<SVGFEMorphologyElement>>;
-    feOffset: ForwardRefComponent<SVGFEOffsetElement, SVGMotionProps<SVGFEOffsetElement>>;
-    fePointLight: ForwardRefComponent<SVGFEPointLightElement, SVGMotionProps<SVGFEPointLightElement>>;
-    feSpecularLighting: ForwardRefComponent<SVGFESpecularLightingElement, SVGMotionProps<SVGFESpecularLightingElement>>;
-    feSpotLight: ForwardRefComponent<SVGFESpotLightElement, SVGMotionProps<SVGFESpotLightElement>>;
-    feTile: ForwardRefComponent<SVGFETileElement, SVGMotionProps<SVGFETileElement>>;
-    feTurbulence: ForwardRefComponent<SVGFETurbulenceElement, SVGMotionProps<SVGFETurbulenceElement>>;
-    foreignObject: ForwardRefComponent<SVGForeignObjectElement, SVGMotionProps<SVGForeignObjectElement>>;
-    g: ForwardRefComponent<SVGGElement, SVGMotionProps<SVGGElement>>;
-    line: ForwardRefComponent<SVGLineElement, SVGMotionProps<SVGLineElement>>;
-    linearGradient: ForwardRefComponent<SVGLinearGradientElement, SVGMotionProps<SVGLinearGradientElement>>;
-    metadata: ForwardRefComponent<SVGMetadataElement, SVGMotionProps<SVGMetadataElement>>;
-    path: ForwardRefComponent<SVGPathElement, SVGMotionProps<SVGPathElement>>;
-    pattern: ForwardRefComponent<SVGPatternElement, SVGMotionProps<SVGPatternElement>>;
-    polygon: ForwardRefComponent<SVGPolygonElement, SVGMotionProps<SVGPolygonElement>>;
-    polyline: ForwardRefComponent<SVGPolylineElement, SVGMotionProps<SVGPolylineElement>>;
-    radialGradient: ForwardRefComponent<SVGRadialGradientElement, SVGMotionProps<SVGRadialGradientElement>>;
-    rect: ForwardRefComponent<SVGRectElement, SVGMotionProps<SVGRectElement>>;
-    stop: ForwardRefComponent<SVGStopElement, SVGMotionProps<SVGStopElement>>;
-    switch: ForwardRefComponent<SVGSwitchElement, SVGMotionProps<SVGSwitchElement>>;
-    textPath: ForwardRefComponent<SVGTextPathElement, SVGMotionProps<SVGTextPathElement>>;
-    tspan: ForwardRefComponent<SVGTSpanElement, SVGMotionProps<SVGTSpanElement>>;
-    use: ForwardRefComponent<SVGUseElement, SVGMotionProps<SVGUseElement>>;
-    view: ForwardRefComponent<SVGViewElement, SVGMotionProps<SVGViewElement>>;
-    object: ForwardRefComponent<HTMLObjectElement, HTMLMotionProps<"object">>;
-    style: ForwardRefComponent<HTMLStyleElement, HTMLMotionProps<"style">>;
-    progress: ForwardRefComponent<HTMLProgressElement, HTMLMotionProps<"progress">>;
-    ruby: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    table: ForwardRefComponent<HTMLTableElement, HTMLMotionProps<"table">>;
-    small: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    sub: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    embed: ForwardRefComponent<HTMLEmbedElement, HTMLMotionProps<"embed">>;
-    pre: ForwardRefComponent<HTMLPreElement, HTMLMotionProps<"pre">>;
-    caption: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    menu: ForwardRefComponent<HTMLElement, HTMLMotionProps<"menu">>;
-    button: ForwardRefComponent<HTMLButtonElement, HTMLMotionProps<"button">>;
-    menuitem: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    meter: ForwardRefComponent<HTMLElement, HTMLMotionProps<"meter">>;
-    textarea: ForwardRefComponent<HTMLTextAreaElement, HTMLMotionProps<"textarea">>;
-    time: ForwardRefComponent<HTMLElement, HTMLMotionProps<"time">>;
-    link: ForwardRefComponent<HTMLLinkElement, HTMLMotionProps<"link">>;
-    dialog: ForwardRefComponent<HTMLDialogElement, HTMLMotionProps<"dialog">>;
-    input: ForwardRefComponent<HTMLInputElement, HTMLMotionProps<"input">>;
-    select: ForwardRefComponent<HTMLSelectElement, HTMLMotionProps<"select">>;
-    a: ForwardRefComponent<HTMLAnchorElement, HTMLMotionProps<"a">>;
-    abbr: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    address: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    area: ForwardRefComponent<HTMLAreaElement, HTMLMotionProps<"area">>;
-    article: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    aside: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    audio: ForwardRefComponent<HTMLAudioElement, HTMLMotionProps<"audio">>;
-    b: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    base: ForwardRefComponent<HTMLBaseElement, HTMLMotionProps<"base">>;
-    bdi: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    bdo: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    big: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    blockquote: ForwardRefComponent<HTMLElement, HTMLMotionProps<"blockquote">>;
-    body: ForwardRefComponent<HTMLBodyElement, HTMLMotionProps<"body">>;
-    br: ForwardRefComponent<HTMLBRElement, HTMLMotionProps<"br">>;
-    canvas: ForwardRefComponent<HTMLCanvasElement, HTMLMotionProps<"canvas">>;
-    cite: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    code: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    col: ForwardRefComponent<HTMLTableColElement, HTMLMotionProps<"col">>;
-    colgroup: ForwardRefComponent<HTMLTableColElement, HTMLMotionProps<"colgroup">>;
-    data: ForwardRefComponent<HTMLDataElement, HTMLMotionProps<"data">>;
-    datalist: ForwardRefComponent<HTMLDataListElement, HTMLMotionProps<"datalist">>;
-    dd: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    del: ForwardRefComponent<HTMLElement, HTMLMotionProps<"del">>;
-    details: ForwardRefComponent<HTMLElement, HTMLMotionProps<"details">>;
-    dfn: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    div: ForwardRefComponent<HTMLDivElement, HTMLMotionProps<"div">>;
-    dl: ForwardRefComponent<HTMLDListElement, HTMLMotionProps<"dl">>;
-    dt: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    em: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    fieldset: ForwardRefComponent<HTMLFieldSetElement, HTMLMotionProps<"fieldset">>;
-    figcaption: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    figure: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    footer: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    form: ForwardRefComponent<HTMLFormElement, HTMLMotionProps<"form">>;
-    h1: ForwardRefComponent<HTMLHeadingElement, HTMLMotionProps<"h1">>;
-    h2: ForwardRefComponent<HTMLHeadingElement, HTMLMotionProps<"h1">>;
-    h3: ForwardRefComponent<HTMLHeadingElement, HTMLMotionProps<"h1">>;
-    h4: ForwardRefComponent<HTMLHeadingElement, HTMLMotionProps<"h1">>;
-    h5: ForwardRefComponent<HTMLHeadingElement, HTMLMotionProps<"h1">>;
-    h6: ForwardRefComponent<HTMLHeadingElement, HTMLMotionProps<"h1">>;
-    head: ForwardRefComponent<HTMLHeadElement, HTMLMotionProps<"head">>;
-    header: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    hgroup: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    hr: ForwardRefComponent<HTMLHRElement, HTMLMotionProps<"hr">>;
-    html: ForwardRefComponent<HTMLHtmlElement, HTMLMotionProps<"html">>;
-    i: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    iframe: ForwardRefComponent<HTMLIFrameElement, HTMLMotionProps<"iframe">>;
-    img: ForwardRefComponent<HTMLImageElement, HTMLMotionProps<"img">>;
-    ins: ForwardRefComponent<HTMLModElement, HTMLMotionProps<"ins">>;
-    kbd: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    keygen: ForwardRefComponent<HTMLElement, HTMLMotionProps<"keygen">>;
-    label: ForwardRefComponent<HTMLLabelElement, HTMLMotionProps<"label">>;
-    legend: ForwardRefComponent<HTMLLegendElement, HTMLMotionProps<"legend">>;
-    li: ForwardRefComponent<HTMLLIElement, HTMLMotionProps<"li">>;
-    main: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    map: ForwardRefComponent<HTMLMapElement, HTMLMotionProps<"map">>;
-    mark: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    meta: ForwardRefComponent<HTMLMetaElement, HTMLMotionProps<"meta">>;
-    nav: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    noscript: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    ol: ForwardRefComponent<HTMLOListElement, HTMLMotionProps<"ol">>;
-    optgroup: ForwardRefComponent<HTMLOptGroupElement, HTMLMotionProps<"optgroup">>;
-    option: ForwardRefComponent<HTMLOptionElement, HTMLMotionProps<"option">>;
-    output: ForwardRefComponent<HTMLElement, HTMLMotionProps<"output">>;
-    p: ForwardRefComponent<HTMLParagraphElement, HTMLMotionProps<"p">>;
-    param: ForwardRefComponent<HTMLParamElement, HTMLMotionProps<"param">>;
-    picture: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    q: ForwardRefComponent<HTMLQuoteElement, HTMLMotionProps<"q">>;
-    rp: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    rt: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    s: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    samp: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    script: ForwardRefComponent<HTMLScriptElement, HTMLMotionProps<"script">>;
-    section: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    source: ForwardRefComponent<HTMLSourceElement, HTMLMotionProps<"source">>;
-    span: ForwardRefComponent<HTMLSpanElement, HTMLMotionProps<"span">>;
-    strong: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    summary: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    sup: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    tbody: ForwardRefComponent<HTMLTableSectionElement, HTMLMotionProps<"tbody">>;
-    td: ForwardRefComponent<HTMLTableDataCellElement, HTMLMotionProps<"td">>;
-    tfoot: ForwardRefComponent<HTMLTableSectionElement, HTMLMotionProps<"tbody">>;
-    th: ForwardRefComponent<HTMLTableHeaderCellElement, HTMLMotionProps<"th">>;
-    thead: ForwardRefComponent<HTMLTableSectionElement, HTMLMotionProps<"tbody">>;
-    title: ForwardRefComponent<HTMLTitleElement, HTMLMotionProps<"title">>;
-    tr: ForwardRefComponent<HTMLTableRowElement, HTMLMotionProps<"tr">>;
-    track: ForwardRefComponent<HTMLTrackElement, HTMLMotionProps<"track">>;
-    u: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    ul: ForwardRefComponent<HTMLUListElement, HTMLMotionProps<"ul">>;
-    var: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    video: ForwardRefComponent<HTMLVideoElement, HTMLMotionProps<"video">>;
-    wbr: ForwardRefComponent<HTMLElement, HTMLMotionProps<"ruby">>;
-    webview: ForwardRefComponent<HTMLWebViewElement, HTMLMotionProps<"webview">>;
-    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<Element>>;
-};
+export const motion: Motion;
 
 // @public (undocumented)
 export interface MotionAdvancedProps {
@@ -538,7 +331,7 @@ export const MotionContext: React.Context<MotionContextProps>;
 // @public (undocumented)
 export interface MotionFeature {
     // (undocumented)
-    Component: ComponentType<FeatureProps>;
+    Component: React.ComponentType<FeatureProps>;
     // (undocumented)
     key: string;
     // (undocumented)
@@ -707,6 +500,7 @@ export type ResolveLayoutTransition = (info: RelayoutInfo) => Transition | boole
 export function resolveMotionValue(value?: string | number | CustomValueType | MotionValue): string | number;
 
 // Warning: (ae-forgotten-export) The symbol "SharedBatchTree" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SharedLayoutTree" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "SharedLayoutContext" should be prefixed with an underscore because the declaration is marked as @internal
 // 
 // @internal (undocumented)
@@ -884,10 +678,6 @@ export type Variants = {
     [key: string]: Variant;
 };
 
-
-// Warnings were encountered during analysis:
-// 
-// types/components/AnimateSharedLayout/index.d.ts:55:9 - (ae-forgotten-export) The symbol "Auto" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/behaviours/__tests__/index.test.tsx
+++ b/src/behaviours/__tests__/index.test.tsx
@@ -1,10 +1,9 @@
 import * as React from "react"
 import { useState } from "react"
 import { render } from "../../../jest.setup"
-import { motion } from "../../"
+import { motion, BoundingBox2D } from "../../"
 import { motionValue, MotionValue } from "../../value"
 import { fireEvent } from "@testing-library/dom"
-import { Constraints } from "../ComponentDragControls"
 import { MockDrag, Point, drag, frame, deferred, sleep } from "./utils"
 
 describe("dragging", () => {
@@ -702,7 +701,11 @@ describe("dragging", () => {
     test("drag constraints can be updated", async () => {
         const x = motionValue(0)
         const y = motionValue(0)
-        const Component = ({ constraints }: { constraints: Constraints }) => (
+        const Component = ({
+            constraints,
+        }: {
+            constraints: Partial<BoundingBox2D>
+        }) => (
             <MockDrag>
                 <motion.div
                     drag
@@ -736,7 +739,11 @@ describe("dragging", () => {
     test("updates position when updating drag constraints", async () => {
         const x = motionValue(100)
         const y = motionValue(100)
-        const Component = ({ constraints }: { constraints: Constraints }) => (
+        const Component = ({
+            constraints,
+        }: {
+            constraints: Partial<BoundingBox2D>
+        }) => (
             <MockDrag>
                 <motion.div
                     drag

--- a/src/behaviours/types.ts
+++ b/src/behaviours/types.ts
@@ -273,10 +273,7 @@ export interface DraggableProps extends DragHandlers {
      * }
      * ```
      */
-    dragConstraints?:
-        | false
-        | { top?: number; right?: number; bottom?: number; left?: number }
-        | RefObject<Element>
+    dragConstraints?: false | Partial<BoundingBox2D> | RefObject<Element>
 
     /**
      * The degree of movement allowed outside constraints. 0 = no movement, 1 =

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import {
     useContext,
     useRef,
@@ -8,12 +9,15 @@ import {
     ReactNode,
     FunctionComponent,
 } from "react"
-import * as React from "react"
 import { AnimatePresenceProps } from "./types"
 import { SharedLayoutContext } from "../AnimateSharedLayout/SharedLayoutContext"
-import { SharedLayoutTree, SharedBatchTree } from "../AnimateSharedLayout/types"
 import { useForceUpdate } from "../../utils/use-force-update"
 import { PresenceChild } from "./PresenceChild"
+import {
+    SharedLayoutTree,
+    SharedBatchTree,
+} from "../../components/AnimateSharedLayout/types"
+
 type ComponentKey = string | number
 
 function getChildKey(child: ReactElement<any>): ComponentKey {
@@ -127,10 +131,10 @@ export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
     // We want to force a re-render once all exiting animations have finished. We
     // either use a local forceRender function, or one from a parent context if it exists.
     let forceRender = useForceUpdate()
-    const magicContext = useContext(SharedLayoutContext)
+    const layoutContext = useContext(SharedLayoutContext)
 
-    if (isControlledSharedLayoutContext(magicContext)) {
-        forceRender = magicContext.forceRender
+    if (isControlledSharedLayoutContext(layoutContext)) {
+        forceRender = layoutContext.forceRender
     }
 
     const isInitialRender = useRef(true)

--- a/src/components/AnimatePresence/index.tsx
+++ b/src/components/AnimatePresence/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import {
     useContext,
     useRef,
@@ -7,8 +6,8 @@ import {
     Children,
     ReactElement,
     ReactNode,
-    FunctionComponent,
 } from "react"
+import * as React from "react"
 import { AnimatePresenceProps } from "./types"
 import { SharedLayoutContext } from "../AnimateSharedLayout/SharedLayoutContext"
 import { useForceUpdate } from "../../utils/use-force-update"
@@ -121,7 +120,7 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  *
  * @public
  */
-export const AnimatePresence: FunctionComponent<AnimatePresenceProps> = ({
+export const AnimatePresence: React.FunctionComponent<AnimatePresenceProps> = ({
     children,
     custom,
     initial = true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,13 @@
-/**
- * Components
- */
+export { motion, useExternalRef, createMotionComponent } from "./motion"
 export {
-    motion,
-    useExternalRef,
-    createMotionComponent,
     HTMLMotionProps,
     SVGMotionProps,
     SVGAttributesAsMotionValues,
     ForwardRefComponent,
-} from "./motion"
-export { AnimatePresence } from "./components/AnimatePresence"
-export { AnimateSharedLayout } from "./components/AnimateSharedLayout"
-
-/**
- * Motion values
- */
+} from "./motion/types"
+export { useMotionValue } from "./value/use-motion-value"
 export { MotionValue, motionValue, PassiveEffect, Subscriber } from "./value"
 export { resolveMotionValue } from "./value/utils/resolve-motion-value"
-export { useMotionValue } from "./value/use-motion-value"
 export { useInvertedScale } from "./value/use-inverted-scale"
 export { useViewportScroll } from "./value/use-viewport-scroll"
 export { useTransform } from "./value/use-transform"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
+/**
+ * Components
+ */
 export { motion, useExternalRef, createMotionComponent } from "./motion"
+export { AnimatePresence } from "./components/AnimatePresence"
+export { AnimateSharedLayout } from "./components/AnimateSharedLayout"
 export {
     HTMLMotionProps,
     SVGMotionProps,
     SVGAttributesAsMotionValues,
     ForwardRefComponent,
 } from "./motion/types"
+
+/**
+ * Motion values
+ */
 export { useMotionValue } from "./value/use-motion-value"
 export { MotionValue, motionValue, PassiveEffect, Subscriber } from "./value"
 export { resolveMotionValue } from "./value/utils/resolve-motion-value"

--- a/src/motion/features/auto/__tests__/utils.test.ts
+++ b/src/motion/features/auto/__tests__/utils.test.ts
@@ -1,4 +1,3 @@
-import { Axis, Box } from "../types"
 import {
     safeSize,
     calcOrigin,
@@ -13,9 +12,8 @@ import {
     isNear,
     applyBoxDelta,
     applyTreeDeltas,
-    // applyTreeDeltas,
-    // applyBoxDelta,
 } from "../utils"
+import { Axis, AxisBox2D } from "../../../../types/geometry"
 
 describe("safeSize", () => {
     test("should return large bounding boxes as provided", () => {
@@ -313,7 +311,7 @@ test("isTreeVisible", () => {
 
 describe("resetBox", () => {
     test("it resets the provided box to the origin box", () => {
-        const box: Box = {
+        const box: AxisBox2D = {
             x: { min: 100, max: 200 },
             y: { min: 100, max: 200 },
         }

--- a/src/motion/features/auto/__tests__/values.test.ts
+++ b/src/motion/features/auto/__tests__/values.test.ts
@@ -1,8 +1,8 @@
 import { radiusAsPixels } from "../values"
-import { Box } from "../types"
+import { AxisBox2D } from "../../../../types/geometry"
 
 describe("radiusAsPixels", () => {
-    const box: Box = {
+    const box: AxisBox2D = {
         x: { min: 100, max: 200 },
         y: { min: 100, max: 300 },
     }

--- a/src/motion/features/types.ts
+++ b/src/motion/features/types.ts
@@ -1,4 +1,4 @@
-import { ComponentType, CSSProperties, ReactElement } from "react"
+import * as React from "react"
 import { MotionProps } from "../types"
 import { ValueAnimationControls } from "../../animation/ValueAnimationControls"
 import { MotionValuesMap } from "../utils/use-motion-values"
@@ -26,7 +26,7 @@ export interface MotionFeature {
         props: MotionProps,
         parentContext: MotionContextProps
     ) => boolean
-    Component: ComponentType<FeatureProps>
+    Component: React.ComponentType<FeatureProps>
 }
 
 export type LoadMotionFeatures<P = {}> = (
@@ -38,12 +38,12 @@ export type LoadMotionFeatures<P = {}> = (
     controls: ValueAnimationControls<P>,
     inherit: boolean,
     plugins: MotionPluginsContext
-) => ReactElement<FeatureProps>[]
+) => React.ReactElement<FeatureProps>[]
 
 export type RenderComponent<P = {}> = (
     nativeElement: NativeElement,
-    style: CSSProperties,
+    style: React.CSSProperties,
     values: MotionValuesMap,
     props: P,
     isStatic?: boolean
-) => ReactElement
+) => React.ReactElement

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -12,8 +12,6 @@ export { useExternalRef } from "./utils/use-external-ref"
 export { ValueAnimationControls } from "../animation/ValueAnimationControls"
 export { createMotionComponent }
 
-type Motion = HTMLMotionComponents & SVGMotionComponents
-
 /**
  * Convert any React component into a `motion` component. The provided component
  * **must** use `React.forwardRef` to the underlying DOM component you want to animate.
@@ -32,41 +30,30 @@ function custom<Props>(Component: string | React.ComponentType<Props>) {
     return createMotionComponent<Props>(createDomMotionConfig(Component))
 }
 
+type CustomMotionComponent = { custom: typeof custom }
+type Motion = HTMLMotionComponents & SVGMotionComponents & CustomMotionComponent
+
 const componentCache = new Map<string, any>()
+function getMotionComponent(target: CustomMotionComponent, key: string) {
+    if (key === "custom") return target.custom
+
+    if (!componentCache.has(key)) {
+        componentCache.set(
+            key,
+            createMotionComponent(createDomMotionConfig(key))
+        )
+    }
+
+    return componentCache.get(key)
+}
 
 /**
  * HTML & SVG components, optimised for use with gestures and animation. These can be used as
  * drop-in replacements for any HTML & SVG component, all CSS & SVG properties are supported.
  *
- * @internalremarks
- *
- * I'd like to make it possible for these to be loaded "on demand" - to reduce bundle size by only
- * including HTML/SVG stylers, animation and/or gesture support when necessary.
- *
- * ```jsx
- * <motion.div animate={{ x: 100 }} />
- *
- * <motion.p animate={{ height: 200 }} />
- *
- * <svg><motion.circle r={10} animate={{ r: 20 }} /></svg>
- * ```
- *
  * @public
  */
 export const motion = new Proxy(
     { custom },
-    {
-        get: (target: any, key: string) => {
-            if (key === "custom") return target.custom
-
-            if (!componentCache.has(key)) {
-                componentCache.set(
-                    key,
-                    createMotionComponent(createDomMotionConfig(key))
-                )
-            }
-
-            return componentCache.get(key)
-        },
-    }
+    { get: getMotionComponent }
 ) as Motion

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -1,12 +1,13 @@
 import * as React from "react"
 import { createMotionComponent } from "./component"
 import { createDomMotionConfig } from "./features/dom"
-import { HTMLMotionComponents, SVGMotionComponents } from "./types"
+import { HTMLMotionComponents, SVGMotionComponents, MotionProps } from "./types"
 
 export { MotionContext } from "./context/MotionContext"
 export { MotionValuesMap } from "./utils/use-motion-values"
 export { useExternalRef } from "./utils/use-external-ref"
 export { ValueAnimationControls } from "../animation/ValueAnimationControls"
+export { MotionProps }
 export { createMotionComponent }
 
 /**

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -3,9 +3,6 @@ import { createMotionComponent } from "./component"
 import { createDomMotionConfig } from "./features/dom"
 import { HTMLMotionComponents, SVGMotionComponents } from "./types"
 
-/**
- * These re-exports are to
- */
 export { MotionContext } from "./context/MotionContext"
 export { MotionValuesMap } from "./utils/use-motion-values"
 export { useExternalRef } from "./utils/use-external-ref"

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -1,45 +1,38 @@
+import * as React from "react"
 import { createMotionComponent } from "./component"
 import { createDomMotionConfig } from "./features/dom"
-import * as React from "react"
-import {
-    ReactHTML,
-    DetailedHTMLFactory,
-    HTMLAttributes,
-    PropsWithoutRef,
-    RefAttributes,
-    SVGAttributes,
-    ForwardRefExoticComponent,
-} from "react"
-import { HTMLElements, htmlElements } from "./utils/supported-elements"
-import { svgElements, SVGElements } from "./utils/supported-elements"
-import { MotionProps, MakeMotion } from "./types"
+import { HTMLMotionComponents, SVGMotionComponents } from "./types"
 
+/**
+ * These re-exports are to
+ */
 export { MotionContext } from "./context/MotionContext"
 export { MotionValuesMap } from "./utils/use-motion-values"
 export { useExternalRef } from "./utils/use-external-ref"
 export { ValueAnimationControls } from "../animation/ValueAnimationControls"
 export { createMotionComponent }
 
-export const htmlMotionComponents: HTMLMotionComponents = htmlElements.reduce(
-    (acc, Component) => {
-        const config = createDomMotionConfig(Component)
-        // Suppress "Expression produces a union type that is too complex to represent" error
-        // @ts-ignore
-        acc[Component] = createMotionComponent(config)
-        return acc
-    },
-    {} as HTMLMotionComponents
-)
+type Motion = HTMLMotionComponents & SVGMotionComponents
 
-export const svgMotionComponents: SVGMotionComponents = svgElements.reduce(
-    (acc, Component) => {
-        // Suppress "Expression produces a union type that is too complex to represent" error
-        // @ts-ignore
-        acc[Component] = createMotionComponent(createDomMotionConfig(Component))
-        return acc
-    },
-    {} as SVGMotionComponents
-)
+/**
+ * Convert any React component into a `motion` component. The provided component
+ * **must** use `React.forwardRef` to the underlying DOM component you want to animate.
+ *
+ * ```jsx
+ * const Component = React.forwardRef((props, ref) => {
+ *   return <div ref={ref} />
+ * })
+ *
+ * const MotionComponent = motion.custom(Component)
+ * ```
+ *
+ * @public
+ */
+function custom<Props>(Component: string | React.ComponentType<Props>) {
+    return createMotionComponent<Props>(createDomMotionConfig(Component))
+}
+
+const componentCache = new Map<string, any>()
 
 /**
  * HTML & SVG components, optimised for use with gestures and animation. These can be used as
@@ -60,103 +53,20 @@ export const svgMotionComponents: SVGMotionComponents = svgElements.reduce(
  *
  * @public
  */
-export const motion = {
-    /**
-     * Convert a custom React component into a `motion` component.
-     *
-     * It can also accept a string, to create [custom DOM elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements).
-     *
-     * ```jsx
-     * const Component = React.forwardRef((props: Props, ref) => {
-     *   return <div ref={ref} />
-     * })
-     *
-     * const MotionComponent = motion.custom<Props>(Component)
-     * ```
-     *
-     * @param Component -
-     */
-    custom: function custom<Props>(
-        Component: string | React.ComponentType<Props>
-    ) {
-        return createMotionComponent<Props>(createDomMotionConfig(Component))
-    },
-    ...htmlMotionComponents,
-    ...svgMotionComponents,
-}
+export const motion = new Proxy(
+    { custom },
+    {
+        get: (target: any, key: string) => {
+            if (key === "custom") return target.custom
 
-type UnwrapFactoryAttributes<F> = F extends DetailedHTMLFactory<infer P, any>
-    ? P
-    : never
-type UnwrapFactoryElement<F> = F extends DetailedHTMLFactory<any, infer P>
-    ? P
-    : never
-type UnwrapSVGFactoryElement<F> = F extends React.SVGProps<infer P> ? P : never
+            if (!componentCache.has(key)) {
+                componentCache.set(
+                    key,
+                    createMotionComponent(createDomMotionConfig(key))
+                )
+            }
 
-type HTMLAttributesWithoutMotionProps<
-    Attributes extends HTMLAttributes<Element>,
-    Element extends HTMLElement
-> = { [K in Exclude<keyof Attributes, keyof MotionProps>]?: Attributes[K] }
-
-/**
- * @public
- */
-export type HTMLMotionProps<
-    TagName extends keyof ReactHTML
-> = HTMLAttributesWithoutMotionProps<
-    UnwrapFactoryAttributes<ReactHTML[TagName]>,
-    UnwrapFactoryElement<ReactHTML[TagName]>
-> &
-    MotionProps
-
-/**
- * Motion-optimised versions of React's HTML components.
- *
- * @public
- */
-export type HTMLMotionComponents = {
-    [K in HTMLElements]: ForwardRefComponent<
-        UnwrapFactoryElement<ReactHTML[K]>,
-        HTMLMotionProps<K>
-    >
-}
-
-interface SVGAttributesWithoutMotionProps<T>
-    extends Pick<
-        SVGAttributes<T>,
-        Exclude<keyof SVGAttributes<T>, keyof MotionProps>
-    > {}
-
-/**
- * Blanket-accept any SVG attribute as a `MotionValue`
- * @public
- */
-export type SVGAttributesAsMotionValues<T> = MakeMotion<
-    SVGAttributesWithoutMotionProps<T>
->
-
-/**
- * @public
- */
-export interface SVGMotionProps<T>
-    extends SVGAttributesAsMotionValues<T>,
-        MotionProps {}
-
-/**
- * @public
- */
-export type ForwardRefComponent<T, P> = ForwardRefExoticComponent<
-    PropsWithoutRef<P> & RefAttributes<T>
->
-
-/**
- * Motion-optimised versions of React's SVG components.
- *
- * @public
- */
-export type SVGMotionComponents = {
-    [K in SVGElements]: ForwardRefComponent<
-        UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>,
-        SVGMotionProps<UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>>
-    >
-}
+            return componentCache.get(key)
+        },
+    }
+) as Motion

--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -1,4 +1,13 @@
-import { CSSProperties } from "react"
+import {
+    CSSProperties,
+    ReactHTML,
+    DetailedHTMLFactory,
+    HTMLAttributes,
+    PropsWithoutRef,
+    RefAttributes,
+    SVGAttributes,
+    ForwardRefExoticComponent,
+} from "react"
 import { MotionValue } from "../value"
 import { AnimationControls } from "../animation/AnimationControls"
 import {
@@ -13,6 +22,8 @@ import {
 import { GestureHandlers } from "../gestures"
 import { DraggableProps } from "../behaviours/types"
 import { AutoAnimateProps } from "./features/auto/types"
+import { HTMLElements } from "./utils/supported-elements"
+import { SVGElements } from "./utils/supported-elements"
 
 export type MotionStyleProp = string | number | MotionValue
 
@@ -552,4 +563,83 @@ export enum AnimatePropType {
     Target = "Target", // eslint-disable-line no-shadow
     VariantLabel = "VariantLabel",
     AnimationSubscription = "AnimationSubscription",
+}
+
+/**
+ * Support for React component props
+ */
+type UnwrapFactoryAttributes<F> = F extends DetailedHTMLFactory<infer P, any>
+    ? P
+    : never
+type UnwrapFactoryElement<F> = F extends DetailedHTMLFactory<any, infer P>
+    ? P
+    : never
+type UnwrapSVGFactoryElement<F> = F extends React.SVGProps<infer P> ? P : never
+
+type HTMLAttributesWithoutMotionProps<
+    Attributes extends HTMLAttributes<Element>,
+    Element extends HTMLElement
+> = { [K in Exclude<keyof Attributes, keyof MotionProps>]?: Attributes[K] }
+
+/**
+ * @public
+ */
+export type HTMLMotionProps<
+    TagName extends keyof ReactHTML
+> = HTMLAttributesWithoutMotionProps<
+    UnwrapFactoryAttributes<ReactHTML[TagName]>,
+    UnwrapFactoryElement<ReactHTML[TagName]>
+> &
+    MotionProps
+
+/**
+ * Motion-optimised versions of React's HTML components.
+ *
+ * @public
+ */
+export type HTMLMotionComponents = {
+    [K in HTMLElements]: ForwardRefComponent<
+        UnwrapFactoryElement<ReactHTML[K]>,
+        HTMLMotionProps<K>
+    >
+}
+
+interface SVGAttributesWithoutMotionProps<T>
+    extends Pick<
+        SVGAttributes<T>,
+        Exclude<keyof SVGAttributes<T>, keyof MotionProps>
+    > {}
+
+/**
+ * Blanket-accept any SVG attribute as a `MotionValue`
+ * @public
+ */
+export type SVGAttributesAsMotionValues<T> = MakeMotion<
+    SVGAttributesWithoutMotionProps<T>
+>
+
+/**
+ * @public
+ */
+export interface SVGMotionProps<T>
+    extends SVGAttributesAsMotionValues<T>,
+        MotionProps {}
+
+/**
+ * @public
+ */
+export type ForwardRefComponent<T, P> = ForwardRefExoticComponent<
+    PropsWithoutRef<P> & RefAttributes<T>
+>
+
+/**
+ * Motion-optimised versions of React's SVG components.
+ *
+ * @public
+ */
+export type SVGMotionComponents = {
+    [K in SVGElements]: ForwardRefComponent<
+        UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>,
+        SVGMotionProps<UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>>
+    >
 }

--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -22,8 +22,7 @@ import {
 import { GestureHandlers } from "../gestures"
 import { DraggableProps } from "../behaviours/types"
 import { AutoAnimateProps } from "./features/auto/types"
-import { HTMLElements } from "./utils/supported-elements"
-import { SVGElements } from "./utils/supported-elements"
+import { HTMLElements, SVGElements } from "./utils/supported-elements"
 
 export type MotionStyleProp = string | number | MotionValue
 


### PR DESCRIPTION
Currently, components like motion.div are generated from an explicit list of HTML and SVG elements. This PR replaces this with a Proxy that can dynamically create motion components for any motion.. This reduces the generated bundle size by 0.5kb. With improved types we can extend this approach to support all custom Web Components.