### PR TITLE
Add documentation above useIsPresent

### DIFF
--- a/src/components/AnimatePresence/use-presence.ts
+++ b/src/components/AnimatePresence/use-presence.ts
@@ -53,6 +53,23 @@ export function usePresence(): AlwaysPresent | Present | NotPresent {
 }
 
 /**
+ * Similar to `usePresence`, except `useIsPresent` simply returns whether or not the component is present.
+ * There is no `safeToRemove` function.
+ *
+ * ```jsx
+ * import { useIsPresent } from "framer-motion"
+ *
+ * export const Component = () => {
+ *   const isPresent = useIsPresent()
+ *
+ *   useEffect(() => {
+ *     !isPresent && console.log("I've been removed!")
+ *   }, [isPresent])
+ *
+ *   return <div />
+ * }
+ * ```
+ *
  * @public
  */
 export function useIsPresent() {


### PR DESCRIPTION
I was poking around the codebase to see if there was a way to use `usePresence` without the `safeToRemove` argument (or how easy it would be to make it do that) and I noticed that there's a `useIsPresent` hook that does exactly that. It's even already exported from the library and possible to import and use. My hope is to document it in the api docs so I can confidently use it :). It appears that the api docs pull in the documentation direction from here so I added some in here.

I apologize if I was supposed to open an issue first. The change I wanted to make was so small I should just go for it. If you merge this, I'm happy to make the accompanying PR in the api docs.

For more context, my exact use-case in wanting this has to do with redux (or context in general). If I have a component that gets unmounted because some state changed in redux and that component also pulls state out of redux, the component will update with the new redux values while unmounting. I'm pretty sure that, with `useIsPresent`, I'll be able to fashion a way to deal with this.