### PR TITLE
Layout projection performance

### DIFF
--- a/dev/examples/Animation-layout-update-stress.tsx
+++ b/dev/examples/Animation-layout-update-stress.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+import { motion, useCycle, AnimateSharedLayout } from "@framer"
+import styled from "styled-components"
+
+/**
+ * This is an example used to stress-test the updateDelta algorithm
+ */
+const transition = { duration: 3, ease: "circIn" }
+
+const maxChildren = 4
+const maxDepth = 2
+function layoutChildren(currentDepth: number) {
+    const children = []
+
+    for (let i = 0; i < maxChildren; i++) {
+        children.push(
+            <motion.div layout key={i}>
+                {currentDepth < maxDepth && layoutChildren(currentDepth + 1)}
+            </motion.div>
+        )
+    }
+
+    return children
+}
+
+export const App = () => {
+    const [isOpen, toggleIsOpen] = useCycle(true, false)
+
+    return (
+        <AnimateSharedLayout>
+            <Container layout data-isOpen={isOpen} onClick={toggleIsOpen}>
+                {layoutChildren(0)}
+            </Container>
+        </AnimateSharedLayout>
+    )
+}
+
+const Container = styled(motion.div)`
+    width: 500px;
+    height: 500px;
+    background: white;
+    display: flex;
+    align-items: stretch;
+    justify-content: stretch;
+
+    div {
+        display: flex;
+        align-items: stretch;
+        justify-content: stretch;
+        background-color: red;
+        width: 25%;
+        height: 25%;
+
+        div {
+            background-color: blue;
+
+            div {
+                background-color: green;
+            }
+        }
+    }
+
+    &[data-isOpen="true"] {
+        align-items: flex-end;
+        div {
+            align-items: flex-end;
+        }
+    }
+`

--- a/src/animation/use-animated-state.ts
+++ b/src/animation/use-animated-state.ts
@@ -12,6 +12,8 @@ import { ResolvedValues } from "../render/types"
 class StateVisualElement extends VisualElement {
     initialState: ResolvedValues = {}
 
+    updateLayoutDelta() {}
+
     build() {}
 
     clean() {}

--- a/src/render/VisualElement.ts
+++ b/src/render/VisualElement.ts
@@ -19,6 +19,9 @@ export abstract class VisualElement<E = any> {
     // A reference to the parent VisualElement
     parent?: VisualElement<E>
 
+    // A reference to the root parent VisualElement
+    rootParent?: VisualElement<E>
+
     // An iterable list of current children
     children: Set<VisualElement<E>> = new Set()
 
@@ -59,10 +62,9 @@ export abstract class VisualElement<E = any> {
     readonly depth: number
 
     constructor(parent?: VisualElement<E>, ref?: Ref<E>) {
-        // Create a relationship with the provided parent. When we come to replace
-        // the auto-animation stuff with VisualElement we might need to make this
-        // relationship two-way
+        // Create a relationship with the provided parent.
         this.parent = parent
+        this.rootParent = parent ? parent.rootParent : this
 
         this.treePath = parent ? [...parent.treePath, parent] : []
 
@@ -200,13 +202,6 @@ export abstract class VisualElement<E = any> {
 
         if (this.parent) {
             this.removeFromParent = this.parent.subscribe(this)
-
-            /**
-             * Save a reference to the nearest layout projecting ancestor.
-             */
-            // this.layoutParent = this.parent.isLayoutProjectionEnabled
-            //     ? this.parent
-            //     : this.parent.layoutParent
         }
 
         /**

--- a/src/render/VisualElement.ts
+++ b/src/render/VisualElement.ts
@@ -20,7 +20,7 @@ export abstract class VisualElement<E = any> {
     parent?: VisualElement<E>
 
     // A reference to the root parent VisualElement
-    rootParent?: VisualElement<E>
+    rootParent: VisualElement<E>
 
     // An iterable list of current children
     children: Set<VisualElement<E>> = new Set()
@@ -155,6 +155,8 @@ export abstract class VisualElement<E = any> {
     // A function that returns a bounding box for the rendered instance.
     abstract getBoundingBox(): AxisBox2D
 
+    abstract updateLayoutDelta(): void
+
     // Set a single `latest` value
     private setSingleStaticValue(key: string, value: string | number) {
         this.latest[key] = value
@@ -175,6 +177,10 @@ export abstract class VisualElement<E = any> {
     triggerRender = () => this.render()
 
     scheduleRender = () => sync.render(this.triggerRender, false, true)
+
+    scheduleUpdateLayoutDelta() {
+        sync.update(this.rootParent.updateLayoutDelta, false, true)
+    }
 
     // Subscribe to changes in a MotionValue
     private subscribeToValue(key: string, value: MotionValue) {

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -25,7 +25,6 @@ import { eachAxis } from "../../utils/each-axis"
 import { motionValue, MotionValue } from "../../value"
 import { startAnimation } from "../../animation/utils/transitions"
 import { getBoundingBox } from "./layout/measure"
-import sync, { getFrameData } from "framesync"
 import { createDeltaTransform } from "./utils/project-layout"
 
 export type LayoutUpdateHandler = (
@@ -381,7 +380,7 @@ export class HTMLVisualElement<
         // Flag that we want to fire the onViewportBoxUpdate event handler
         this.hasViewportBoxUpdated = true
 
-        this.rootParent.scheduleUpdateDeltas()
+        this.rootParent.scheduleUpdateLayoutDelta()
     }
 
     /**
@@ -411,10 +410,6 @@ export class HTMLVisualElement<
 
     stopLayoutAnimation() {
         eachAxis(axis => this.axisProgress[axis].stop())
-    }
-
-    scheduleUpdateDeltas() {
-        sync.update(this.rootParent.updateLayoutDelta, false, true)
     }
 
     updateLayoutDelta = () => {
@@ -447,8 +442,8 @@ export class HTMLVisualElement<
         if (this.parent) {
             updateTreeScale(
                 this.treeScale,
-                this.parent.treeScale,
-                this.parent.delta
+                (this.parent as any).treeScale,
+                (this.parent as any).delta
             )
         }
 
@@ -550,7 +545,7 @@ export class HTMLVisualElement<
     }
 }
 
-const fireUpdateLayoutDelta = (child: HTMLVisualElement) =>
+const fireUpdateLayoutDelta = (child: VisualElement) =>
     child.updateLayoutDelta()
 
 interface MotionPoint {

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -242,7 +242,9 @@ export class HTMLVisualElement<
     deltaFinal: BoxDelta = delta()
 
     /**
-     *
+     * The computed transform string to apply deltaFinal to the element. Currently this is only
+     * being used to diff and decide whether to render on the current frame, but a minor optmisation
+     * could be to provide this to the buildHTMLStyle function.
      */
     deltaTransform: string
 

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -547,6 +547,10 @@ export class HTMLVisualElement<
     }
 }
 
+/**
+ * Pre-bound version of updateLayoutDelta so we're not creating a new function multiple
+ * times per frame.
+ */
 const fireUpdateLayoutDelta = (child: VisualElement) =>
     child.updateLayoutDelta()
 

--- a/src/render/dom/render.ts
+++ b/src/render/dom/render.ts
@@ -24,7 +24,7 @@ export function render<Props>(
      * that might have been taken out of the provided props.
      */
     visualElement.clean()
-    visualElement.build(true)
+    visualElement.build()
 
     // Generate props to visually render this component
     const visualProps = isSVGComponent(Component)

--- a/src/render/dom/utils/__tests__/build-html-props.test.ts
+++ b/src/render/dom/utils/__tests__/build-html-props.test.ts
@@ -25,7 +25,7 @@ describe("buildHTMLProps", () => {
         element.reactStyle.color = "#fff"
 
         element.clean()
-        element.build(true)
+        element.build()
 
         const draggableProps = buildHTMLProps(element, { drag: true })
 
@@ -40,7 +40,7 @@ describe("buildHTMLProps", () => {
         })
 
         element.clean()
-        element.build(true)
+        element.build()
         const notDraggableProps = buildHTMLProps(element, { drag: false })
 
         expect(notDraggableProps).toEqual({

--- a/src/render/dom/utils/build-html-styles.ts
+++ b/src/render/dom/utils/build-html-styles.ts
@@ -6,6 +6,7 @@ import { buildTransform } from "./build-transform"
 import { isCSSVariable } from "./is-css-variable"
 import { valueScaleCorrection } from "../layout/scale-correction"
 import { Point2D, AxisBox2D, BoxDelta } from "../../../types/geometry"
+import { createDeltaTransform } from "./project-layout"
 
 /**
  * Build style and CSS variables
@@ -133,7 +134,7 @@ export function buildHTMLStyles(
                 allowTransformNone
             )
         } else {
-            style.transform = layoutReprojection(deltaFinal!, treeScale!)
+            style.transform = createDeltaTransform(deltaFinal!, treeScale!)
         }
     }
 
@@ -151,12 +152,4 @@ export function buildHTMLStyles(
 
         style.transformOrigin = `${originX} ${originY} ${originZ}`
     }
-}
-
-function layoutReprojection(delta: BoxDelta, treeScale: Point2D) {
-    const x = delta.x.translate / treeScale.x
-    const y = delta.y.translate / treeScale.y
-    const scaleX = delta.x.scale
-    const scaleY = delta.y.scale
-    return `translate3d(${x}px, ${y}px, 0) scale(${scaleX}, ${scaleY})`
 }

--- a/src/render/dom/utils/project-layout.ts
+++ b/src/render/dom/utils/project-layout.ts
@@ -1,0 +1,9 @@
+import { BoxDelta, Point2D } from "../../../types/geometry"
+
+export function createDeltaTransform(delta: BoxDelta, treeScale: Point2D) {
+    const x = delta.x.translate / treeScale.x
+    const y = delta.y.translate / treeScale.y
+    const scaleX = delta.x.scale
+    const scaleY = delta.y.scale
+    return `translate3d(${x}px, ${y}px, 0) scale(${scaleX}, ${scaleY})`
+}

--- a/src/utils/geometry/__tests__/delta-apply.test.ts
+++ b/src/utils/geometry/__tests__/delta-apply.test.ts
@@ -195,8 +195,6 @@ describe("applyTreeDeltas", () => {
             y: { min: 300, max: 400 },
         }
 
-        const scale = { x: 1, y: 1 }
-
         const delta = {
             x: { translate: 100, scale: 2, origin: 0.5, originPoint: 150 },
             y: { translate: -100, scale: 0.5, origin: 0.5, originPoint: 350 },
@@ -205,16 +203,11 @@ describe("applyTreeDeltas", () => {
         const element = new HTMLVisualElement()
         element.delta = delta
 
-        applyTreeDeltas(box, scale, [element, element])
+        applyTreeDeltas(box, [element, element])
 
         expect(box).toEqual({
             x: { min: 250, max: 650 },
             y: { min: 187.5, max: 212.5 },
-        })
-
-        expect(scale).toEqual({
-            x: 4,
-            y: 0.25,
         })
     })
 })

--- a/src/utils/geometry/__tests__/delta-calc.test.ts
+++ b/src/utils/geometry/__tests__/delta-calc.test.ts
@@ -3,7 +3,9 @@ import {
     calcTranslate,
     calcOrigin,
     updateAxisDelta,
+    updateTreeScale,
 } from "../delta-calc"
+import { HTMLVisualElement } from "../../../render/dom/HTMLVisualElement"
 
 describe("isNear", () => {
     test("Correctly indicate when the provided value is within maxDistance of the provided target", () => {
@@ -101,5 +103,21 @@ describe("updateAxisDelta", () => {
             scale: 2,
             translate: 300,
         })
+    })
+})
+
+describe("updateTreeScale", () => {
+    test("Correctly updates a treeScale object by incorporating a parent delta into its scale", () => {
+        const treeScale = { x: 1, y: 1 }
+        const element = new HTMLVisualElement()
+        element.delta = {
+            x: { scale: 2, translate: 0, origin: 0, originPoint: 0 },
+            y: { scale: 0.5, translate: 0, origin: 0, originPoint: 0 },
+        }
+        element.treeScale = { x: 2, y: 2 }
+
+        updateTreeScale(treeScale, element.treeScale, element.delta)
+
+        expect(treeScale).toEqual({ x: 4, y: 1 })
     })
 })

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -2,7 +2,6 @@ import { Axis, AxisBox2D, BoxDelta } from "../../types/geometry"
 import { mix } from "@popmotion/popcorn"
 import { HTMLVisualElement } from "../../render/dom/HTMLVisualElement"
 import { ResolvedValues } from "../../render/types"
-import { getFrameData } from "framesync"
 
 /**
  * Reset an axis to the provided origin box.

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -2,6 +2,7 @@ import { Axis, AxisBox2D, BoxDelta } from "../../types/geometry"
 import { mix } from "@popmotion/popcorn"
 import { HTMLVisualElement } from "../../render/dom/HTMLVisualElement"
 import { ResolvedValues } from "../../render/types"
+import { getFrameData } from "framesync"
 
 /**
  * Reset an axis to the provided origin box.
@@ -215,20 +216,12 @@ export function removeBoxTransforms(
 /**
  * Apply a tree of deltas to a box. We do this to calculate the effect of all the transforms
  * in a tree upon our box before then calculating how to project it into our desired viewport-relative box
+ *
+ * This is the final nested loop within HTMLVisualElement.updateLayoutDelta
  */
-export function applyTreeDeltas(
-    box: AxisBox2D,
-    treeScale: { x: number; y: number },
-    treePath: HTMLVisualElement[]
-) {
-    treeScale.x = treeScale.y = 1
-
+export function applyTreeDeltas(box: AxisBox2D, treePath: HTMLVisualElement[]) {
     const treeLength = treePath.length
     for (let i = 0; i < treeLength; i++) {
-        const parent = treePath[i]
-        const delta = parent.delta
-        applyBoxDelta(box, delta)
-        treeScale.x *= delta.x.scale
-        treeScale.y *= delta.y.scale
+        applyBoxDelta(box, treePath[i].delta)
     }
 }

--- a/src/utils/geometry/delta-calc.ts
+++ b/src/utils/geometry/delta-calc.ts
@@ -82,3 +82,15 @@ export function updateBoxDelta(
     updateAxisDelta(delta.x, source.x, target.x, origin)
     updateAxisDelta(delta.y, source.y, target.y, origin)
 }
+
+/**
+ * Update the treeScale by incorporating the parent's latest scale into its treeScale.
+ */
+export function updateTreeScale(
+    treeScale: Point2D,
+    parentTreeScale: Point2D,
+    parentDelta: BoxDelta
+) {
+    treeScale.x = parentTreeScale.x * parentDelta.x.scale
+    treeScale.y = parentTreeScale.y * parentDelta.y.scale
+}

--- a/src/utils/geometry/delta-calc.ts
+++ b/src/utils/geometry/delta-calc.ts
@@ -1,4 +1,10 @@
-import { Axis, AxisDelta, BoxDelta, AxisBox2D } from "../../types/geometry"
+import {
+    Axis,
+    AxisDelta,
+    BoxDelta,
+    AxisBox2D,
+    Point2D,
+} from "../../types/geometry"
 import { mix, progress, clamp, distance } from "@popmotion/popcorn"
 
 const clampProgress = clamp(0, 1)


### PR DESCRIPTION
This PR changes the way layout deltas are updated per frame.

When a component has its viewport box updated, we need to update its transform delta so it correctly projects to this new bounding box.

For these calculations to be correct, we need to make sure all the component's parents are updated too. Currently, each component traverses its parents first and make sure those components have run their calculations.

This is safe in that it means the calculations are always correct but it's quite wasteful as it means that given a tree

```
A
 |-B
     |-C
```

The update methods for A will run three times if all three components are updating that frame.

This can been very wasteful - in the added dev/examples/Animation-layout-update-stress.tsx example, for 84 components we have ~550 updates(!). This is quite a common size for Magic Motion docs.

With this update we instead, when any component's viewport box is updated, schedule a function to run in the root component of that tree at the end of the current update step in `framesync`. This function traverses the tree, updating the layout box for each in turn. For 84 components we only update 84 times.