### PR TITLE
Coerce zero to unit type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 -   Fixing detection of transition definitions and application of default transitions.
+-   When animating to/from `0` and a unit type, `0` will be coerced to that unit type rather than needing unit conversion via DOM measurement.
 
 ## [2.6.1] 2020-08-26
 

--- a/dev/examples/Animation-between-value-types.tsx
+++ b/dev/examples/Animation-between-value-types.tsx
@@ -1,9 +1,23 @@
 import * as React from "react"
-import { motion } from "@framer"
+import { motion, useCycle } from "@framer"
 
 /**
- * An example of animating between the detected value type (px) and the set one (%)
+ * An example of animating between different value types
  */
+
+export const App = () => {
+    const [width, nextWidth] = useCycle(0, "100%", "calc(50% + 100px)")
+    return (
+        <div style={stretch} onClick={() => nextWidth()}>
+            <motion.div
+                initial={false}
+                animate={{ width }}
+                transition={{ duration: 5 }}
+                style={style}
+            />
+        </div>
+    )
+}
 
 const style = {
     width: 100,
@@ -11,12 +25,10 @@ const style = {
     background: "white",
 }
 
-export const App = () => {
-    return (
-        <motion.div
-            animate={{ width: "100%" }}
-            transition={{ duration: 5, from: "50%" }}
-            style={style}
-        />
-    )
+const stretch: React.CSSProperties = {
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
 }

--- a/src/render/dom/utils/unit-type-conversion.ts
+++ b/src/render/dom/utils/unit-type-conversion.ts
@@ -72,14 +72,14 @@ const getTranslateFromMatrix = (
 
 const transformKeys = new Set(["x", "y", "z"])
 const nonTranslationalTransformKeys = transformProps.filter(
-    key => !transformKeys.has(key)
+    (key) => !transformKeys.has(key)
 )
 
 type RemovedTransforms = [string, string | number][]
 function removeNonTranslationalTransform(visualElement: HTMLVisualElement) {
     const removedTransforms: RemovedTransforms = []
 
-    nonTranslationalTransformKeys.forEach(key => {
+    nonTranslationalTransformKeys.forEach((key) => {
         const value:
             | MotionValue<string | number>
             | undefined = visualElement.getValue(key)
@@ -141,7 +141,7 @@ const convertChangedValueTypes = (
 
     const targetBbox = visualElement.getBoundingBox()
 
-    changedKeys.forEach(key => {
+    changedKeys.forEach((key) => {
         // Restore styles to their **calculated computed style**, not their actual
         // originally set style. This allows us to animate between equivalent pixel units.
         const value = visualElement.getValue(key) as MotionValue
@@ -173,7 +173,7 @@ const checkAndConvertChangedValueTypes = (
 
     const changedValueTypeKeys: string[] = []
 
-    targetPositionalKeys.forEach(key => {
+    targetPositionalKeys.forEach((key) => {
         const value = visualElement.getValue(key) as MotionValue<
             number | string
         >
@@ -224,6 +224,14 @@ const checkAndConvertChangedValueTypes = (
                 } else if (Array.isArray(to) && toType === px) {
                     target[key] = to.map(parseFloat)
                 }
+            } else if (fromType && toType && (from === 0 || to === 0)) {
+                // If one or the other value is 0, it's safe to coerce it to the
+                // type of the other without measurement
+                if (from === 0) {
+                    value.set((toType as any).transform(from))
+                } else {
+                    target[key] = (fromType as any).transform(from)
+                }
             } else {
                 // If we're going to do value conversion via DOM measurements, we first
                 // need to remove non-positional transform values that could affect the bbox measurements.
@@ -239,6 +247,7 @@ const checkAndConvertChangedValueTypes = (
                     transitionEnd[key] !== undefined
                         ? transitionEnd[key]
                         : target[key]
+
                 setAndResetVelocity(value, to)
             }
         }


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/706

Motion implements its ability to animate between unit types by measuring the before/after state and animating via pixels. The way it does this is less sophisticated than the layout animation implementation so it can be a performance issue. It also causes problems when we involved `display: none` as we can't measure the DOM in these instances.

This PR adds the detection of a common pattern where a value is animated from `0` (considered pixels) and another value type and simply coerces `0` into the unit type.