### PR TITLE
Duration-based springs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.0] 2020-09-22
+
+### Added
+
+-   Duration-based springs.
+
 ## [2.6.15] 2020-09-18
 
 ### Fix

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -729,8 +729,10 @@ export type SingleTarget = ResolvedSingleTarget | CustomValueType;
 // @public
 export interface Spring extends Repeat {
     damping?: number;
+    dampingRatio?: number;
     // @internal (undocumented)
     delay?: number;
+    duration?: number;
     from?: number | string;
     mass?: number;
     restDelta?: number;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -728,8 +728,8 @@ export type SingleTarget = ResolvedSingleTarget | CustomValueType;
 
 // @public
 export interface Spring extends Repeat {
+    bounce?: number;
     damping?: number;
-    dampingRatio?: number;
     // @internal (undocumented)
     delay?: number;
     duration?: number;

--- a/dev/examples/Animation-transition-tween.tsx
+++ b/dev/examples/Animation-transition-tween.tsx
@@ -15,9 +15,9 @@ const style = {
 export const App = () => {
     const [x, setX] = useState(0)
     const transition = {
-        type: "tween",
-        ease: "anticipate",
+        type: "spring",
         duration: 0.4,
+        dampingRatio: 0.4,
     }
 
     return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.7.0-rc.0",
+    "version": "2.7.0-rc.1",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "2.6.15",
+    "version": "2.7.0-rc.0",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",
     "types": "types/index.d.ts",
@@ -94,7 +94,7 @@
     "dependencies": {
         "framesync": "^4.1.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.0.0-rc.14",
+        "popmotion": "9.0.0-rc.17",
         "style-value-types": "^3.1.9",
         "tslib": "^1.10.0"
     },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "dependencies": {
         "framesync": "^4.1.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "9.0.0-rc.17",
+        "popmotion": "9.0.0-rc.18",
         "style-value-types": "^3.1.9",
         "tslib": "^1.10.0"
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -945,7 +945,7 @@ export interface Spring extends Repeat {
     /**
      * The duration of the animation, defined in seconds. Spring animations can be a maximum of 10 seconds.
      *
-     * **Note:** `duration` and `dampingRatio` override all other spring options.
+     * **Note:** `duration` and `bounce` override all other spring options.
      *
      * @library
      *
@@ -975,18 +975,18 @@ export interface Spring extends Repeat {
     duration?: number
 
     /**
-     * `dampingRatio` determines the amount of "springiness" of a spring animation.
+     * `bounce` determines the "bounciness" of a spring animation.
      *
-     * `0` is no damping, for maximum springiness. `1` is full damping, for no springiness.
+     * `0` is no bounce, and `1` is extremely bouncy.
      *
-     * **Note:** `dampingRatio` and `duration` override all other spring options.
+     * **Note:** `bounce` and `duration` override all other spring options.
      *
      * @library
      *
      * ```jsx
      * const transition = {
      *   type: "spring",
-     *   dampingRatio: 1
+     *   bounce: 0.25
      * }
      *
      * <Frame
@@ -1000,13 +1000,13 @@ export interface Spring extends Repeat {
      * ```jsx
      * <motion.div
      *   animate={{ x: 100 }}
-     *   transition={{ type: "spring", dampingRatio: 1 }}
+     *   transition={{ type: "spring", bounce: 0.25 }}
      * />
      * ```
      *
      * @public
      */
-    dampingRatio?: number
+    bounce?: number
 
     /**
      * End animation if absolute speed (in units per second) drops below this

--- a/src/types.ts
+++ b/src/types.ts
@@ -943,6 +943,72 @@ export interface Spring extends Repeat {
     mass?: number
 
     /**
+     * The duration of the animation, defined in seconds. Spring animations can be a maximum of 10 seconds.
+     *
+     * **Note:** `duration` and `dampingRatio` override all other spring options.
+     *
+     * @library
+     *
+     * ```jsx
+     * const transition = {
+     *   type: "spring",
+     *   duration: 0.8
+     * }
+     *
+     * <Frame
+     *   animate={{ rotate: 180 }}
+     *   transition={transition}
+     * />
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{ x: 100 }}
+     *   transition={{ type: "spring", duration: 0.8 }}
+     * />
+     * ```
+     *
+     * @public
+     */
+    duration?: number
+
+    /**
+     * `dampingRatio` determines the amount of "springiness" of a spring animation.
+     *
+     * `0` is no damping, for maximum springiness. `1` is full damping, for no springiness.
+     *
+     * **Note:** `dampingRatio` and `duration` override all other spring options.
+     *
+     * @library
+     *
+     * ```jsx
+     * const transition = {
+     *   type: "spring",
+     *   dampingRatio: 1
+     * }
+     *
+     * <Frame
+     *   animate={{ rotate: 180 }}
+     *   transition={transition}
+     * />
+     * ```
+     *
+     * @motion
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{ x: 100 }}
+     *   transition={{ type: "spring", dampingRatio: 1 }}
+     * />
+     * ```
+     *
+     * @public
+     */
+    dampingRatio?: number
+
+    /**
      * End animation if absolute speed (in units per second) drops below this
      * value and delta is smaller than `restDelta`. Set to `0.01` by default.
      *

--- a/src/types.ts
+++ b/src/types.ts
@@ -945,7 +945,7 @@ export interface Spring extends Repeat {
     /**
      * The duration of the animation, defined in seconds. Spring animations can be a maximum of 10 seconds.
      *
-     * **Note:** `duration` and `bounce` override all other spring options.
+     * Note: `duration` and `bounce` override all other spring options.
      *
      * @library
      *
@@ -979,7 +979,7 @@ export interface Spring extends Repeat {
      *
      * `0` is no bounce, and `1` is extremely bouncy.
      *
-     * **Note:** `bounce` and `duration` override all other spring options.
+     * Note: `bounce` and `duration` override all other spring options.
      *
      * @library
      *

--- a/yarn.lock
+++ b/yarn.lock
@@ -7414,10 +7414,10 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-popmotion@9.0.0-rc.17:
-  version "9.0.0-rc.17"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.17.tgz#6cbebf3333915e2bae54a914801022b5213ff04b"
-  integrity sha512-tdRpDQlipsBLx+ikYU46hTAADVP6TibMheNGChP66CDqVxZZjzU8zM+zwYJDrJeSra3M6nqj+htUxgH7pHobBw==
+popmotion@9.0.0-rc.18:
+  version "9.0.0-rc.18"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.18.tgz#1764d16bc157e067f92c0b2366672385d7199118"
+  integrity sha512-vylSPC3lX6ATg/R0tMgHAlKLdbrczjccRwPXS35V+hDQngjQsSxbnv+AHo81P/9C3yeufFTePBN3niPQrFXYeA==
   dependencies:
     framesync "^4.1.0"
     hey-listen "^1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7414,10 +7414,10 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-popmotion@9.0.0-rc.14:
-  version "9.0.0-rc.14"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.14.tgz#e57351b7b85a3e42b7a16affbbd440138797c11f"
-  integrity sha512-zdMw1OSKjFBH+KKpZx7P+cGSUb3QCqg5QD12f6llucUeEFT+SDZYxvTY09JI23ZcJyzxgKFT1anbLq0eZ9bj3g==
+popmotion@9.0.0-rc.17:
+  version "9.0.0-rc.17"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.0-rc.17.tgz#6cbebf3333915e2bae54a914801022b5213ff04b"
+  integrity sha512-tdRpDQlipsBLx+ikYU46hTAADVP6TibMheNGChP66CDqVxZZjzU8zM+zwYJDrJeSra3M6nqj+htUxgH7pHobBw==
   dependencies:
     framesync "^4.1.0"
     hey-listen "^1.0.8"


### PR DESCRIPTION
This PR adds duration-based springs to Motion.

Rather than using time-unbounded `stiffness` `mass` and `damping`, which are great for interactive springs, this allows springs to be defined using `duration` and/or `bounce` for timeline-compatible springs:

```
transition={{ type: "spring", duration: 0.7, bounce: 0.35 }}
```

`bounce` is a value between `0` (no overshoot) and `1` (extreme bounciness)

Demo: https://codesandbox.io/s/framer-motion-duration-based-springs-api-rc-z8fbu?file=/src/Example.tsx