### PR TITLE
Fixing default keyframes duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.6.11] 2020-09-11
+
+### Fixed
+
+-   Reinstating default keyframes duration of `0.8` seconds.
+
 ## [2.6.10] 2020-09-10
 
 ### Fixed

--- a/src/animation/utils/__tests__/transitions.test.ts
+++ b/src/animation/utils/__tests__/transitions.test.ts
@@ -19,6 +19,8 @@ describe("isTransitionDefined", () => {
         expect(isTransitionDefined({ delay: 0 })).toBe(false)
         expect(isTransitionDefined({ duration: 1 })).toBe(true)
         expect(isTransitionDefined({ delay: 0, duration: 1 })).toBe(true)
+        expect(isTransitionDefined({ type: "tween" })).toBe(true)
+        expect(isTransitionDefined({ ease: "linear" })).toBe(true)
     })
 })
 
@@ -200,6 +202,40 @@ describe("getPopmotionAnimationOptions", () => {
             to: [50, 100],
             type: "keyframes",
             duration: 400,
+        })
+
+        expect(
+            getPopmotionAnimationOptions({}, { from: 50, to: [null, 100] }, "x")
+        ).toEqual({
+            from: 50,
+            to: [50, 100],
+            type: "keyframes",
+            duration: 800,
+        })
+
+        expect(
+            getPopmotionAnimationOptions(
+                { duration: 0.9 },
+                { from: 50, to: [null, 100] },
+                "x"
+            )
+        ).toEqual({
+            from: 50,
+            to: [50, 100],
+            type: "keyframes",
+            duration: 900,
+        })
+
+        expect(
+            getPopmotionAnimationOptions(
+                { type: "tween" },
+                { from: 50, to: 100 },
+                "x"
+            )
+        ).toEqual({
+            from: 50,
+            to: 100,
+            type: "keyframes",
         })
 
         expect(

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -117,6 +117,10 @@ export function getPopmotionAnimationOptions(
     options: any,
     key: string
 ) {
+    if (Array.isArray(options.to)) {
+        transition.duration ??= 0.8
+    }
+
     hydrateKeyframes(options)
 
     /**


### PR DESCRIPTION
Keyframes animations defined using an array used to have a default duration of `0.8` in Popmotion, this reimplements that here.