### PR TITLE
Adding onViewportBoxUpdate to HTMLVisualElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   Support for `transformPerspective` style.
 -   Internal: `_dragX` and `_dragY` external `MotionValue` targets for drag gesture.
+-   Internal: Support for rotate in `AnimateSharedLayout` within Framer.
+-   Internal: `onViewportBoxUpdate`, `onLayoutMeasure` and `onLayoutUpdate` event handlers added to `HTMLVisualElement`.
 
 ### Fixed
 
 -   Fixed `AnimateSharedLayout` within React `17.0.0-rc.0`.
--   Internal: Support for rotate in `AnimateSharedLayout` within Framer.
-
-### Fixed
-
 -   Drag now works directly on `x` and `y` transforms unless `layout` or `layoutId` are also set.
 
 ## [2.3.0] 2020-07-28

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -447,7 +447,7 @@ export class MotionValue<V = any> {
     isAnimating(): boolean;
     onChange(subscription: Subscriber<V>): () => void;
     // @internal
-    onRenderRequest(subscription: Subscriber<V>): () => boolean;
+    onRenderRequest(subscription: Subscriber<V>): () => undefined;
     set(v: V, render?: boolean): void;
     // Warning: (ae-forgotten-export) The symbol "StartAnimation" needs to be exported by the entry point index.d.ts
     // 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -447,7 +447,7 @@ export class MotionValue<V = any> {
     isAnimating(): boolean;
     onChange(subscription: Subscriber<V>): () => void;
     // @internal
-    onRenderRequest(subscription: Subscriber<V>): () => boolean;
+    onRenderRequest(subscription: Subscriber<V>): () => void;
     set(v: V, render?: boolean): void;
     // Warning: (ae-forgotten-export) The symbol "StartAnimation" needs to be exported by the entry point index.d.ts
     // 
@@ -456,8 +456,10 @@ export class MotionValue<V = any> {
     stop(): void;
     // (undocumented)
     updateAndNotify: (v: V, render?: boolean) => void;
+    // Warning: (ae-forgotten-export) The symbol "SubscriptionManager" needs to be exported by the entry point index.d.ts
+    // 
     // @internal
-    updateSubscribers?: Set<Subscriber<V>>;
+    updateSubscribers: SubscriptionManager<Subscriber<V>>;
     }
 
 // Warning: (ae-internal-missing-underscore) The name "motionValue" should be prefixed with an underscore because the declaration is marked as @internal

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -447,7 +447,7 @@ export class MotionValue<V = any> {
     isAnimating(): boolean;
     onChange(subscription: Subscriber<V>): () => void;
     // @internal
-    onRenderRequest(subscription: Subscriber<V>): () => void;
+    onRenderRequest(subscription: Subscriber<V>): () => boolean;
     set(v: V, render?: boolean): void;
     // Warning: (ae-forgotten-export) The symbol "StartAnimation" needs to be exported by the entry point index.d.ts
     // 

--- a/cypress/integration/drag-svg.ts
+++ b/cypress/integration/drag-svg.ts
@@ -10,6 +10,7 @@
 describe("Drag SVG", () => {
     it("Drags the element by the defined distance", () => {
         cy.visit("?test=drag-svg")
+            .wait(200)
             .get("[data-testid='draggable']")
             .wait(200)
             .trigger("pointerdown", 0, 0, { force: true })
@@ -171,6 +172,7 @@ describe("Drag SVG & Layout", () => {
 
     it("Locks drag to x", () => {
         cy.visit("?test=drag-svg&axis=x&layout=true")
+            .wait(200)
             .get("[data-testid='draggable']")
             .wait(200)
             .trigger("pointerdown", 50, 50, { force: true })
@@ -190,6 +192,7 @@ describe("Drag SVG & Layout", () => {
 
     it("Locks drag to y", () => {
         cy.visit("?test=drag-svg&axis=y&layout=true")
+            .wait(200)
             .get("[data-testid='draggable']")
             .wait(200)
             .trigger("pointerdown", 50, 50, { force: true })
@@ -256,6 +259,7 @@ describe("Drag SVG & Layout", () => {
         cy.visit("?test=drag-svg&right=100&bottom=100&layout=true")
             .wait(200)
             .get("[data-testid='draggable']")
+            .wait(200)
             .trigger("pointerdown", 50, 50, { force: true })
             .trigger("pointermove", 60, 60, { force: true }) // Gesture will start from first move past threshold
             .wait(50)
@@ -275,6 +279,7 @@ describe("Drag SVG & Layout", () => {
         cy.visit("?test=drag-svg&left=-10&top=-10&layout=true")
             .wait(200)
             .get("[data-testid='draggable']")
+            .wait(200)
             .trigger("pointerdown", 50, 50, { force: true })
             .trigger("pointermove", 60, 60, { force: true }) // Gesture will start from first move past threshold
             .wait(50)

--- a/cypress/integration/drag.ts
+++ b/cypress/integration/drag.ts
@@ -67,7 +67,7 @@ describe("Drag", () => {
 
     it("Direction locks to x", () => {
         cy.visit("?test=drag&lock=true")
-            .wait(100)
+            .wait(200)
             .get("[data-testid='draggable']")
             .wait(200)
             .trigger("pointerdown", 5, 5)
@@ -89,7 +89,7 @@ describe("Drag", () => {
 
     it("Direction locks to y", () => {
         cy.visit("?test=drag&lock=true")
-            .wait(100)
+            .wait(200)
             .get("[data-testid='draggable']")
             .wait(200)
             .trigger("pointerdown", 5, 5)
@@ -113,6 +113,7 @@ describe("Drag", () => {
         cy.visit("?test=drag&right=100&bottom=100")
             .wait(200)
             .get("[data-testid='draggable']")
+            .wait(100)
             .trigger("pointerdown", 5, 5)
             .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
             .wait(50)
@@ -132,6 +133,7 @@ describe("Drag", () => {
         cy.visit("?test=drag&left=-10&top=-10")
             .wait(200)
             .get("[data-testid='draggable']")
+            .wait(100)
             .trigger("pointerdown", 40, 40)
             .trigger("pointermove", 30, 30) // Gesture will start from first move past threshold
             .wait(50)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.3.1-rc.1",
+    "version": "2.3.1-rc.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.3.0",
+    "version": "2.3.1-rc.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.3.1-rc.2",
+    "version": "2.3.0",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "dist/framer-motion.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.3.0",
+    "version": "2.3.1-rc.1",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "dist/framer-motion.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.3.1-rc.1",
+    "version": "2.3.1-rc.2",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "dist/framer-motion.d.ts",

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -39,7 +39,7 @@ class Animate extends React.Component<AnimateProps> {
         y: undefined,
     }
 
-    private unsubLayoutReady: () => {}
+    private unsubLayoutReady: () => void
 
     componentDidMount() {
         const { visualElement } = this.props

--- a/src/motion/features/layout/types.ts
+++ b/src/motion/features/layout/types.ts
@@ -1,5 +1,7 @@
 import { AxisBox2D, BoxDelta } from "../../../types/geometry"
 
+export type OnViewportBoxUpdate = (box: AxisBox2D, delta: BoxDelta) => void
+
 /**
  * @public
  */

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -115,18 +115,8 @@ export class HTMLVisualElement<
         this.transform = {}
     }
 
-    private removeOnViewportBoxUpdate?: () => void
-
     updateConfig(config: DOMVisualElementConfig = {}) {
         this.config = { ...this.defaultConfig, ...config }
-
-        // Handle onViewportBoxUpdate prop as a normal subscription to onViewportBoxUpdate
-        if (config.onViewportBoxUpdate) {
-            this.removeOnViewportBoxUpdate?.()
-            this.removeOnViewportBoxUpdate = this.onViewportBoxUpdate(
-                config.onViewportBoxUpdate
-            )
-        }
     }
 
     /**

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -27,6 +27,7 @@ import { startAnimation } from "../../animation/utils/transitions"
 import { getBoundingBox } from "./layout/measure"
 import { buildLayoutProjectionTransform } from "./utils/build-transform"
 import { SubscriptionManager } from "../../utils/subscription-manager"
+import { MotionProps } from "../../motion/types"
 
 export type LayoutUpdateHandler = (
     layout: AxisBox2D,
@@ -166,6 +167,10 @@ export class HTMLVisualElement<
         LayoutUpdateHandler
     >()
 
+    private viewportBoxUpdateListeners = new SubscriptionManager<
+        MotionProps["onViewportBoxUpdate"]
+    >()
+
     /**
      * Keep track of whether the viewport box has been updated since the last render.
      * If it has, we want to fire the onViewportBoxUpdate listener.
@@ -295,6 +300,10 @@ export class HTMLVisualElement<
      */
     onLayoutUpdate(callback: LayoutUpdateHandler) {
         return this.layoutUpdateListeners.subscribe(callback)
+    }
+
+    onViewportBoxUpdate(callback: MotionProps["onViewportBoxUpdate"]) {
+        return this.viewportBoxUpdateListeners.subscribe(callback)
     }
 
     /**
@@ -547,7 +556,7 @@ export class HTMLVisualElement<
          * If we have a listener for the viewport box, fire it.
          */
         this.hasViewportBoxUpdated &&
-            this.config.onViewportBoxUpdate?.(this.targetBox, this.delta)
+            this.viewportBoxUpdateListeners.notify(this.targetBox, this.delta)
         this.hasViewportBoxUpdated = false
 
         /**

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -167,6 +167,10 @@ export class HTMLVisualElement<
         LayoutUpdateHandler
     >()
 
+    private layoutMeasureListeners = new SubscriptionManager<
+        LayoutUpdateHandler
+    >()
+
     private viewportBoxUpdateListeners = new SubscriptionManager<
         OnViewportBoxUpdate
     >()
@@ -302,6 +306,10 @@ export class HTMLVisualElement<
         return this.layoutUpdateListeners.add(callback)
     }
 
+    onLayoutMeasure(callback: LayoutUpdateHandler) {
+        return this.layoutMeasureListeners.add(callback)
+    }
+
     onViewportBoxUpdate(callback: OnViewportBoxUpdate) {
         return this.viewportBoxUpdateListeners.add(callback)
     }
@@ -366,6 +374,11 @@ export class HTMLVisualElement<
         this.boxCorrected = copyAxisBox(this.box)
 
         if (!this.targetBox) this.targetBox = copyAxisBox(this.box)
+
+        this.layoutMeasureListeners.notify(
+            this.box,
+            this.prevViewportBox || this.box
+        )
     }
 
     /**

--- a/src/render/dom/types.ts
+++ b/src/render/dom/types.ts
@@ -48,8 +48,6 @@ export interface DOMVisualElementConfig extends VisualElementConfig {
      */
     transformTemplate?: MotionProps["transformTemplate"]
 
-    onViewportBoxUpdate?: MotionProps["onViewportBoxUpdate"]
-
     transition?: MotionProps["transition"]
 
     layoutOrder?: number

--- a/src/render/dom/use-dom-visual-element.ts
+++ b/src/render/dom/use-dom-visual-element.ts
@@ -5,6 +5,7 @@ import { SVGVisualElement } from "./SVGVisualElement"
 import { UseVisualElement } from "../types"
 import { isSVGComponent } from "./utils/is-svg-component"
 import { useIsPresent } from "../../components/AnimatePresence/use-presence"
+import { useEffect } from "react"
 
 /**
  * DOM-flavoured variation of the useVisualElement hook. Used to create either a HTMLVisualElement
@@ -35,6 +36,12 @@ export const useDomVisualElement: UseVisualElement<MotionProps, any> = (
     const isPresent = useIsPresent()
     visualElement.isPresent =
         props.isPresent !== undefined ? props.isPresent : isPresent
+
+    useEffect(() => {
+        if (props.onViewportBoxUpdate) {
+            return visualElement.onViewportBoxUpdate(props.onViewportBoxUpdate)
+        }
+    }, [props.onViewportBoxUpdate])
 
     return visualElement
 }

--- a/src/utils/__tests__/subscription-manager.test.ts
+++ b/src/utils/__tests__/subscription-manager.test.ts
@@ -1,0 +1,30 @@
+import { SubscriptionManager } from "../subscription-manager"
+
+describe("SubscriptionManager", () => {
+    test("Adds a subscription", () => {
+        const manager = new SubscriptionManager()
+        const callback = jest.fn()
+        manager.add(callback)
+        manager.notify(2)
+        expect(callback).toBeCalledTimes(1)
+        expect(callback).toBeCalledWith(2, undefined, undefined)
+    })
+
+    test("Removes a subscription", () => {
+        const manager = new SubscriptionManager()
+        const callback = jest.fn()
+        const remove = manager.add(callback)
+        remove()
+        manager.notify(2)
+        expect(callback).toBeCalledTimes(0)
+    })
+
+    test("Clears all subscription", () => {
+        const manager = new SubscriptionManager()
+        const callback = jest.fn()
+        manager.add(callback)
+        manager.clear()
+        manager.notify(2)
+        expect(callback).toBeCalledTimes(0)
+    })
+})

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -1,27 +1,58 @@
+/**
+ *
+ */
+// export class SubscriptionManager<Handler> {
+//     private subscriptions: Handler[] = []
+//     private numSubscriptions: number = 0
+
+//     private updateSubscriptionCount() {
+//         this.numSubscriptions = this.subscriptions.length
+//     }
+
+//     private findHandlerIndex(handler: Handler) {
+//         return this.subscriptions.findIndex(h => h === handler)
+//     }
+
+//     subscribe(handler: Handler) {
+//         let i = this.findHandlerIndex(handler)
+//         i === -1 && this.subscriptions.push(handler)
+//         this.updateSubscriptionCount()
+
+//         return () => {
+//             i = this.findHandlerIndex(handler)
+//             i !== -1 && this.subscriptions.splice(i, 1)
+//             this.updateSubscriptionCount()
+//         }
+//     }
+
+//     notify(a?: any, b?: any, c?: any) {
+//         if (!this.numSubscriptions) return
+
+//         for (let i = 0; i < this.numSubscriptions; i++) {
+//             ;(this.subscriptions[i] as any)(a, b, c)
+//         }
+//     }
+
+//     clear() {
+//         this.subscriptions.length = 0
+//         this.updateSubscriptionCount()
+//     }
+// }
+
 export class SubscriptionManager<Handler> {
-    private subscriptions: Handler[] = []
-    private numSubscriptions: number = 0
+    private subscriptions = new Set<Handler>()
+    private numSubscriptions = 0
 
     private updateSubscriptionCount() {
-        this.numSubscriptions = this.subscriptions.length
-    }
-
-    private findHandlerIndex(handler: Handler) {
-        return this.subscriptions.findIndex(h => h === handler)
-    }
-
-    private containsHandler(handler: Handler) {
-        const i = this.findHandlerIndex(handler)
-        return i !== -1
+        this.numSubscriptions = this.subscriptions.size
     }
 
     subscribe(handler: Handler) {
-        !this.containsHandler(handler) && this.subscriptions.push(handler)
+        this.subscriptions.add(handler)
         this.updateSubscriptionCount()
 
         return () => {
-            const i = this.findHandlerIndex(handler)
-            i !== -1 && this.subscriptions.splice(i, 1)
+            this.subscriptions.delete(handler)
             this.updateSubscriptionCount()
         }
     }
@@ -29,13 +60,13 @@ export class SubscriptionManager<Handler> {
     notify(a?: any, b?: any, c?: any) {
         if (!this.numSubscriptions) return
 
-        for (let i = 0; i < this.numSubscriptions; i++) {
-            ;(this.subscriptions[i] as any)(a, b, c)
+        for (const handler of this.subscriptions) {
+            ;(handler as any)(a, b, c)
         }
     }
 
     clear() {
-        this.subscriptions = []
+        this.subscriptions.clear()
         this.updateSubscriptionCount()
     }
 }

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -1,0 +1,41 @@
+export class SubscriptionManager<Handler> {
+    private subscriptions: Handler[] = []
+    private numSubscriptions: number = 0
+
+    private updateSubscriptionCount() {
+        this.numSubscriptions = this.subscriptions.length
+    }
+
+    private findHandlerIndex(handler: Handler) {
+        return this.subscriptions.findIndex(h => h === handler)
+    }
+
+    private containsHandler(handler: Handler) {
+        const i = this.findHandlerIndex(handler)
+        return i !== -1
+    }
+
+    subscribe(handler: Handler) {
+        !this.containsHandler(handler) && this.subscriptions.push(handler)
+        this.updateSubscriptionCount()
+
+        return () => {
+            const i = this.findHandlerIndex(handler)
+            i !== -1 && this.subscriptions.splice(i, 1)
+            this.updateSubscriptionCount()
+        }
+    }
+
+    notify(a?: any, b?: any, c?: any) {
+        if (!this.numSubscriptions) return
+
+        for (let i = 0; i < this.numSubscriptions; i++) {
+            ;(this.subscriptions[i] as any)(a, b, c)
+        }
+    }
+
+    clear() {
+        this.subscriptions = []
+        this.updateSubscriptionCount()
+    }
+}

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -1,65 +1,25 @@
+type GenericHandler = (...args: any) => void
+
 /**
- *
+ * A generic subscription manager.
  */
-// export class SubscriptionManager<Handler> {
-//     private subscriptions: Handler[] = []
-//     private numSubscriptions: number = 0
-
-//     private updateSubscriptionCount() {
-//         this.numSubscriptions = this.subscriptions.length
-//     }
-
-//     private findHandlerIndex(handler: Handler) {
-//         return this.subscriptions.findIndex(h => h === handler)
-//     }
-
-//     subscribe(handler: Handler) {
-//         let i = this.findHandlerIndex(handler)
-//         i === -1 && this.subscriptions.push(handler)
-//         this.updateSubscriptionCount()
-
-//         return () => {
-//             i = this.findHandlerIndex(handler)
-//             i !== -1 && this.subscriptions.splice(i, 1)
-//             this.updateSubscriptionCount()
-//         }
-//     }
-
-//     notify(a?: any, b?: any, c?: any) {
-//         if (!this.numSubscriptions) return
-
-//         for (let i = 0; i < this.numSubscriptions; i++) {
-//             ;(this.subscriptions[i] as any)(a, b, c)
-//         }
-//     }
-
-//     clear() {
-//         this.subscriptions.length = 0
-//         this.updateSubscriptionCount()
-//     }
-// }
-
-export class SubscriptionManager<Handler> {
+export class SubscriptionManager<Handler extends GenericHandler> {
     private subscriptions = new Set<Handler>()
-    private numSubscriptions = 0
 
-    private updateSubscriptionCount() {
-        this.numSubscriptions = this.subscriptions.size
-    }
-
-    subscribe(handler: Handler) {
+    add(handler: Handler) {
         this.subscriptions.add(handler)
-        this.updateSubscriptionCount()
-
-        return () => {
-            this.subscriptions.delete(handler)
-            this.updateSubscriptionCount()
-        }
+        return () => this.subscriptions.delete(handler)
     }
 
-    notify(a?: any, b?: any, c?: any) {
-        if (!this.numSubscriptions) return
-
+    notify(
+        /**
+         * Using ...args would be preferable but it's array creation and this
+         * might be fired every frame.
+         */
+        a?: Parameters<Handler>[0],
+        b?: Parameters<Handler>[1],
+        c?: Parameters<Handler>[2]
+    ) {
         for (const handler of this.subscriptions) {
             ;(handler as any)(a, b, c)
         }
@@ -67,6 +27,5 @@ export class SubscriptionManager<Handler> {
 
     clear() {
         this.subscriptions.clear()
-        this.updateSubscriptionCount()
     }
 }

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -16,12 +16,12 @@ export class SubscriptionManager<Handler extends GenericHandler> {
          * Using ...args would be preferable but it's array creation and this
          * might be fired every frame.
          */
-        a?: Parameters<Handler>[0],
-        b?: Parameters<Handler>[1],
-        c?: Parameters<Handler>[2]
+        _a?: Parameters<Handler>[0],
+        _b?: Parameters<Handler>[1],
+        _c?: Parameters<Handler>[2]
     ) {
         for (const handler of this.subscriptions) {
-            ;(handler as any)(a, b, c)
+            handler.call(arguments)
         }
     }
 

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -8,7 +8,7 @@ export class SubscriptionManager<Handler extends GenericHandler> {
 
     add(handler: Handler) {
         this.subscriptions.add(handler)
-        return () => this.subscriptions.delete(handler)
+        return (): void => this.subscriptions.delete(handler)
     }
 
     notify(

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -8,7 +8,7 @@ export class SubscriptionManager<Handler extends GenericHandler> {
 
     add(handler: Handler) {
         this.subscriptions.add(handler)
-        return (): void => this.subscriptions.delete(handler)
+        return () => void this.subscriptions.delete(handler)
     }
 
     notify(

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -16,13 +16,13 @@ export class SubscriptionManager<Handler extends GenericHandler> {
          * Using ...args would be preferable but it's array creation and this
          * might be fired every frame.
          */
-        _a?: Parameters<Handler>[0],
-        _b?: Parameters<Handler>[1],
-        _c?: Parameters<Handler>[2]
+        a?: Parameters<Handler>[0],
+        b?: Parameters<Handler>[1],
+        c?: Parameters<Handler>[2]
     ) {
         if (!this.subscriptions.size) return
         for (const handler of this.subscriptions) {
-            handler.call(arguments)
+            handler(a, b, c)
         }
     }
 

--- a/src/utils/subscription-manager.ts
+++ b/src/utils/subscription-manager.ts
@@ -20,6 +20,7 @@ export class SubscriptionManager<Handler extends GenericHandler> {
         _b?: Parameters<Handler>[1],
         _c?: Parameters<Handler>[2]
     ) {
+        if (!this.subscriptions.size) return
         for (const handler of this.subscriptions) {
             handler.call(arguments)
         }

--- a/src/value/__tests__/use-spring.test.tsx
+++ b/src/value/__tests__/use-spring.test.tsx
@@ -69,6 +69,6 @@ describe("useSpring", () => {
         rerender(<Component target={a} />)
         rerender(<Component target={a} />)
 
-        expect((a!.updateSubscribers! as any).numSubscriptions).toBe(1)
+        expect((a!.updateSubscribers! as any).subscriptions.size).toBe(1)
     })
 })

--- a/src/value/__tests__/use-spring.test.tsx
+++ b/src/value/__tests__/use-spring.test.tsx
@@ -69,6 +69,6 @@ describe("useSpring", () => {
         rerender(<Component target={a} />)
         rerender(<Component target={a} />)
 
-        expect(a!.updateSubscribers!.size).toBe(1)
+        expect((a!.updateSubscribers! as any).numSubscriptions).toBe(1)
     })
 })

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -207,6 +207,9 @@ export class MotionValue<V = any> {
      * @internal
      */
     onRenderRequest(subscription: Subscriber<V>) {
+        // Render immediately
+        subscription(this.get())
+
         return this.renderSubscribers.add(subscription)
     }
 

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -2,6 +2,7 @@ import sync, { getFrameData, FrameData } from "framesync"
 import { Action } from "popmotion"
 import { velocityPerSecond } from "@popmotion/popcorn"
 import { PopmotionTransitionProps } from "../types"
+import { SubscriptionManager } from "../utils/subscription-manager"
 
 export type Transformer<T> = (v: T) => T
 
@@ -62,14 +63,14 @@ export class MotionValue<V = any> {
      *
      * @internal
      */
-    updateSubscribers?: Set<Subscriber<V>>
+    updateSubscribers = new SubscriptionManager<Subscriber<V>>()
 
     /**
      * Functions to notify when the `MotionValue` updates and `render` is set to `true`.
      *
      * @internal
      */
-    private renderSubscribers?: Set<Subscriber<V>>
+    private renderSubscribers = new SubscriptionManager<Subscriber<V>>()
 
     /**
      * Add a passive effect to this `MotionValue`.
@@ -109,21 +110,6 @@ export class MotionValue<V = any> {
     constructor(init: V) {
         this.set(init, false)
         this.canTrackVelocity = isFloat(this.current)
-    }
-
-    /**
-     * Subscribes a subscriber function to a subscription list.
-     *
-     * @param subscriptions - A `Set` of subscribers.
-     * @param subscription - A subscriber function.
-     */
-    private subscribeTo(
-        subscriptions: Set<Subscriber<V>>,
-        subscription: Subscriber<V>
-    ) {
-        const updateSubscriber = () => subscription(this.current)
-        subscriptions.add(updateSubscriber)
-        return () => subscriptions.delete(updateSubscriber)
     }
 
     /**
@@ -205,12 +191,11 @@ export class MotionValue<V = any> {
      * @public
      */
     onChange(subscription: Subscriber<V>): () => void {
-        if (!this.updateSubscribers) this.updateSubscribers = new Set()
-        return this.subscribeTo(this.updateSubscribers, subscription)
+        return this.updateSubscribers.subscribe(subscription)
     }
 
     clearListeners() {
-        this.updateSubscribers?.clear()
+        this.updateSubscribers.clear()
     }
 
     /**
@@ -222,10 +207,7 @@ export class MotionValue<V = any> {
      * @internal
      */
     onRenderRequest(subscription: Subscriber<V>) {
-        if (!this.renderSubscribers) this.renderSubscribers = new Set()
-        // Render immediately
-        this.notifySubscriber(subscription)
-        return this.subscribeTo(this.renderSubscribers, subscription)
+        return this.renderSubscribers.subscribe(subscription)
     }
 
     /**
@@ -264,12 +246,12 @@ export class MotionValue<V = any> {
         this.prev = this.current
         this.current = v
 
-        if (this.updateSubscribers && this.prev !== this.current) {
-            this.updateSubscribers.forEach(this.notifySubscriber)
+        if (this.prev !== this.current) {
+            this.updateSubscribers.notify(this.current)
         }
 
-        if (render && this.renderSubscribers) {
-            this.renderSubscribers.forEach(this.notifySubscriber)
+        if (render) {
+            this.renderSubscribers.notify(this.current)
         }
 
         // Update timestamp
@@ -317,20 +299,6 @@ export class MotionValue<V = any> {
                   this.timeDelta
               )
             : 0
-    }
-
-    /**
-     * Notify a subscriber with the latest value.
-     *
-     * This is an instanced and bound function to prevent generating a new
-     * function once per frame.
-     *
-     * @param subscriber - The subscriber to notify.
-     *
-     * @internal
-     */
-    private notifySubscriber = (subscriber: Subscriber<V>) => {
-        subscriber(this.current)
     }
 
     /**
@@ -411,8 +379,8 @@ export class MotionValue<V = any> {
      * @public
      */
     destroy() {
-        this.updateSubscribers && this.updateSubscribers.clear()
-        this.renderSubscribers && this.renderSubscribers.clear()
+        this.updateSubscribers.clear()
+        this.renderSubscribers.clear()
         this.stop()
     }
 }

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -191,7 +191,7 @@ export class MotionValue<V = any> {
      * @public
      */
     onChange(subscription: Subscriber<V>): () => void {
-        return this.updateSubscribers.subscribe(subscription)
+        return this.updateSubscribers.add(subscription)
     }
 
     clearListeners() {
@@ -207,7 +207,7 @@ export class MotionValue<V = any> {
      * @internal
      */
     onRenderRequest(subscription: Subscriber<V>) {
-        return this.renderSubscribers.subscribe(subscription)
+        return this.renderSubscribers.add(subscription)
     }
 
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
         "noUnusedParameters": true,
         "removeComments": false,
         "lib": ["es2017", "dom"],
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "downlevelIteration": true
     },
     "compileOnSave": false,
     "buildOnSave": false,


### PR DESCRIPTION
This moves `onViewportBoxUpdate` from a single prop listener to something we can add multiple subscribers to via context in children. This allows us to do some interesting stuff with projected viewport boxes, for instance using them to correct for visual distortion in `canvas` components.

This PR adds `SubscriptionManager` which consolidates a common subscriber pattern in Motion to a single class.