### PR TITLE
Features refactor and tree-shaking improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   Respecting `transformTemplate` for layout animations.
 -   Fixed `this.box is undefined` errors.
 
+### Changed
+
+-   Internal refactoring to improve tree-shaking and allow for dynamic feature injection.
+
 ## [2.1.1] 2020-07-20
 
 ### Fixed

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -168,7 +168,7 @@ export interface BoxDelta {
 // Warning: (ae-internal-missing-underscore) The name "createMotionComponent" should be prefixed with an underscore because the declaration is marked as @internal
 // 
 // @internal
-export function createMotionComponent<P extends {}, E>(Component: string | React.ComponentType<P>, { useVisualElement, render, animationControlsConfig, }: MotionComponentConfig<E>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<E>>;
+export function createMotionComponent<P extends {}, E>(Component: string | React.ComponentType<P>, { defaultFeatures, useVisualElement, render, animationControlsConfig, }: MotionComponentConfig<E>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<E>>;
 
 // @public (undocumented)
 export interface CustomValueType {
@@ -326,10 +326,18 @@ export interface LayoutProps {
     onViewportBoxUpdate?(box: AxisBox2D, delta: BoxDelta): void;
 }
 
-// Warning: (ae-forgotten-export) The symbol "Motion" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "HTMLMotionComponents" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SVGMotionComponents" needs to be exported by the entry point index.d.ts
 // 
+// @public (undocumented)
+export const m: HTMLMotionComponents & SVGMotionComponents & {
+    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => CustomDomComponent<Props>;
+};
+
 // @public
-export const motion: Motion;
+export const motion: HTMLMotionComponents & SVGMotionComponents & {
+    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => CustomDomComponent<Props>;
+};
 
 // @public (undocumented)
 export interface MotionAdvancedProps {
@@ -762,6 +770,10 @@ export class VisualElementAnimationControls<P extends {} = {}, V extends {} = {}
     stop(): void;
     }
 
+
+// Warnings were encountered during analysis:
+// 
+// types/render/dom/index.d.ts:23:5 - (ae-forgotten-export) The symbol "CustomDomComponent" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,14 @@ const external = [
     ...Object.keys(pkg.peerDependencies || {}),
 ]
 
+const pureClass = {
+    transform(code) {
+        // Replace TS emitted @class function annotations with PURE so terser
+        // can remove them
+        return code.replace(/\/\*\* @class \*\//g, "/*@__PURE__*/")
+    },
+}
+
 const umd = Object.assign({}, config, {
     output: {
         file: `dist/${pkg.name}.dev.js`,
@@ -38,7 +46,8 @@ const umdProd = Object.assign({}, umd, {
         replace({
             "process.env.NODE_ENV": JSON.stringify("production"),
         }),
-        terser({ output:{ comments: false }}),
+        pureClass,
+        terser({ output: { comments: false } }),
     ],
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Components
  */
-export { motion } from "./render/dom"
+export { motion, m } from "./render/dom"
 export { AnimatePresence } from "./components/AnimatePresence"
 export { AnimateSharedLayout } from "./components/AnimateSharedLayout"
 
@@ -64,7 +64,6 @@ export {
 } from "./motion/context/MotionPluginContext"
 export { MotionContext } from "./motion/context/MotionContext"
 export { PresenceContext } from "./components/AnimatePresence/PresenceContext"
-export { AnimatePresenceProps } from "./components/AnimatePresence/types"
 
 /**
  * Types
@@ -112,5 +111,6 @@ export { MotionFeature, FeatureProps } from "./motion/features/types"
 export { GestureHandlers } from "./gestures"
 export { DraggableProps, DragHandlers } from "./gestures/drag/types"
 export { LayoutProps } from "./motion/features/layout/types"
+export { AnimatePresenceProps } from "./components/AnimatePresence/types"
 export { SharedLayoutProps } from "./components/AnimateSharedLayout/types"
 export * from "./types/geometry"

--- a/src/motion/features/layout/types.ts
+++ b/src/motion/features/layout/types.ts
@@ -1,5 +1,8 @@
 import { AxisBox2D, BoxDelta } from "../../../types/geometry"
 
+/**
+ * @public
+ */
 export interface LayoutProps {
     /**
      * If `true`, this component will automatically animate to its new position when

--- a/src/motion/features/use-features.tsx
+++ b/src/motion/features/use-features.tsx
@@ -4,24 +4,15 @@ import { MotionPluginContext } from "../context/MotionPluginContext"
 import { VisualElement } from "../../render/VisualElement"
 import { MotionProps } from ".."
 import { MotionContextProps } from "../context/MotionContext"
-import { Drag } from "./drag"
-import { Gestures } from "./gestures"
-import { Exit } from "./exit"
 import { VisualElementAnimationControls } from "../../animation/VisualElementAnimationControls"
 import { getAnimationComponent } from "./animation"
-import { AnimateLayout } from "./layout/Animate"
-import { MeasureLayout } from "./layout/Measure"
-
-/**
- * Currently we load all features synchronously, but it would be better to offer multiple entry points
- * that allow these to be loaded in asynchronously.
- */
-const defaultFeatures = [MeasureLayout, Drag, Gestures, Exit, AnimateLayout]
+import { MotionFeature } from "./types"
 
 /**
  * Load features via renderless components based on the provided MotionProps
  */
 export function useFeatures(
+    defaultFeatures: MotionFeature[],
     isStatic: boolean,
     visualElement: VisualElement,
     controls: VisualElementAnimationControls,

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -5,7 +5,7 @@ import { MotionProps } from "./types"
 import { checkShouldInheritVariant } from "./utils/should-inherit-variant"
 import { useMotionValues } from "./utils/use-motion-values"
 import { UseVisualElement } from "../render/types"
-import { RenderComponent } from "./features/types"
+import { RenderComponent, MotionFeature } from "./features/types"
 import { AnimationControlsConfig } from "../animation/VisualElementAnimationControls"
 import { useVisualElementAnimation } from "../animation/use-visual-element-animation"
 import { useFeatures } from "./features/use-features"
@@ -13,6 +13,7 @@ import { useSnapshotOnUnmount } from "./features/layout/use-snapshot-on-unmount"
 export { MotionProps }
 
 export interface MotionComponentConfig<E> {
+    defaultFeatures: MotionFeature[]
     useVisualElement: UseVisualElement<E>
     render: RenderComponent
     animationControlsConfig: AnimationControlsConfig
@@ -32,6 +33,7 @@ export interface MotionComponentConfig<E> {
 export function createMotionComponent<P extends {}, E>(
     Component: string | React.ComponentType<P>,
     {
+        defaultFeatures,
         useVisualElement,
         render,
         animationControlsConfig,
@@ -94,6 +96,7 @@ export function createMotionComponent<P extends {}, E>(
          * Load features as renderless components unless the component isStatic
          */
         const features = useFeatures(
+            defaultFeatures,
             isStatic,
             visualElement,
             controls,


### PR DESCRIPTION
This PR achieves two improvements to the codebase in regards to bundle size.

## 1. Features refactor

Context: https://github.com/framer/motion/issues/254

This PR refactors `motion`'s exposure to feature components like `drag` and `exit`. This allows us to add a second entrypoint for `motion` components, `m`. This shares the same API as `motion` and can be migrated to like this:

```jsx
import { m as motion } from "framer-motion"
```

`m` comes without any reference to or knowledge of features like `drag` or `exit`. In a future PR, we'll introduce user-facing API that users can use to re-introduce these features via context, either synchronously or dynamically (via `import()`). This functionality already exists in the codebase, we just need to add documentation and a user-safe API.

This can save about 5kb from the bundle size.

## 2. Pure classes

Currently, even if a user doesn't explicitly import `AnimateSharedLayout`, it still gets imported into their bundle. Other bits of code suffer this to a less extent.

This is because when a class gets transpiled into a function, it doesn't get marked as `PURE`, which is a mark that Terser/Uglify etc can use to decide whether it's safe to remove code from the minified bundle.

Here, we replace Typescript's `@class` annotation that it adds to transpiled classes with the `PURE` annotation. This reduces ~2kb from bundles that don't import `AnimateSharedLayout`, and has smaller other improvements to the tree shaked bundle.