### PR TITLE
Ensure crossfade is always performed

### DIFF
--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -279,10 +279,15 @@ export class AnimateSharedLayout extends React.Component<
                     stack
                 )
 
+                const shouldAnimate =
+                    type === "crossfade" && child.depth === this.rootDepth
+                        ? true
+                        : stack?.shouldStackAnimate()
+
                 const animation = child.startAnimation({
                     ...options,
                     ...config,
-                    shouldAnimate: stack?.shouldStackAnimate(),
+                    shouldAnimate,
                 })
 
                 if (!animation) return

--- a/src/components/AnimateSharedLayout/stack.ts
+++ b/src/components/AnimateSharedLayout/stack.ts
@@ -171,11 +171,7 @@ export class LayoutStack<T extends StackChild = StackChild> {
     }
 
     getFollowOrigin() {
-        // This shouldAnimate check is quite specifically a fix for the optimisation made in Framer
-        // where components are kept in the tree ready to be re-used
-        return this.follow && this.follow.shouldAnimate
-            ? this.follow.measuredOrigin
-            : this.snapshot
+        return this.follow ? this.follow.measuredOrigin : this.snapshot
     }
 
     getFollowTarget() {


### PR DESCRIPTION
- This fix ensures crossfades are always performed in Framer even if `_shouldAnimate` is false (for instance if ground nodes do not share matching layoutId's and so should not animate between transitions)
- Additionally removes a Framer-specific check that is no longer required.

The former fix could ofc live in Framer by ensuring ground nodes are always tagged with _shouldAnimate: true. However if we are going to support _shouldAnimate in motion anyway I think this could be a gotcha because it completely breaks the animation if the root is tagged with _shouldAnimate=false so I think it makes sense to ensure crossfades always work here.