### PR TITLE
Add interface to fix transform values tests

### DIFF
--- a/src/motion/__tests__/util-transform-values.ts
+++ b/src/motion/__tests__/util-transform-values.ts
@@ -5,6 +5,7 @@ import {
     ValueTarget,
     ResolvedValueTarget,
     ResolvedKeyframesTarget,
+    TransformValues,
 } from "../../types"
 
 const resolveSingleValue = (
@@ -29,7 +30,9 @@ const resolveValue = (v: ValueTarget): ResolvedValueTarget => {
 }
 
 // If this function grows with new properties it'll probably benefit from a map approach
-export const transformValues = <T extends any>(values: T): T => {
+export const transformValues = <T extends any | TransformValues>(
+    values: T
+): T => {
     for (const key in values) {
         values[key] = resolveValue(values[key]) as any
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1575,6 +1575,16 @@ export interface None {
     velocity?: number
 }
 
+/**
+ * @public
+ */
+export interface TransformValues {
+    image?: string
+    size?: number | string
+    width?: number | string
+    height?: number | string
+}
+
 export type PopmotionTransitionProps =
     | Tween
     | Spring


### PR DESCRIPTION
When running `npm run test` script.

_Before_

<img width="872" alt="Screen Shot 2020-05-23 at 8 11 38 PM" src="https://user-images.githubusercontent.com/3586765/82742961-68c6b500-9d32-11ea-9ed1-6ca6ff57d19e.png">

_After_ 

<img width="830" alt="Screen Shot 2020-05-23 at 8 15 10 PM" src="https://user-images.githubusercontent.com/3586765/82742960-66645b00-9d32-11ea-8a60-4469ea888a0b.png">