### PR TITLE
Add shouldAnimate prop to Auto & animate stack based on lead

### DIFF
--- a/dev/examples/sharedLayoutFramerSetupShouldAnimate.tsx
+++ b/dev/examples/sharedLayoutFramerSetupShouldAnimate.tsx
@@ -1,0 +1,133 @@
+import * as React from "react"
+import { useState } from "react"
+import { motion, AnimateSharedLayout, AnimatePresence } from "@framer"
+import styled from "styled-components"
+
+/** This demo emulates the screen setup that Framer uses in Navigation component */
+
+const Container = styled.div`
+    width: 300px;
+    height: 500px;
+    overflow: hidden;
+    background-color: #f3f3f3;
+    border-radius: 20px;
+    position: relative;
+`
+
+const screen = {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+}
+
+const card = {
+    position: "absolute",
+    top: 50,
+    left: 50,
+    width: 200,
+    height: 200,
+    background: "rgba(0,0,255,0.5)",
+    borderRadius: 10,
+}
+
+const child = {
+    position: "absolute",
+    top: 10,
+    left: 10,
+    width: 100,
+    height: 100,
+    background: "rgba(0,255,0,1)",
+    borderRadius: 20,
+}
+
+function A({ layoutOrder, zIndex, shouldAnimate }) {
+    return (
+        <motion.div style={{ ...screen, zIndex }}>
+            <motion.div
+                key="card"
+                layoutId="card"
+                layoutOrder={layoutOrder}
+                shouldAnimate={false}
+                style={{ ...card, background: "green" }}
+            >
+                <motion.div
+                    key="child"
+                    layoutId="child"
+                    layoutOrder={layoutOrder}
+                    shouldAnimate={shouldAnimate}
+                    style={{ ...child }}
+                ></motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+function B({ layoutOrder, zIndex, shouldAnimate }) {
+    return (
+        <motion.div style={{ ...screen, zIndex }}>
+            <motion.div
+                layoutId="card"
+                layoutOrder={layoutOrder}
+                shouldAnimate={false}
+                style={{ ...card, background: "red" }}
+            >
+                <motion.div
+                    layoutId="child"
+                    layoutOrder={layoutOrder}
+                    shouldAnimate={shouldAnimate}
+                    style={{ ...child, top: 50 }}
+                ></motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+const stack = [A, B, A, B, A, B]
+
+export const App = () => {
+    const [page, setPage] = useState(0)
+
+    const components = []
+
+    for (let i = 0; i <= page; i++) {
+        const Component = stack[i]
+        const existingIndex = components.findIndex(
+            entry => entry.Component === Component
+        )
+
+        if (existingIndex === -1) {
+            components.push({
+                Component: stack[i],
+                key: i,
+                layoutOrder: i,
+                shouldAnimate: i === 0 ? false : true,
+            })
+        } else {
+            components[existingIndex] = {
+                Component: stack[i],
+                key: existingIndex,
+                zIndex: i,
+                layoutOrder: i,
+                shouldAnimate: true,
+            }
+        }
+    }
+
+    return (
+        <Container onClick={() => setPage(page + 1)}>
+            <AnimateSharedLayout
+                type="crossfade"
+                supportRotate
+                transition={{ duration: 2 }}
+            >
+                <AnimatePresence>
+                    {components.map(({ Component, ...props }) => (
+                        <Component {...props} />
+                    ))}
+                </AnimatePresence>
+            </AnimateSharedLayout>
+        </Container>
+    )
+}

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -258,9 +258,9 @@ export class AnimateSharedLayout extends React.Component<
                     isAutoAnimate(child) ||
                     // If this component is either entering or present
                     child.presence !== Presence.Exiting ||
-                    // If the lead component in the stack is present, snapshot
+                    // If the lead component in the stack is present and should animate, snapshot
                     // TODO: Figure out what this breaks if removed
-                    stack?.lead?.isPresent()
+                    (stack?.lead?.isPresent() && stack?.shouldStackAnimate())
                 ) {
                     child.snapshotTarget()
                 }
@@ -282,6 +282,7 @@ export class AnimateSharedLayout extends React.Component<
                 const animation = child.startAnimation({
                     ...options,
                     ...config,
+                    shouldAnimate: stack?.shouldStackAnimate(),
                 })
 
                 if (!animation) return

--- a/src/components/AnimateSharedLayout/stack.ts
+++ b/src/components/AnimateSharedLayout/stack.ts
@@ -9,6 +9,7 @@ export interface StackChild {
     shouldAnimate?: boolean
     props: {
         layoutOrder?: number
+        shouldAnimate?: boolean
     }
 }
 
@@ -161,6 +162,10 @@ export class LayoutStack<T extends StackChild = StackChild> {
 
     isLeadPresent() {
         return this.lead && this.lead?.presence !== Presence.Exiting
+    }
+
+    shouldStackAnimate() {
+        return this.lead && this.lead?.props?.shouldAnimate === true
     }
 
     getFollowOrigin() {

--- a/src/motion/features/auto/Auto.tsx
+++ b/src/motion/features/auto/Auto.tsx
@@ -210,6 +210,10 @@ export class Auto extends React.Component<FeatureProps & ContextProps> {
         this.delta = props.localContext.layoutDelta as BoxDelta
         this.depth = props.localContext.layoutDepth
         this.progress = props.localContext.layoutProgress as MotionValue<number>
+        this.shouldAnimate =
+            props.shouldAnimate !== undefined
+                ? props.shouldAnimate
+                : this.shouldAnimate
 
         const { autoValues } = props
         this.supportedAutoValues = {
@@ -276,6 +280,11 @@ export class Auto extends React.Component<FeatureProps & ContextProps> {
     }
 
     shouldComponentUpdate(nextProps: FeatureProps & ContextProps) {
+        if (this.props.shouldAnimate !== undefined) {
+            this.shouldAnimate = this.props.shouldAnimate
+            return true
+        }
+
         const hasDependency =
             this.props.magicDependency !== undefined ||
             nextProps.magicDependency !== undefined
@@ -451,6 +460,11 @@ export class Auto extends React.Component<FeatureProps & ContextProps> {
 
         const { parentContext } = this.props
         const parentDeltas = parentContext.layoutDeltas || []
+
+        this.shouldAnimate =
+            opts.shouldAnimate !== undefined
+                ? opts.shouldAnimate
+                : this.shouldAnimate
 
         if (
             this.shouldAnimate &&

--- a/src/motion/features/auto/types.ts
+++ b/src/motion/features/auto/types.ts
@@ -63,6 +63,7 @@ export interface AutoAnimationConfig {
     crossfadeEasing?: Easing
     type?: "switch" | "crossfade"
     crossfade?: any
+    shouldAnimate?: boolean
 }
 
 export interface AutoAnimateProps {
@@ -100,4 +101,11 @@ export interface AutoAnimateProps {
      * @internal
      */
     isPresent?: boolean
+
+    /**
+     * Manually control whether a component should animate it's transition. Currently only intended for optimisations in Framer Navigation component.
+     *
+     * @internal
+     */
+    shouldAnimate?: boolean
 }


### PR DESCRIPTION
### Changes
- Allow preventing Auto animations by passing `shouldAnimate={false}` 
- In shared layout transitions, use the lead value for `shouldAnimate` to determine whether the stack should animate.
- Add example