### PR TITLE
Adding new repeat syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.0] 2020-08-18
+
+### Added
+
+-   New repeat syntax
+-   Support for repeated springs
+
+### Fixed
+
+-   Fixed support for `null` in keyframes animations.
+
 ## [2.4.3] 2020-08-18
 
 ### Changed

--- a/dev/examples/Animation-repeat-spring.tsx
+++ b/dev/examples/Animation-repeat-spring.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { motion } from "@framer"
+
+/**
+ * An example of the Motion keyframes syntax.
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "white",
+    x: 0,
+    borderRadius: 20,
+}
+
+export const App = () => {
+    return (
+        <motion.div
+            initial={{ x: -300 }}
+            animate={{ x: 300 }}
+            transition={{
+                type: "spring",
+                delay: 1,
+                repeat: 2,
+                repeatDelay: 1,
+                repeatType: "reverse",
+            }}
+            style={style}
+        />
+    )
+}

--- a/src/animation/utils/__tests__/transitions.test.ts
+++ b/src/animation/utils/__tests__/transitions.test.ts
@@ -2,6 +2,7 @@ import {
     isTransitionDefined,
     convertTransitionToAnimationOptions,
     getDelayFromTransition,
+    hydrateKeyframes,
 } from "../transitions"
 import { linear, easeInOut, circIn } from "popmotion"
 
@@ -45,6 +46,15 @@ describe("convertTransitionToAnimationOptions", () => {
         ).toEqual({
             repeat: Infinity,
             repeatType: "loop",
+            type: "keyframes",
+        })
+
+        expect(
+            convertTransitionToAnimationOptions({
+                repeat: Infinity,
+            })
+        ).toEqual({
+            repeat: Infinity,
             type: "keyframes",
         })
 
@@ -105,5 +115,31 @@ describe("getDelayFromTransition", () => {
                 "x"
             )
         ).toBe(0)
+    })
+})
+
+describe("hydrateKeyframes", () => {
+    test("Replaces null with from", () => {
+        const opts = {
+            from: 1,
+            to: [null, 2, 3],
+        }
+        hydrateKeyframes(opts)
+        expect(opts).toEqual({
+            from: 1,
+            to: [1, 2, 3],
+        })
+    })
+
+    test("Leaves to alone if first value is not null", () => {
+        const opts = {
+            from: 1,
+            to: [2, 2, 3],
+        }
+        hydrateKeyframes(opts)
+        expect(opts).toEqual({
+            from: 1,
+            to: [2, 2, 3],
+        })
     })
 })

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -72,7 +72,7 @@ export function convertTransitionToAnimationOptions<T extends Animatable>({
     } else if (flip) {
         options.repeatType = "mirror"
     }
-    options.repeat = loop || yoyo || flip
+    options.repeat = loop || yoyo || flip || transition.repeat
 
     /**
      * TODO: Popmotion 9 has the ability to automatically detect whether to use
@@ -96,10 +96,20 @@ export function getDelayFromTransition(transition: Transition, key: string) {
     )
 }
 
+export function hydrateKeyframes(options: PermissiveTransitionDefinition) {
+    if (Array.isArray(options.to) && options.to[0] === null) {
+        options.to = [...options.to]
+        options.to[0] = options.from
+    }
+
+    return options
+}
+
 function startPopmotionAnimate(
     transition: PermissiveTransitionDefinition,
     options: any
 ): PlaybackControls {
+    hydrateKeyframes(options)
     return animate({
         ...options,
         ...convertTransitionToAnimationOptions(transition),

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ export {
 export { VisualElementAnimationControls } from "./animation/VisualElementAnimationControls"
 export {
     Orchestration,
+    Repeat,
     Tween,
     Spring,
     Keyframes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,7 +393,7 @@ export interface Orchestration {
     staggerDirection?: number
 }
 
-export interface RepeatOptions {
+export interface Repeat {
     /**
      * The number of times to repeat the transition. Set to `Infinity` for perpetual repeating.
      *
@@ -502,7 +502,7 @@ export interface RepeatOptions {
  *
  * @public
  */
-export interface Tween extends RepeatOptions {
+export interface Tween extends Repeat {
     /**
      * Set `type` to `"tween"` to use a duration-based tween animation.
      * If any non-orchestration `transition` values are set without a `type` property,
@@ -815,7 +815,7 @@ export interface Tween extends RepeatOptions {
  *
  * @public
  */
-export interface Spring extends RepeatOptions {
+export interface Spring extends Repeat {
     /**
      * Set `type` to `"spring"` to animate using spring physics for natural
      * movement. Type is set to `"spring"` by default.

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,13 +393,116 @@ export interface Orchestration {
     staggerDirection?: number
 }
 
+export interface RepeatOptions {
+    /**
+     * The number of times to repeat the transition. Set to `Infinity` for perpetual repeating.
+     *
+     * Without setting `repeatType`, this will loop the animation.
+     *
+     * @library
+     *
+     * ```jsx
+     * const transition = {
+     *   repeat: Infinity,
+     *   duration: 2
+     * }
+     *
+     * <Frame
+     *   animate={{ rotate: 180 }}
+     *   transition={transition}
+     * />
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{ rotate: 180 }}
+     *   transition={{ repeat: Infinity, duration: 2 }}
+     * />
+     * ```
+     *
+     * @public
+     */
+    repeat?: number
+
+    /**
+     * How to repeat the animation. This can be either:
+     * - "loop": Repeats the animation from the start
+     * - "reverse": Alternates between forward and backwards playback
+     * - "mirror": Switchs `from` and `to` alternately
+     *
+     * @library
+     *
+     * ```jsx
+     * const transition = {
+     *   repeat: 1,
+     *   repeatType: "reverse",
+     *   duration: 2
+     * }
+     *
+     * <Frame
+     *   animate={{ rotate: 180 }}
+     *   transition={transition}
+     * />
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{ rotate: 180 }}
+     *   transition={{
+     *     repeat: 1,
+     *     repeatType: "reverse",
+     *     duration: 2
+     *   }}
+     * />
+     * ```
+     *
+     * @public
+     */
+    repeatType?: "loop" | "reverse" | "mirror"
+
+    /**
+     * When repeating an animation using `loop`, `flip`, or `yoyo`, `repeatDelay` can set the
+     * duration of the time to wait, in seconds, between each repetition.
+     *
+     * @library
+     *
+     * ```jsx
+     * const transition = {
+     *   yoyo: Infinity,
+     *   repeatDelay: 1
+     * }
+     *
+     * <Frame
+     *   animate={{ rotate: 180 }}
+     *   transition={transition}
+     * />
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{ rotate: 180 }}
+     *   transition={{ yoyo: Infinity, repeatDelay: 1 }}
+     * />
+     * ```
+     *
+     * @public
+     */
+    repeatDelay?: number
+}
+
 /**
  * An animation that animates between two or more values over a specific duration of time.
  * This is the default animation for non-physical values like `color` and `opacity`.
  *
  * @public
  */
-export interface Tween {
+export interface Tween extends RepeatOptions {
     /**
      * Set `type` to `"tween"` to use a duration-based tween animation.
      * If any non-orchestration `transition` values are set without a `type` property,
@@ -593,7 +696,7 @@ export interface Tween {
      * />
      * ```
      *
-     * @public
+     * @deprecated
      */
     loop?: number
 
@@ -624,7 +727,7 @@ export interface Tween {
      * />
      * ```
      *
-     * @public
+     * @deprecated
      */
     flip?: number
 
@@ -655,41 +758,9 @@ export interface Tween {
      * />
      * ```
      *
-     * @public
+     * @deprecated
      */
     yoyo?: number
-
-    /**
-     * When repeating an animation using `loop`, `flip`, or `yoyo`, `repeatDelay` can set the
-     * duration of the time to wait, in seconds, between each repetition.
-     *
-     * @library
-     *
-     * ```jsx
-     * const transition = {
-     *   yoyo: Infinity,
-     *   repeatDelay: 1
-     * }
-     *
-     * <Frame
-     *   animate={{ rotate: 180 }}
-     *   transition={transition}
-     * />
-     * ```
-     *
-     * @motion
-     *
-     * ```jsx
-     * <motion.div
-     *   animate={{ rotate: 180 }}
-     *   transition={{ yoyo: Infinity, repeatDelay: 1 }}
-     * />
-     * ```
-     *
-     *
-     * @public
-     */
-    repeatDelay?: number
 
     /**
      * The value to animate from.
@@ -744,7 +815,7 @@ export interface Tween {
  *
  * @public
  */
-export interface Spring {
+export interface Spring extends RepeatOptions {
     /**
      * Set `type` to `"spring"` to animate using spring physics for natural
      * movement. Type is set to `"spring"` by default.


### PR DESCRIPTION
This PR adds support for the new repeat syntax.

```jsx
repeat: Infinity
repeatType: "mirror"
```

It also fixes a bug with keyframes null syntax