### PR TITLE
Fix: Don't unset keys with 0 values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.6.13",
+    "version": "2.6.14-rc.0",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "dist/framer-motion.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.6.14-rc.0",
+    "version": "2.6.14-rc.2",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "dist/framer-motion.d.ts",

--- a/src/motion/utils/use-motion-values.ts
+++ b/src/motion/utils/use-motion-values.ts
@@ -39,8 +39,8 @@ export function useMotionValues<P>(
      */
     for (const key in prev) {
         const isForced = isForcedMotionValue(key, props)
-        const existsAsProp = props[key]
-        const existsAsStyle = props.style && props.style[key]
+        const existsAsProp = props[key] !== undefined
+        const existsAsStyle = props.style && props.style[key] !== undefined
         const propIsMotionValue = existsAsProp && isMotionValue(props[key])
         const styleIsMotionValue =
             existsAsStyle && isMotionValue(props.style![key])


### PR DESCRIPTION
- Animations from a current value to 0 were being unset because the target value was falsy
- Includes package.json bumps from releases that couldn't be pushed to master with my permissions