### PR TITLE
[WIP] Adding layoutX and layoutY props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] 2020-07-20
+
+### Added
+
+-   Added `layoutX` and `layoutY` readonly MotionValue props for hooking other MotionValues into the layout calculations.
+
+### Fixed
+
+-   Fixed `originX` and `originY` being used incorrectly in bounding box measurements for layout children.
+
 ## [2.1.1] 2020-07-20
 
 ### Fixed

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -322,6 +322,8 @@ export type KeyframesTarget = ResolvedKeyframesTarget | [null, ...CustomValueTyp
 export interface LayoutProps {
     layout?: boolean | "position";
     layoutId?: string;
+    layoutX?: MotionValue<number>;
+    layoutY?: MotionValue<number>;
     onLayoutAnimationComplete?(): void;
     onViewportBoxUpdate?(box: AxisBox2D, delta: BoxDelta): void;
 }

--- a/dev/examples/Drag-drag-to-reorder.tsx
+++ b/dev/examples/Drag-drag-to-reorder.tsx
@@ -44,6 +44,8 @@ const Item = ({ color, setPosition, moveItem, i }) => {
                     background: "white",
                     height: heights[color],
                     borderRadius: 5,
+                    originX: 0,
+                    originY: 0,
                 }}
                 whileHover={{
                     scale: 1.03,

--- a/dev/examples/Layout-Projection-external-motion-values.tsx
+++ b/dev/examples/Layout-Projection-external-motion-values.tsx
@@ -1,0 +1,118 @@
+import * as React from "react"
+import { motion, useMotionValue, useTransform } from "@framer"
+import styled from "styled-components"
+
+/**
+ *
+ */
+
+export const Example = () => {
+    const x = useMotionValue(0)
+    const xInput = [-100, 0, 100]
+    const background = useTransform(x, xInput, [
+        "linear-gradient(180deg, #ff008c 0%, rgb(211, 9, 225) 100%)",
+        "linear-gradient(180deg, #7700ff 0%, rgb(68, 0, 255) 100%)",
+        "linear-gradient(180deg, rgb(230, 255, 0) 0%, rgb(3, 209, 0) 100%)",
+    ])
+    const color = useTransform(x, xInput, [
+        "rgb(211, 9, 225)",
+        "rgb(68, 0, 255)",
+        "rgb(3, 209, 0)",
+    ])
+    const tickPath = useTransform(x, [10, 100], [0, 1])
+    const crossPathA = useTransform(x, [-10, -55], [0, 1])
+    const crossPathB = useTransform(x, [-50, -100], [0, 1])
+
+    return (
+        <motion.div className="example-container" style={{ background }}>
+            <motion.div
+                className="box"
+                layoutX={x}
+                drag="x"
+                dragConstraints={{ left: 0, right: 0 }}
+            >
+                <svg className="progress-icon" viewBox="0 0 50 50">
+                    <motion.path
+                        fill="none"
+                        strokeWidth="2"
+                        stroke={color}
+                        d="M 0, 20 a 20, 20 0 1,0 40,0 a 20, 20 0 1,0 -40,0"
+                        style={{ translateX: 5, translateY: 5 }}
+                    />
+                    <motion.path
+                        fill="none"
+                        strokeWidth="2"
+                        stroke={color}
+                        d="M14,26 L 22,33 L 35,16"
+                        strokeDasharray="0 1"
+                        style={{ pathLength: tickPath }}
+                    />
+                    <motion.path
+                        fill="none"
+                        strokeWidth="2"
+                        stroke={color}
+                        d="M17,17 L33,33"
+                        strokeDasharray="0 1"
+                        style={{ pathLength: crossPathA }}
+                    />
+                    <motion.path
+                        fill="none"
+                        strokeWidth="2"
+                        stroke={color}
+                        d="M33,17 L17,33"
+                        strokeDasharray="0 1"
+                        style={{ pathLength: crossPathB }}
+                    />
+                </svg>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    return (
+        <Container>
+            <Example />
+        </Container>
+    )
+}
+
+const Container = styled.div`
+    .example-container {
+        width: 100vw;
+        height: 100vh;
+    }
+
+    .box {
+        background: white;
+        border-radius: 30px;
+        width: 150px;
+        height: 150px;
+        position: absolute;
+        top: calc(50% - 150px / 2);
+        left: calc(50% - 150px / 2);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .progress-icon {
+        width: 80%;
+        height: 80%;
+    }
+
+    .refresh {
+        padding: 10px;
+        position: absolute;
+        background: rgba(0, 0, 0, 0.4);
+        border-radius: 10px;
+        width: 20px;
+        height: 20px;
+        top: 10px;
+        right: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+    }
+`

--- a/dev/examples/Layout-Projection-external-motion-values.tsx
+++ b/dev/examples/Layout-Projection-external-motion-values.tsx
@@ -3,7 +3,8 @@ import { motion, useMotionValue, useTransform } from "@framer"
 import styled from "styled-components"
 
 /**
- *
+ * This is an example of hooking up MotionValues to the component's projected layout
+ * via the layoutX and layoutY props.
  */
 
 export const Example = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "dist/framer-motion.d.ts",

--- a/src/motion/features/layout/types.ts
+++ b/src/motion/features/layout/types.ts
@@ -1,4 +1,5 @@
 import { AxisBox2D, BoxDelta } from "../../../types/geometry"
+import { MotionValue } from "../../../value"
 
 export interface LayoutProps {
     /**
@@ -63,4 +64,52 @@ export interface LayoutProps {
      * @public
      */
     onViewportBoxUpdate?(box: AxisBox2D, delta: BoxDelta): void
+
+    /**
+     * A **readonly** MotionValue that will be updated with the latest x-axis delta
+     * between a component's viewport box and its actual layout box.
+     *
+     * This will only be updated when using layout-aware props like `layout` and `drag`.
+     *
+     * ```jsx
+     * function Component() {
+     *   const deltaX = useMotionValue(0)
+     *   const opacity = useTransform(deltaX, [-100, 0, 100], [0, 1, 0])
+     *
+     *   return (
+     *     <motion.div
+     *       drag="x"
+     *       deltaX={deltaX}
+     *       style={{ opacity }}
+     *     />
+     * }
+     * ```
+     *
+     * @public
+     */
+    deltaX?: MotionValue<number>
+
+    /**
+     * A **readonly** MotionValue that will be updated with the latest x-axis delta
+     * between a component's viewport box and its actual layout box.
+     *
+     * This will only be updated when using layout-aware props like `layout` and `drag`.
+     *
+     * ```jsx
+     * function Component() {
+     *   const deltaY = useMotionValue(0)
+     *   const opacity = useTransform(deltaY, [-100, 0, 100], [0, 1, 0])
+     *
+     *   return (
+     *     <motion.div
+     *       drag="x"
+     *       deltaY={deltaY}
+     *       style={{ opacity }}
+     *     />
+     * }
+     * ```
+     *
+     * @public
+     */
+    deltaY?: MotionValue<number>
 }

--- a/src/motion/utils/use-motion-values.ts
+++ b/src/motion/utils/use-motion-values.ts
@@ -108,6 +108,6 @@ function addMotionValues(
  * These are props we accept as MotionValues but don't want to add
  * to the VisualElement
  */
-const reservedNames = new Set<string>([])
+const reservedNames = new Set<string>(["layoutX", "layoutY"])
 
 const empty = (): MotionValueSource => ({})

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -20,6 +20,8 @@ const validMotionProps = new Set<keyof MotionProps>([
     "static",
     "layout",
     "layoutId",
+    "deltaX",
+    "deltaY",
     "onLayoutAnimationComplete",
     "onViewportBoxUpdate",
     "onAnimationStart",

--- a/src/render/dom/types.ts
+++ b/src/render/dom/types.ts
@@ -11,6 +11,7 @@ import { MotionProps, MakeMotion } from "../../motion/types"
 import { TransformPoint2D } from "../../types/geometry"
 import { HTMLElements, SVGElements } from "./utils/supported-elements"
 import { VisualElementConfig } from "../types"
+import { LayoutProps } from "../../motion/features/layout/types"
 
 /**
  * Configuration for the HTML and SVGVisualElement renderers.
@@ -48,11 +49,14 @@ export interface DOMVisualElementConfig extends VisualElementConfig {
      */
     transformTemplate?: MotionProps["transformTemplate"]
 
-    onViewportBoxUpdate?: MotionProps["onViewportBoxUpdate"]
+    onViewportBoxUpdate?: LayoutProps["onViewportBoxUpdate"]
 
     transition?: MotionProps["transition"]
 
     layoutOrder?: number
+
+    deltaX?: LayoutProps["deltaX"]
+    deltaY?: LayoutProps["deltaY"]
 }
 
 export interface TransformOrigin {

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -99,11 +99,10 @@ export function applyAxisTransforms(
     final.min = axis.min
     final.max = axis.max
 
-    const originPoint = mix(
-        axis.min,
-        axis.max,
-        (transforms[originKey] as number) || 0.5
-    )
+    const axisOrigin =
+        transforms[originKey] !== undefined ? transforms[originKey] : 0.5
+
+    const originPoint = mix(axis.min, axis.max, axisOrigin as number)
 
     // Apply the axis delta to the final axis
     applyAxisDelta(


### PR DESCRIPTION
# The Problem

In Motion 2, layout animations and drag gestures are performed using **layout projection**. Once every frame, we calculate the transform needed to project an element from its actual layout, as transformed by parent transforms, into a desired viewport-relative bounding box.

As such, this transform is often seemingly arbitrary, and as such can't really be leveraged by users for any useful effects.

In Motion 1, it was often the case that people would hook into x/y transforms for effects like this: https://codesandbox.io/s/framer-motion-path-drawing-drag-and-usetransform-jnqk2. This is no longer possible with drag gestures in Motion 2.

# The Solution

This PR adds a new viewport-relative `delta` model that is saner for users. It is calculated only if the user indicates they want to "listen" to it by setting `onViewportBoxUpdate`, or the new `layoutX`/`layoutY` props.

`layoutX` and `layoutY` accept readonly motion values that can be hooked up the same way as the linked sandbox (see added example). They're "readonly" in the sense that they're not the source of truth and, like `scrollX`/`scrollY` from `useViewportScroll`, if set by a user they're not expected to have an effect.

# Question

Currently the `deltaViewport` calculated for `onViewportBoxUpdate` and the new props is based on the delta between the layout bounding box and the target bounding box **before user-set transforms are applied to it**. Is it potentially more useful for us to calculate it in relation to the target bounding box **after** transforms are applied? My intuition is to keep them separate, but I thought I'd get opinions.

# Bug fixes

This PR also fixes a bug where the user-defined `originX` and `originY` weren't correctly factored into the measurement of bounding boxes which lead to glitchy behaviours when mixing transforms with drag.

