### PR TITLE
Create a reference to Animate's safeToRemove on VisualElement.config

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -843,7 +843,7 @@ export function useAnimation(): AnimationControls;
 export function useCycle<T>(...items: T[]): CycleState<T>;
 
 // @public
-export function useDomEvent(ref: RefObject<Element>, eventName: string, handler?: EventListener | undefined, options?: AddEventListenerOptions): void;
+export function useDomEvent(ref: RefObject<EventTarget>, eventName: string, handler?: EventListener | undefined, options?: AddEventListenerOptions): void;
 
 // @public
 export function useDragControls(): DragControls;

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -45,6 +45,11 @@ class Animate extends React.Component<AnimateProps> {
         const { visualElement } = this.props
         visualElement.enableLayoutProjection()
         this.unsubLayoutReady = visualElement.onLayoutUpdate(this.animate)
+
+        visualElement.updateConfig({
+            ...visualElement.config,
+            safeToRemove: () => this.safeToRemove(),
+        })
     }
 
     componentWillUnmount() {

--- a/src/render/dom/types.ts
+++ b/src/render/dom/types.ts
@@ -49,6 +49,8 @@ export interface DOMVisualElementConfig extends VisualElementConfig {
     transformTemplate?: MotionProps["transformTemplate"]
 
     transition?: MotionProps["transition"]
+
+    safeToRemove?: () => void
 }
 
 export interface TransformOrigin {

--- a/src/render/dom/use-dom-visual-element.ts
+++ b/src/render/dom/use-dom-visual-element.ts
@@ -10,6 +10,7 @@ import { useEffect } from "react"
 /**
  * DOM-flavoured variation of the useVisualElement hook. Used to create either a HTMLVisualElement
  * or SVGVisualElement for the component.
+ *
  */
 export const useDomVisualElement: UseVisualElement<MotionProps, any> = (
     Component,
@@ -27,8 +28,8 @@ export const useDomVisualElement: UseVisualElement<MotionProps, any> = (
     })
 
     visualElement.updateConfig({
-        enableHardwareAcceleration: !isStatic,
         ...visualElement.config,
+        enableHardwareAcceleration: !isStatic,
         ...props,
     })
 

--- a/src/render/dom/use-dom-visual-element.ts
+++ b/src/render/dom/use-dom-visual-element.ts
@@ -28,6 +28,7 @@ export const useDomVisualElement: UseVisualElement<MotionProps, any> = (
 
     visualElement.updateConfig({
         enableHardwareAcceleration: !isStatic,
+        ...visualElement.config,
         ...props,
     })
 


### PR DESCRIPTION
In Framer, screens with VisualElements that have been assigned a `layoutId` in case a shared layout transition is performed, prevent screens that are removed with a different transition type from being fully removed from the DOM. This is because they've registered to the PresenceContext, and haven't called `safeToRemove()`. 

This isn't a problem for shared layout transitions, because we flush a callback to all children telling them to call `safeToRemove()` at the end of their animation, or immediately if they're not being animated.

Since framer uses `exit` transitions on containers for other transition types, rather than flushing a callback to every child of the exiting screen through the SharedLayout batcher (which would require us to perform some unnecessary dom manipulations and measurements on each outgoing component), this PR adds a reference to safeToRemove to the `visualElement` config. This is then called in framer on each exiting child without forking the batcher logic, or adding unnecessary overhead.

Fixes containers not being removed in Framer here: https://github.com/framer/FramerStudio/pull/6348



