### PR TITLE
Fixing support for transformPerspective style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+### Fixed
+
+-   Support for `transformPerspective` style.
+
 ## [2.3.1] Unreleased
 
 ### Added

--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -45,6 +45,7 @@ export interface TransformProperties {
     originY?: string | number
     originZ?: string | number
     perspective?: string | number
+    transformPerspective?: string | number
 }
 
 /**

--- a/src/render/dom/utils/__tests__/build-html-styles.test.ts
+++ b/src/render/dom/utils/__tests__/build-html-styles.test.ts
@@ -22,13 +22,13 @@ describe("buildHTMLStyles", () => {
     })
 
     test("Builds transform with default value types", () => {
-        const latest = { x: 1, y: 2, rotateX: 90 }
+        const latest = { x: 1, y: 2, rotateX: 90, transformPerspective: 200 }
         const style = {}
         build(latest, { style })
 
         expect(style).toEqual({
             transform:
-                "translateX(1px) translateY(2px) rotateX(90deg) translateZ(0)",
+                "perspective(200px) translateX(1px) translateY(2px) rotateX(90deg) translateZ(0)",
         })
     })
 

--- a/src/render/dom/utils/__tests__/build-transform.test.ts
+++ b/src/render/dom/utils/__tests__/build-transform.test.ts
@@ -31,6 +31,17 @@ describe("buildTransform", () => {
         ).toBe("translateX(0) translateZ(5px)")
     })
 
+    it("Correctly handles transformPerspective", () => {
+        expect(
+            buildTransform(
+                { x: "100px", transformPerspective: "200px" },
+                ["x", "transformPerspective"],
+                undefined,
+                false
+            )
+        ).toBe("perspective(200px) translateX(100px) translateZ(0)")
+    })
+
     it("Correctly handles transformTemplate if provided", () => {
         expect(
             buildTransform(

--- a/src/render/dom/utils/build-transform.ts
+++ b/src/render/dom/utils/build-transform.ts
@@ -8,6 +8,7 @@ const translateAlias: { [key: string]: string } = {
     x: "translateX",
     y: "translateY",
     z: "translateZ",
+    transformPerspective: "perspective",
 }
 
 /**

--- a/src/render/dom/utils/transform.ts
+++ b/src/render/dom/utils/transform.ts
@@ -8,7 +8,7 @@ export const transformAxes = ["", "X", "Y", "Z"]
  * An ordered array of each transformable value. By default, transform values
  * will be sorted to this order.
  */
-const order = ["translate", "scale", "rotate", "skew", "transformPerspective"]
+const order = ["perspective", "translate", "scale", "rotate", "skew"]
 
 /**
  * Used to store the keys of all transforms that will distorted a measured bounding box.
@@ -18,7 +18,7 @@ export const boxDistortingKeys: Set<string> = new Set()
 /**
  * Generate a list of every possible transform key.
  */
-export const transformProps = ["x", "y", "z"]
+export const transformProps = ["transformPerspective", "x", "y", "z"]
 order.forEach(operationKey => {
     const isDistorting = new Set(["rotate", "skew"]).has(operationKey)
     transformAxes.forEach(axesKey => {

--- a/src/render/dom/utils/value-types.ts
+++ b/src/render/dom/utils/value-types.ts
@@ -105,6 +105,7 @@ const defaultValueTypes: ValueTypeMap = {
     y: px,
     z: px,
     perspective: px,
+    transformPerspective: px,
     opacity: alpha,
     originX: progressPercentage,
     originY: progressPercentage,


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/687

`perspective` is a CSS style with behaviour distinct from the less-used `transform: perspective()` style.

To support both, there was nascent support for a `transformPerspective` style carried over from Stylefire. But it hadn't been correctly ported over. This PR implements this support.