### PR TITLE
Accept multiple MotionValues in useTransform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+-   Upgraded `useTransform` to accept multiple `MotionValue`s.
 -   Support for `transformPerspective` style.
 -   Internal: `_dragX` and `_dragY` external `MotionValue` targets for drag gesture.
 -   Internal: Support for rotate in `AnimateSharedLayout` within Framer.
@@ -15,6 +16,10 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   Fixed `AnimateSharedLayout` within React `17.0.0-rc.0`.
 -   Drag now works directly on `x` and `y` transforms unless `layout` or `layoutId` are also set.
+
+### Changed
+
+-   Marked `useInvertedScale` as deprecated.
 
 ## [2.3.0] 2020-07-28
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -750,17 +750,17 @@ export function useTapGesture({ onTap, onTapStart, onTapCancel, whileTap, contro
 // Warning: (ae-forgotten-export) The symbol "InputRange" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-export function useTransform<I = number, O = string | number>(value: MotionValue<number>, inputRange: InputRange, outputRange: O[], options?: TransformOptions<O>): MotionValue<O>;
+export function useTransform<I = string | number, O = string | number>(value: MotionValue<number>, inputRange: InputRange, outputRange: O[], options?: TransformOptions<O>): MotionValue<O>;
 
 // Warning: (ae-forgotten-export) The symbol "SingleTransformer" needs to be exported by the entry point index.d.ts
 // 
-// @public (undocumented)
-export function useTransform<I = string | number, O = string | number>(value: MotionValue<I>, transformer: SingleTransformer<I, O>): MotionValue<O>;
+// @public
+export function useTransform<I = string | number, O = string | number>(input: MotionValue<I>, transformer: SingleTransformer<I, O>): MotionValue<O>;
 
 // Warning: (ae-forgotten-export) The symbol "MultiTransformer" needs to be exported by the entry point index.d.ts
 // 
-// @public (undocumented)
-export function useTransform<I = string | number, O = string | number>(value: MotionValue<I>[], transformer: MultiTransformer<I, O>): MotionValue<O>;
+// @public
+export function useTransform<I = string | number, O = string | number>(input: MotionValue<I>[], transformer: MultiTransformer<I, O>): MotionValue<O>;
 
 // @public
 export function useViewportScroll(): ScrollMotionValues;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -711,7 +711,7 @@ export function useGestures<GestureHandlers>(props: GestureHandlers, ref: Visual
 
 // Warning: (ae-forgotten-export) The symbol "ScaleMotionValues" needs to be exported by the entry point index.d.ts
 // 
-// @public
+// @public (undocumented)
 export function useInvertedScale(scale?: Partial<ScaleMotionValues>): ScaleMotionValues;
 
 // @public (undocumented)
@@ -749,18 +749,18 @@ export function useTapGesture({ onTap, onTapStart, onTapCancel, whileTap, contro
 
 // Warning: (ae-forgotten-export) The symbol "InputRange" needs to be exported by the entry point index.d.ts
 // 
-// @public (undocumented)
-export function useTransform<I = string | number, O = string | number>(value: MotionValue<number>, inputRange: InputRange, outputRange: O[], options?: TransformOptions<O>): MotionValue<O>;
+// @public
+export function useTransform<I, O>(value: MotionValue<number>, inputRange: InputRange, outputRange: O[], options?: TransformOptions<O>): MotionValue<O>;
 
 // Warning: (ae-forgotten-export) The symbol "SingleTransformer" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export function useTransform<I = string | number, O = string | number>(input: MotionValue<I>, transformer: SingleTransformer<I, O>): MotionValue<O>;
+export function useTransform<I, O>(input: MotionValue<I>, transformer: SingleTransformer<I, O>): MotionValue<O>;
 
 // Warning: (ae-forgotten-export) The symbol "MultiTransformer" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export function useTransform<I = string | number, O = string | number>(input: MotionValue<I>[], transformer: MultiTransformer<I, O>): MotionValue<O>;
+export function useTransform<I, O>(input: MotionValue<string | number>[], transformer: MultiTransformer<I, O>): MotionValue<O>;
 
 // @public
 export function useViewportScroll(): ScrollMotionValues;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -747,13 +747,20 @@ export function useSpring(source: MotionValue | number, config?: SpringProps): M
 // @internal (undocumented)
 export function useTapGesture({ onTap, onTapStart, onTapCancel, whileTap, controls, }: TapHandlers & ControlsProp, ref: RefObject<Element>): void;
 
-// Warning: (ae-forgotten-export) The symbol "Transformer" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "InputRange" needs to be exported by the entry point index.d.ts
 // 
-// @public
-export function useTransform<T>(parent: MotionValue, transform: Transformer<T>): MotionValue;
+// @public (undocumented)
+export function useTransform<I = number, O = string | number>(value: MotionValue<number>, inputRange: InputRange, outputRange: O[], options?: TransformOptions<O>): MotionValue<O>;
 
-// @public
-export function useTransform<T>(parent: MotionValue<number>, from: number[], to: T[], options?: TransformOptions<T>): MotionValue<T>;
+// Warning: (ae-forgotten-export) The symbol "SingleTransformer" needs to be exported by the entry point index.d.ts
+// 
+// @public (undocumented)
+export function useTransform<I = string | number, O = string | number>(value: MotionValue<I>, transformer: SingleTransformer<I, O>): MotionValue<O>;
+
+// Warning: (ae-forgotten-export) The symbol "MultiTransformer" needs to be exported by the entry point index.d.ts
+// 
+// @public (undocumented)
+export function useTransform<I = string | number, O = string | number>(value: MotionValue<I>[], transformer: MultiTransformer<I, O>): MotionValue<O>;
 
 // @public
 export function useViewportScroll(): ScrollMotionValues;

--- a/src/value/__tests__/use-transform.test.tsx
+++ b/src/value/__tests__/use-transform.test.tsx
@@ -36,6 +36,26 @@ describe("as function", () => {
     })
 })
 
+describe("as function with multiple values", () => {
+    test("sets initial value", async () => {
+        const Component = () => {
+            const x = useMotionValue(4)
+            const y = useMotionValue("5px")
+            const z = useTransform(
+                [x, y],
+                ([latestX, latestY]: [number, string]) =>
+                    latestX * parseFloat(latestY)
+            )
+            return <motion.div style={{ x, y, z }} />
+        }
+
+        const { container } = render(<Component />)
+        expect(container.firstChild).toHaveStyle(
+            "transform: translateX(4px) translateY(5px) translateZ(20px)"
+        )
+    })
+})
+
 describe("as input/output range", () => {
     test("sets initial value", async () => {
         const Component = () => {

--- a/src/value/__tests__/use-transform.test.tsx
+++ b/src/value/__tests__/use-transform.test.tsx
@@ -21,40 +21,40 @@ class Custom {
     }
 }
 
-// describe("as function", () => {
-//     test("sets initial value", async () => {
-//         const Component = () => {
-//             const x = useMotionValue(100)
-//             const y = useTransform(x, v => -v)
-//             return <motion.div style={{ x, y }} />
-//         }
+describe("as function", () => {
+    test("sets initial value", async () => {
+        const Component = () => {
+            const x = useMotionValue(100)
+            const y = useTransform(x, v => -v)
+            return <motion.div style={{ x, y }} />
+        }
 
-//         const { container } = render(<Component />)
-//         expect(container.firstChild).toHaveStyle(
-//             "transform: translateX(100px) translateY(-100px) translateZ(0)"
-//         )
-//     })
-// })
+        const { container } = render(<Component />)
+        expect(container.firstChild).toHaveStyle(
+            "transform: translateX(100px) translateY(-100px) translateZ(0)"
+        )
+    })
+})
 
-// describe("as function with multiple values", () => {
-//     test("sets initial value", async () => {
-//         const Component = () => {
-//             const x = useMotionValue(4)
-//             const y = useMotionValue("5px")
-//             const z = useTransform(
-//                 [x, y],
-//                 ([latestX, latestY]: [number, string]) =>
-//                     latestX * parseFloat(latestY)
-//             )
-//             return <motion.div style={{ x, y, z }} />
-//         }
+describe("as function with multiple values", () => {
+    test("sets initial value", async () => {
+        const Component = () => {
+            const x = useMotionValue(4)
+            const y = useMotionValue("5px")
+            const z = useTransform(
+                [x, y],
+                ([latestX, latestY]: [number, string]) =>
+                    latestX * parseFloat(latestY)
+            )
+            return <motion.div style={{ x, y, z }} />
+        }
 
-//         const { container } = render(<Component />)
-//         expect(container.firstChild).toHaveStyle(
-//             "transform: translateX(4px) translateY(5px) translateZ(20px)"
-//         )
-//     })
-// })
+        const { container } = render(<Component />)
+        expect(container.firstChild).toHaveStyle(
+            "transform: translateX(4px) translateY(5px) translateZ(20px)"
+        )
+    })
+})
 
 describe("as input/output range", () => {
     test("sets initial value", async () => {
@@ -109,35 +109,35 @@ describe("as input/output range", () => {
     })
 })
 
-// test("is correctly typed", async () => {
-//     const Component = () => {
-//         const x = useMotionValue(0)
-//         const y = useTransform(x, [0, 1], ["0px", "1px"])
-//         const z = useTransform(x, v => v * 2)
-//         return <motion.div style={{ x, y, z }} />
-//     }
+test("is correctly typed", async () => {
+    const Component = () => {
+        const x = useMotionValue(0)
+        const y = useTransform(x, [0, 1], ["0px", "1px"])
+        const z = useTransform(x, v => v * 2)
+        return <motion.div style={{ x, y, z }} />
+    }
 
-//     render(<Component />)
-// })
+    render(<Component />)
+})
 
-// test("can be re-pointed to another `MotionValue`", async () => {
-//     const a = motionValue(1)
-//     const b = motionValue(2)
-//     let x = motionValue(0)
+test("can be re-pointed to another `MotionValue`", async () => {
+    const a = motionValue(1)
+    const b = motionValue(2)
+    let x = motionValue(0)
 
-//     const Component = ({ target }: { target: MotionValue<number> }) => {
-//         x = useTransform(target, [0, 1], [0, 2], { clamp: false })
-//         return <motion.div style={{ x }} />
-//     }
+    const Component = ({ target }: { target: MotionValue<number> }) => {
+        x = useTransform(target, [0, 1], [0, 2], { clamp: false })
+        return <motion.div style={{ x }} />
+    }
 
-//     const { container, rerender } = render(<Component target={a} />)
-//     rerender(<Component target={b} />)
-//     expect(container.firstChild as Element).toHaveStyle(
-//         "transform: translateX(4px) translateZ(0)"
-//     )
+    const { container, rerender } = render(<Component target={a} />)
+    rerender(<Component target={b} />)
+    expect(container.firstChild as Element).toHaveStyle(
+        "transform: translateX(4px) translateZ(0)"
+    )
 
-//     rerender(<Component target={a} />)
-//     expect(container.firstChild as Element).toHaveStyle(
-//         "transform: translateX(2px) translateZ(0)"
-//     )
-// })
+    rerender(<Component target={a} />)
+    expect(container.firstChild as Element).toHaveStyle(
+        "transform: translateX(2px) translateZ(0)"
+    )
+})

--- a/src/value/__tests__/use-transform.test.tsx
+++ b/src/value/__tests__/use-transform.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { motion } from "../../"
 import { useMotionValue } from "../use-motion-value"
 import { useTransform } from "../use-transform"
-// import { MotionValue, motionValue } from ".."
+import { MotionValue, motionValue } from ".."
 
 class Custom {
     value: number = 0

--- a/src/value/__tests__/use-transform.test.tsx
+++ b/src/value/__tests__/use-transform.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { motion } from "../../"
 import { useMotionValue } from "../use-motion-value"
 import { useTransform } from "../use-transform"
-import { MotionValue, motionValue } from ".."
+// import { MotionValue, motionValue } from ".."
 
 class Custom {
     value: number = 0
@@ -21,40 +21,40 @@ class Custom {
     }
 }
 
-describe("as function", () => {
-    test("sets initial value", async () => {
-        const Component = () => {
-            const x = useMotionValue(100)
-            const y = useTransform(x, v => -v)
-            return <motion.div style={{ x, y }} />
-        }
+// describe("as function", () => {
+//     test("sets initial value", async () => {
+//         const Component = () => {
+//             const x = useMotionValue(100)
+//             const y = useTransform(x, v => -v)
+//             return <motion.div style={{ x, y }} />
+//         }
 
-        const { container } = render(<Component />)
-        expect(container.firstChild).toHaveStyle(
-            "transform: translateX(100px) translateY(-100px) translateZ(0)"
-        )
-    })
-})
+//         const { container } = render(<Component />)
+//         expect(container.firstChild).toHaveStyle(
+//             "transform: translateX(100px) translateY(-100px) translateZ(0)"
+//         )
+//     })
+// })
 
-describe("as function with multiple values", () => {
-    test("sets initial value", async () => {
-        const Component = () => {
-            const x = useMotionValue(4)
-            const y = useMotionValue("5px")
-            const z = useTransform(
-                [x, y],
-                ([latestX, latestY]: [number, string]) =>
-                    latestX * parseFloat(latestY)
-            )
-            return <motion.div style={{ x, y, z }} />
-        }
+// describe("as function with multiple values", () => {
+//     test("sets initial value", async () => {
+//         const Component = () => {
+//             const x = useMotionValue(4)
+//             const y = useMotionValue("5px")
+//             const z = useTransform(
+//                 [x, y],
+//                 ([latestX, latestY]: [number, string]) =>
+//                     latestX * parseFloat(latestY)
+//             )
+//             return <motion.div style={{ x, y, z }} />
+//         }
 
-        const { container } = render(<Component />)
-        expect(container.firstChild).toHaveStyle(
-            "transform: translateX(4px) translateY(5px) translateZ(20px)"
-        )
-    })
-})
+//         const { container } = render(<Component />)
+//         expect(container.firstChild).toHaveStyle(
+//             "transform: translateX(4px) translateY(5px) translateZ(20px)"
+//         )
+//     })
+// })
 
 describe("as input/output range", () => {
     test("sets initial value", async () => {
@@ -73,12 +73,15 @@ describe("as input/output range", () => {
             const x = useMotionValue(100)
             const opacity = useTransform(x, [0, 200], [0, 1])
 
-            x.set(20)
+            React.useEffect(() => {
+                x.set(20)
+            }, [])
 
             return <motion.div style={{ x, opacity }} />
         }
 
-        const { container } = render(<Component />)
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
         expect(container.firstChild).toHaveStyle("opacity: 0.1")
     })
 
@@ -91,48 +94,50 @@ describe("as input/output range", () => {
                 [new Custom(100), new Custom(200)]
             )
 
-            x.set(20)
+            React.useEffect(() => {
+                x.set(20)
+            }, [])
 
             return <motion.div style={{ x, y }} />
         }
 
-        const { container } = render(<Component />)
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
         expect(container.firstChild).toHaveStyle(
             "transform: translateX(20px) translateY(120px) translateZ(0)"
         )
     })
 })
 
-test("is correctly typed", async () => {
-    const Component = () => {
-        const x = useMotionValue(0)
-        const y = useTransform(x, [0, 1], ["0px", "1px"])
-        const z = useTransform(x, v => v * 2)
-        return <motion.div style={{ x, y, z }} />
-    }
+// test("is correctly typed", async () => {
+//     const Component = () => {
+//         const x = useMotionValue(0)
+//         const y = useTransform(x, [0, 1], ["0px", "1px"])
+//         const z = useTransform(x, v => v * 2)
+//         return <motion.div style={{ x, y, z }} />
+//     }
 
-    render(<Component />)
-})
+//     render(<Component />)
+// })
 
-test("can be re-pointed to another `MotionValue`", async () => {
-    const a = motionValue(1)
-    const b = motionValue(2)
-    let x = motionValue(0)
+// test("can be re-pointed to another `MotionValue`", async () => {
+//     const a = motionValue(1)
+//     const b = motionValue(2)
+//     let x = motionValue(0)
 
-    const Component = ({ target }: { target: MotionValue<number> }) => {
-        x = useTransform(target, [0, 1], [0, 2], { clamp: false })
-        return <motion.div style={{ x }} />
-    }
+//     const Component = ({ target }: { target: MotionValue<number> }) => {
+//         x = useTransform(target, [0, 1], [0, 2], { clamp: false })
+//         return <motion.div style={{ x }} />
+//     }
 
-    const { container, rerender } = render(<Component target={a} />)
-    rerender(<Component target={b} />)
-    expect(container.firstChild as Element).toHaveStyle(
-        "transform: translateX(4px) translateZ(0)"
-    )
-    b.set(10)
-    expect(x.get()).toBe(20)
-    rerender(<Component target={a} />)
-    expect(container.firstChild as Element).toHaveStyle(
-        "transform: translateX(2px) translateZ(0)"
-    )
-})
+//     const { container, rerender } = render(<Component target={a} />)
+//     rerender(<Component target={b} />)
+//     expect(container.firstChild as Element).toHaveStyle(
+//         "transform: translateX(4px) translateZ(0)"
+//     )
+
+//     rerender(<Component target={a} />)
+//     expect(container.firstChild as Element).toHaveStyle(
+//         "transform: translateX(2px) translateZ(0)"
+//     )
+// })

--- a/src/value/use-combine-values.ts
+++ b/src/value/use-combine-values.ts
@@ -1,0 +1,36 @@
+import { MotionValue } from "."
+import { useMotionValue } from "./use-motion-value"
+import { useMultiOnChange } from "./use-on-change"
+import sync from "framesync"
+
+export function useCombineMotionValues<R>(
+    values: MotionValue[],
+    combineValues: () => R
+) {
+    /**
+     * Initialise the returned motion value. This remains the same between renders.
+     */
+    const value = useMotionValue(combineValues())
+
+    /**
+     * Create a function that will update the template motion value with the latest values.
+     * This is pre-bound so whenever a motion value updates it can schedule its
+     * execution in Framesync. If it's already been scheduled it won't be fired twice
+     * in a single frame.
+     */
+    const updateValue = () => value.set(combineValues())
+
+    /**
+     * Synchronously update the motion value with the latest values during the render.
+     * This ensures that within a React render, the styles applied to the DOM are up-to-date.
+     */
+    updateValue()
+
+    /**
+     * Subscribe to all motion values found within the template. Whenever any of them change,
+     * schedule an update.
+     */
+    useMultiOnChange(values, () => sync.update(updateValue, false, true))
+
+    return value
+}

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -2,7 +2,7 @@ import { useContext } from "react"
 import { MotionContext } from "../motion/context/MotionContext"
 import { useTransform } from "../value/use-transform"
 import { MotionValue } from "./"
-import { invariant } from "hey-listen"
+import { invariant, warning } from "hey-listen"
 import { useMotionValue } from "./use-motion-value"
 
 interface ScaleMotionValues {
@@ -47,6 +47,7 @@ export const invertScale = (scale: number) =>
  *
  * @public
  */
+let hasWarned = false
 export function useInvertedScale(
     scale?: Partial<ScaleMotionValues>
 ): ScaleMotionValues {
@@ -58,6 +59,12 @@ export function useInvertedScale(
         !!(scale || visualElement),
         "If no scale values are provided, useInvertedScale must be used within a child of another motion component."
     )
+
+    warning(
+        hasWarned,
+        "useInvertedScale is deprecated and will be removed in 3.0. Use the layout prop instead."
+    )
+    hasWarned = true
 
     if (scale) {
         parentScaleX = scale.scaleX || parentScaleX

--- a/src/value/use-inverted-scale.ts
+++ b/src/value/use-inverted-scale.ts
@@ -45,7 +45,7 @@ export const invertScale = (scale: number) =>
  * }
  * ```
  *
- * @public
+ * @deprecated
  */
 let hasWarned = false
 export function useInvertedScale(

--- a/src/value/use-motion-template.ts
+++ b/src/value/use-motion-template.ts
@@ -1,7 +1,5 @@
-import { useEffect } from "react"
-import sync from "framesync"
 import { MotionValue } from "."
-import { useMotionValue } from "./use-motion-value"
+import { useCombineMotionValues } from "./use-combine-values"
 
 /**
  * Combine multiple motion values into a new one using a string template literal.
@@ -33,6 +31,7 @@ export function useMotionTemplate(
      * Create a function that will build a string from the latest motion values.
      */
     const numFragments = fragments.length
+
     function buildValue() {
         let output = ``
 
@@ -45,37 +44,5 @@ export function useMotionTemplate(
         return output
     }
 
-    /**
-     * Initialise the returned motion value. This remains the same between renders.
-     */
-    const value = useMotionValue(buildValue())
-
-    /**
-     * Create a function that will update the template motion value with the latest values.
-     * This is pre-bound so whenever a motion value updates it can schedule its
-     * execution in Framesync. If it's already been scheduled it won't be fired twice
-     * in a single frame.
-     */
-    const updateValue = () => value.set(buildValue())
-
-    /**
-     * Synchronously update the motion value with the latest values during the render.
-     * This ensures that within a React render, the styles applied to the DOM are up-to-date.
-     */
-    updateValue()
-
-    /**
-     * Subscribe to all motion values found within the template. Whenever any of them change,
-     * schedule an update.
-     */
-    useValueOnChange(values, () => sync.update(updateValue, false, true))
-
-    return value
-}
-
-function useValueOnChange(values: MotionValue[], handler: () => void) {
-    useEffect(() => {
-        const subscriptions = values.map(value => value.onChange(handler))
-        return () => subscriptions.forEach(unsubscribe => unsubscribe())
-    })
+    return useCombineMotionValues(values, buildValue)
 }

--- a/src/value/use-on-change.ts
+++ b/src/value/use-on-change.ts
@@ -11,3 +11,10 @@ export function useOnChange<T>(
         [value]
     )
 }
+
+export function useMultiOnChange(values: MotionValue[], handler: () => void) {
+    useEffect(() => {
+        const subscriptions = values.map(value => value.onChange(handler))
+        return () => subscriptions.forEach(unsubscribe => unsubscribe())
+    }, values)
+}

--- a/src/value/use-transform.ts
+++ b/src/value/use-transform.ts
@@ -12,15 +12,10 @@ type Transformer<I, O> =
     | SingleTransformer<I, O>
     /**
      * Ideally, this would be typed <I, O> in all instances, but to type this
-     * more accurately requires tuple support in TypeScript.
+     * more accurately requires the tuple support in TypeScript 4:
+     * https://gist.github.com/InventingWithMonster/c4d23752a0fae7888596c4ff6d92733a
      */
     | MultiTransformer<string | number, O>
-
-function isTransformer<I, O>(
-    transformer: InputRange | Transformer<I, O>
-): transformer is Transformer<I, O> {
-    return typeof transformer === "function"
-}
 
 /**
  * Create a `MotionValue` that transforms the output of another `MotionValue` by mapping it from one range of values into another.
@@ -177,9 +172,10 @@ export function useTransform<I = string | number, O = string | number>(
     outputRange?: O[],
     options?: TransformOptions<O>
 ): MotionValue<O> {
-    const transformer = isTransformer(inputRangeOrTransformer)
-        ? inputRangeOrTransformer
-        : transform(inputRangeOrTransformer, outputRange!, options)
+    const transformer =
+        typeof inputRangeOrTransformer === "function"
+            ? inputRangeOrTransformer
+            : transform(inputRangeOrTransformer, outputRange!, options)
 
     return Array.isArray(input)
         ? useListTransform(

--- a/src/value/use-transform.ts
+++ b/src/value/use-transform.ts
@@ -2,8 +2,6 @@ import { MotionValue } from "../value"
 import { transform, TransformOptions } from "../utils/transform"
 import { useCombineMotionValues } from "./use-combine-values"
 import { useConstant } from "../utils/use-constant"
-import { useMotionValue } from "./use-motion-value"
-import { useOnChange } from "./use-on-change"
 
 export type InputRange = number[]
 type SingleTransformer<I, O> = (input: I) => O
@@ -182,21 +180,9 @@ export function useTransform<I, O>(
               input,
               transformer as MultiTransformer<string | number, O>
           )
-        : useSingleTransform(input, transformer as SingleTransformer<I, O>)
-}
-
-function useSingleTransform<I, O>(
-    input: MotionValue<I>,
-    transformer: SingleTransformer<I, O>
-): MotionValue<O> {
-    const initialValue = transformer(input.get())
-
-    const output = useMotionValue(initialValue)
-    output.set(initialValue)
-
-    useOnChange(input, latest => output.set(transformer(latest)))
-
-    return output
+        : useListTransform([input], ([latest]) =>
+              (transformer as SingleTransformer<I, O>)(latest)
+          )
 }
 
 function useListTransform<I, O>(

--- a/src/value/use-transform.ts
+++ b/src/value/use-transform.ts
@@ -5,7 +5,7 @@ import { useConstant } from "../utils/use-constant"
 import { useMotionValue } from "./use-motion-value"
 import { useOnChange } from "./use-on-change"
 
-type InputRange = number[]
+export type InputRange = number[]
 type SingleTransformer<I, O> = (input: I) => O
 type MultiTransformer<I, O> = (input: I[]) => O
 type Transformer<I, O> =
@@ -78,7 +78,7 @@ type Transformer<I, O> =
  *
  * @public
  */
-export function useTransform<I = string | number, O = string | number>(
+export function useTransform<I, O>(
     value: MotionValue<number>,
     inputRange: InputRange,
     outputRange: O[],
@@ -120,7 +120,7 @@ export function useTransform<I = string | number, O = string | number>(
  *
  * @public
  */
-export function useTransform<I = string | number, O = string | number>(
+export function useTransform<I, O>(
     input: MotionValue<I>,
     transformer: SingleTransformer<I, O>
 ): MotionValue<O>
@@ -161,12 +161,12 @@ export function useTransform<I = string | number, O = string | number>(
  *
  * @public
  */
-export function useTransform<I = string | number, O = string | number>(
+export function useTransform<I, O>(
     input: MotionValue<string | number>[],
     transformer: MultiTransformer<I, O>
 ): MotionValue<O>
 
-export function useTransform<I = string | number, O = string | number>(
+export function useTransform<I, O>(
     input: MotionValue<I> | MotionValue<string | number>[],
     inputRangeOrTransformer: InputRange | Transformer<I, O>,
     outputRange?: O[],
@@ -199,7 +199,7 @@ function useSingleTransform<I, O>(
     return output
 }
 
-function useListTransform<I = string | number, O = string | number>(
+function useListTransform<I, O>(
     values: MotionValue<I>[],
     transformer: MultiTransformer<I, O>
 ): MotionValue<O> {


### PR DESCRIPTION
Closes https://github.com/framer/motion/issues/251

This PR upgrades `useTransform` to accept a list of `MotionValue`s.

```jsx
const a = useMotionValue(0)
const b = useMotionValue(0)
const c = useTransform([a, b], ([latestA, latestB]) => latestA * latestB)
```