### PR TITLE
Let useDomEvent handle any EventTarget

### DIFF
--- a/src/events/use-dom-event.ts
+++ b/src/events/use-dom-event.ts
@@ -34,7 +34,7 @@ export function addDomEvent(
  * @public
  */
 export function useDomEvent(
-    ref: RefObject<Element>,
+    ref: RefObject<EventTarget>,
     eventName: string,
     handler?: EventListener | undefined,
     options?: AddEventListenerOptions


### PR DESCRIPTION
Very neat little hook. This change allows passing in a ref `window` or `document`. `addDomEvent` is primed for it above. This change would fix the error on [this line](https://codesandbox.io/s/framer-motion-image-lightbox-47bhc?file=/src/Image.tsx:278-351). Any reason this is bad?