### PR TITLE
Removing Point namespace

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -238,10 +238,8 @@ export type EasingFunction = (v: number) => number;
 
 // @public (undocumented)
 export interface EventInfo {
-    // Warning: (ae-forgotten-export) The symbol "Point" needs to be exported by the entry point index.d.ts
-    // 
     // (undocumented)
-    point: Point;
+    point: Point2D;
 }
 
 // @public (undocumented)
@@ -599,10 +597,10 @@ export interface PanHandlers {
 
 // @public
 export interface PanInfo {
-    delta: Point;
-    offset: Point;
-    point: Point;
-    velocity: Point;
+    delta: Point2D;
+    offset: Point2D;
+    point: Point2D;
+    velocity: Point2D;
 }
 
 // @public (undocumented)
@@ -782,7 +780,7 @@ export interface TapHandlers {
 
 // @public
 export interface TapInfo {
-    point: Point;
+    point: Point2D;
 }
 
 // Warning: (ae-forgotten-export) The symbol "TargetWithKeyframes" needs to be exported by the entry point index.d.ts

--- a/src/events/__tests__/types.test.tsx
+++ b/src/events/__tests__/types.test.tsx
@@ -1,9 +1,36 @@
 import "../../../jest.setup"
-import { Point } from "../types"
+import { Point2D } from "../../types/geometry"
+
+const relativeTo = (idOrElem: string | HTMLElement) => {
+    let elem: HTMLElement | null
+
+    const getElem = () => {
+        // Caching element here could be leaky because of React lifecycle
+        if (elem !== undefined) return elem
+        if (typeof idOrElem === "string") {
+            elem = document.getElementById(idOrElem)
+        } else {
+            elem = idOrElem
+        }
+        return elem
+    }
+
+    return ({ x, y }: Point2D): Point2D | undefined => {
+        const localElem = getElem()
+
+        if (!localElem) return undefined
+        const rect = localElem.getBoundingClientRect()
+
+        return {
+            x: x - rect.left - window.scrollX,
+            y: y - rect.top - window.scrollY,
+        }
+    }
+}
 
 describe("relativeTo", () => {
     it("should return nothing if there is no element available", () => {
-        const convert = Point.relativeTo(null as any)
+        const convert = relativeTo(null as any)
         expect(convert({ x: 1, y: 1 })).toBeUndefined()
     })
     it("should use provided element", () => {
@@ -12,7 +39,7 @@ describe("relativeTo", () => {
                 return { left: 10, top: 5 }
             },
         }
-        const convert = Point.relativeTo(elem as HTMLElement)
+        const convert = relativeTo(elem as HTMLElement)
         expect(convert({ x: 12, y: 12 })).toEqual({ x: 2, y: 7 })
     })
     it("should use element from document if id was provided", () => {
@@ -24,7 +51,7 @@ describe("relativeTo", () => {
 
         const getElementById = document.getElementById
         document.getElementById = () => elem as HTMLElement
-        const convert = Point.relativeTo("test")
+        const convert = relativeTo("test")
         expect(convert({ x: 12, y: 12 })).toEqual({ x: 2, y: 6 })
         document.getElementById = getElementById
     })

--- a/src/events/types.ts
+++ b/src/events/types.ts
@@ -1,50 +1,9 @@
 import { RefObject } from "react"
-
-/** @public */
-export interface Point {
-    x: number
-    y: number
-}
-
-/** @public */
-export namespace Point {
-    /** @beta */
-    export const subtract = (a: Point, b: Point): Point => {
-        return { x: a.x - b.x, y: a.y - b.y }
-    }
-
-    /** @beta */
-    export const relativeTo = (idOrElem: string | HTMLElement) => {
-        let elem: HTMLElement | null
-
-        const getElem = () => {
-            // Caching element here could be leaky because of React lifecycle
-            if (elem !== undefined) return elem
-            if (typeof idOrElem === "string") {
-                elem = document.getElementById(idOrElem)
-            } else {
-                elem = idOrElem
-            }
-            return elem
-        }
-
-        return ({ x, y }: Point): Point | undefined => {
-            const localElem = getElem()
-
-            if (!localElem) return undefined
-            const rect = localElem.getBoundingClientRect()
-
-            return {
-                x: x - rect.left - window.scrollX,
-                y: y - rect.top - window.scrollY,
-            }
-        }
-    }
-}
+import { Point2D } from "../types/geometry"
 
 /** @public */
 export interface EventInfo {
-    point: Point
+    point: Point2D
 }
 
 export type EventHandler = (

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -1,11 +1,11 @@
-import { EventInfo, Point } from "../events/types"
+import { EventInfo } from "../events/types"
 import { isTouchEvent, isMouseEvent } from "./utils/event-type"
 import { extractEventInfo } from "../events/event-info"
 import sync, { getFrameData, cancelSync } from "framesync"
 import { secondsToMilliseconds } from "../utils/time-conversion"
 import { addPointerEvent } from "../events/use-pointer-event"
 import { distance, pipe } from "popmotion"
-import { TransformPoint2D } from "../types/geometry"
+import { Point2D, TransformPoint2D } from "../types/geometry"
 
 export type AnyPointerEvent = MouseEvent | TouchEvent | PointerEvent
 
@@ -61,7 +61,7 @@ export interface PanInfo {
      *
      * @public
      */
-    point: Point
+    point: Point2D
     /**
      * Contains `x` and `y` values for the distance moved since
      * the last event.
@@ -88,7 +88,7 @@ export interface PanInfo {
      *
      * @public
      */
-    delta: Point
+    delta: Point2D
     /**
      * Contains `x` and `y` values for the distance moved from
      * the first pan event.
@@ -115,7 +115,7 @@ export interface PanInfo {
      *
      * @public
      */
-    offset: Point
+    offset: Point2D
     /**
      * Contains `x` and `y` values for the current velocity of the pointer.
      *
@@ -141,7 +141,7 @@ export interface PanInfo {
      *
      * @public
      */
-    velocity: Point
+    velocity: Point2D
 }
 
 export type PanHandler = (event: Event, info: PanInfo) => void
@@ -156,7 +156,7 @@ interface PanSessionOptions {
     transformPagePoint?: TransformPoint2D
 }
 
-interface TimestampedPoint extends Point {
+interface TimestampedPoint extends Point2D {
     timestamp: number
 }
 
@@ -296,16 +296,20 @@ export class PanSession {
 
 function transformPoint(
     info: EventInfo,
-    transformPagePoint?: (point: Point) => Point
+    transformPagePoint?: (point: Point2D) => Point2D
 ) {
     return transformPagePoint ? { point: transformPagePoint(info.point) } : info
+}
+
+function subtractPoint(a: Point2D, b: Point2D): Point2D {
+    return { x: a.x - b.x, y: a.y - b.y }
 }
 
 function getPanInfo({ point }: EventInfo, history: TimestampedPoint[]) {
     return {
         point,
-        delta: Point.subtract(point, lastDevicePoint(history)),
-        offset: Point.subtract(point, startDevicePoint(history)),
+        delta: subtractPoint(point, lastDevicePoint(history)),
+        offset: subtractPoint(point, startDevicePoint(history)),
         velocity: getVelocity(history, 0.1),
     }
 }
@@ -318,7 +322,7 @@ function lastDevicePoint(history: TimestampedPoint[]): TimestampedPoint {
     return history[history.length - 1]
 }
 
-function getVelocity(history: TimestampedPoint[], timeDelta: number): Point {
+function getVelocity(history: TimestampedPoint[], timeDelta: number): Point2D {
     if (history.length < 2) {
         return { x: 0, y: 0 }
     }

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -1,11 +1,11 @@
-import { EventInfo } from "../events/types"
+import type { EventInfo } from "../events/types"
 import { isTouchEvent, isMouseEvent } from "./utils/event-type"
 import { extractEventInfo } from "../events/event-info"
 import sync, { getFrameData, cancelSync } from "framesync"
 import { secondsToMilliseconds } from "../utils/time-conversion"
 import { addPointerEvent } from "../events/use-pointer-event"
 import { distance, pipe } from "popmotion"
-import { Point2D, TransformPoint2D } from "../types/geometry"
+import type { Point2D, TransformPoint2D } from "../types/geometry"
 
 export type AnyPointerEvent = MouseEvent | TouchEvent | PointerEvent
 

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -1,11 +1,11 @@
-import type { EventInfo } from "../events/types"
+import { EventInfo } from "../events/types"
 import { isTouchEvent, isMouseEvent } from "./utils/event-type"
 import { extractEventInfo } from "../events/event-info"
 import sync, { getFrameData, cancelSync } from "framesync"
 import { secondsToMilliseconds } from "../utils/time-conversion"
 import { addPointerEvent } from "../events/use-pointer-event"
 import { distance, pipe } from "popmotion"
-import type { Point2D, TransformPoint2D } from "../types/geometry"
+import { Point2D, TransformPoint2D } from "../types/geometry"
 
 export type AnyPointerEvent = MouseEvent | TouchEvent | PointerEvent
 

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -1,7 +1,6 @@
 import { RefObject } from "react"
 import { DraggableProps, DragHandler } from "./types"
 import { Lock, getGlobalLock } from "./utils/lock"
-import { Point } from "../../events/types"
 import { isRefObject } from "../../utils/is-ref-object"
 import { addPointerEvent } from "../../events/use-pointer-event"
 import { PanSession, AnyPointerEvent, PanInfo } from "../../gestures/PanSession"
@@ -9,7 +8,7 @@ import { invariant } from "hey-listen"
 import { progress } from "popmotion"
 import { addDomEvent } from "../../events/use-dom-event"
 import { getViewportPointFromEvent } from "../../events/event-info"
-import { TransformPoint2D, AxisBox2D, Point2D } from "../../types/geometry"
+import type { TransformPoint2D, AxisBox2D, Point2D } from "../../types/geometry"
 import {
     convertBoundingBoxToAxisBox,
     convertAxisBoxToBoundingBox,
@@ -413,7 +412,7 @@ export class VisualElementDragControls {
     /**
      * Update the specified axis with the latest pointer information.
      */
-    updateAxis(axis: DragDirection, event: AnyPointerEvent, offset?: Point) {
+    updateAxis(axis: DragDirection, event: AnyPointerEvent, offset?: Point2D) {
         const { drag } = this.props
 
         // If we're not dragging this axis, do an early return.
@@ -424,7 +423,7 @@ export class VisualElementDragControls {
             : this.updateVisualElementAxis(axis, event)
     }
 
-    updateAxisMotionValue(axis: DragDirection, offset?: Point) {
+    updateAxisMotionValue(axis: DragDirection, offset?: Point2D) {
         const axisValue = this.getAxisMotionValue(axis)
 
         if (!offset || !axisValue) return
@@ -508,7 +507,7 @@ export class VisualElementDragControls {
         }
     }
 
-    private animateDragEnd(velocity: Point) {
+    private animateDragEnd(velocity: Point2D) {
         const { drag, dragMomentum, dragElastic, dragTransition } = this.props
 
         const momentumAnimations = eachAxis((axis) => {
@@ -685,7 +684,7 @@ function shouldDrag(
  * @param lockThreshold - (Optional) - the minimum absolute offset before we can determine a drag direction.
  */
 function getCurrentDirection(
-    offset: Point,
+    offset: Point2D,
     lockThreshold = 10
 ): DragDirection | null {
     let direction: DragDirection | null = null

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -8,7 +8,7 @@ import { invariant } from "hey-listen"
 import { progress } from "popmotion"
 import { addDomEvent } from "../../events/use-dom-event"
 import { getViewportPointFromEvent } from "../../events/event-info"
-import type { TransformPoint2D, AxisBox2D, Point2D } from "../../types/geometry"
+import { TransformPoint2D, AxisBox2D, Point2D } from "../../types/geometry"
 import {
     convertBoundingBoxToAxisBox,
     convertAxisBoxToBoundingBox,

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -8,7 +8,7 @@ import { getGlobalLock } from "../gestures/drag/utils/lock"
 import { addPointerEvent, usePointerEvent } from "../events/use-pointer-event"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
 import { pipe } from "popmotion"
-import type { Point2D } from "../types/geometry"
+import { Point2D } from "../types/geometry"
 
 const tapGesturePriority = getGesturePriority("whileTap")
 

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -1,5 +1,5 @@
 import { RefObject, useRef } from "react"
-import { EventInfo, Point, EventHandler } from "../events/types"
+import { EventInfo, EventHandler } from "../events/types"
 import { TargetAndTransition } from "../types"
 import { isNodeOrChild } from "./utils/is-node-or-child"
 import { getGesturePriority } from "./utils/gesture-priority"
@@ -7,7 +7,11 @@ import { ControlsProp, RemoveEvent } from "./types"
 import { getGlobalLock } from "../gestures/drag/utils/lock"
 import { addPointerEvent, usePointerEvent } from "../events/use-pointer-event"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
+<<<<<<< HEAD
 import { pipe } from "popmotion"
+=======
+import { Point2D } from "../types/geometry"
+>>>>>>> Removing Point namespace
 
 const tapGesturePriority = getGesturePriority("whileTap")
 
@@ -64,7 +68,7 @@ export interface TapInfo {
      *
      * @public
      */
-    point: Point
+    point: Point2D
 }
 
 /**

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -7,11 +7,8 @@ import { ControlsProp, RemoveEvent } from "./types"
 import { getGlobalLock } from "../gestures/drag/utils/lock"
 import { addPointerEvent, usePointerEvent } from "../events/use-pointer-event"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
-<<<<<<< HEAD
 import { pipe } from "popmotion"
-=======
-import { Point2D } from "../types/geometry"
->>>>>>> Removing Point namespace
+import type { Point2D } from "../types/geometry"
 
 const tapGesturePriority = getGesturePriority("whileTap")
 


### PR DESCRIPTION
The `Point` namespace only contains one method used in the codebase and can't be codesplit. This PR splits out the two functions into their respective points of usage and replaces the `Point` type with the other `Point2D` type used elsewhere in the codebase.