### PR TITLE
Only setForcedRenderCount if component is mounted

### DIFF
--- a/src/utils/use-force-update.ts
+++ b/src/utils/use-force-update.ts
@@ -1,9 +1,20 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 
 export function useForceUpdate() {
+    const unloadingRef = useRef(false)
     const [forcedRenderCount, setForcedRenderCount] = useState(0)
 
-    return useCallback(() => setForcedRenderCount(forcedRenderCount + 1), [
-        forcedRenderCount,
-    ])
+    useEffect(() => {
+        return () => {
+            unloadingRef.current = true
+        }
+    }, [])
+
+    return useCallback(() => {
+        if (unloadingRef.current) {
+            return
+        }
+
+        setForcedRenderCount(forcedRenderCount + 1)
+    }, [forcedRenderCount])
 }


### PR DESCRIPTION
This appears to fix #625. I've tested it locally and it does the trick (🎉 ) but I'm unsure of how to add tests for it. I tested it with the component I put in the original codesandbox and ran my Cypress suite, which used to butt heads against this constantly and is now quite happy.