### PR TITLE
Don't propagate variants if animate is AnimationControls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.4] 2020-09-26
+
+### Fixed
+
+-   Blocks propagation of variants from parent if a component's `animate` prop is set to `AnimationControls`. `inherit` can be used to force inheritence `true` or `false`.
+
 ## [2.7.3] 2020-09-25
 
 ### Fixed

--- a/src/animation/use-animated-state.ts
+++ b/src/animation/use-animated-state.ts
@@ -41,12 +41,12 @@ export function useAnimatedState(initialState: any) {
     const visualElement = useConstant(() => new StateVisualElement())
 
     visualElement.updateConfig({
-        onUpdate: v => setAnimationState({ ...v }),
+        onUpdate: (v) => setAnimationState({ ...v }),
     })
 
     visualElement.initialState = initialState
 
-    const controls = useVisualElementAnimation(visualElement, {}, {})
+    const controls = useVisualElementAnimation(visualElement, {}, {}, false)
 
     useEffect(() => {
         ;(visualElement as any).mount({})

--- a/src/animation/use-visual-element-animation.ts
+++ b/src/animation/use-visual-element-animation.ts
@@ -8,7 +8,6 @@ import { MotionContext } from "../motion/context/MotionContext"
 import { useConstant } from "../utils/use-constant"
 import { PresenceContext } from "../components/AnimatePresence/PresenceContext"
 import { VisualElement } from "../render/VisualElement"
-import { checkShouldInheritVariant } from "../motion/utils/should-inherit-variant"
 
 /**
  * Creates an imperative set of controls to trigger animations.
@@ -20,9 +19,9 @@ import { checkShouldInheritVariant } from "../motion/utils/should-inherit-varian
 export function useVisualElementAnimation<P>(
     visualElement: VisualElement,
     props: P & MotionProps,
-    config: AnimationControlsConfig
+    config: AnimationControlsConfig,
+    subscribeToParentControls: boolean
 ) {
-    const subscribeToParentControls = checkShouldInheritVariant(props)
     const { variants, transition } = props
     const parentControls = useContext(MotionContext).controls
     const presenceContext = useContext(PresenceContext)

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -78,7 +78,8 @@ export function createMotionComponent<P extends {}, E>(
         const controls = useVisualElementAnimation(
             visualElement,
             props,
-            animationControlsConfig
+            animationControlsConfig,
+            shouldInheritVariant
         )
 
         /**

--- a/src/motion/utils/__tests__/should-inherit-variants.test.ts
+++ b/src/motion/utils/__tests__/should-inherit-variants.test.ts
@@ -1,0 +1,31 @@
+import { AnimationControls } from "../../../animation/AnimationControls"
+import { checkShouldInheritVariant } from "../should-inherit-variant"
+
+describe("checkShouldInheritVariant", () => {
+    test("Detects when a component should inherit variants", () => {
+        expect(checkShouldInheritVariant({ animate: { x: 0 } })).toBe(false)
+        expect(checkShouldInheritVariant({ variants: {} })).toBe(true)
+        expect(
+            checkShouldInheritVariant({ variants: {}, inherit: false })
+        ).toBe(false)
+        expect(
+            checkShouldInheritVariant({ variants: {}, inherit: false })
+        ).toBe(false)
+        expect(
+            checkShouldInheritVariant({ variants: {}, animate: "variant" })
+        ).toBe(false)
+        expect(
+            checkShouldInheritVariant({
+                animate: new AnimationControls(),
+                variants: {},
+            })
+        ).toBe(false)
+        expect(
+            checkShouldInheritVariant({
+                animate: new AnimationControls(),
+                variants: {},
+                inherit: true,
+            })
+        ).toBe(true)
+    })
+})

--- a/src/motion/utils/should-inherit-variant.ts
+++ b/src/motion/utils/should-inherit-variant.ts
@@ -1,14 +1,9 @@
 import { MotionProps } from "../types"
-import { AnimationControls } from "../../animation/AnimationControls"
 
-export const checkShouldInheritVariant = ({
+export function checkShouldInheritVariant({
     animate,
     variants,
-    inherit = true,
-}: MotionProps): boolean => {
-    return (
-        inherit &&
-        !!variants &&
-        (!animate || animate instanceof AnimationControls)
-    )
+    inherit,
+}: MotionProps): boolean {
+    return inherit === undefined ? !!variants && !animate : inherit
 }


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/288

This PR disables variant propagation if `animate` is an instance of `AnimationControls`.

There was an exception for `AnimationControls` but this doesn't seem to be covered by tests or have any explanation. I can't think of why you'd want this and it goes against the docs as quoted in the ticket.

As a compromise I've changed the behaviour of the `inherit` prop so now it can be used to either force a component to inherit or not, whereas before it could only disable inheritance.