### PR TITLE
Create a new MotionValue for a transform when an old one is removed from style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.6] 2020-09-29
+
+### Fixed
+
+-   When a `transform` is provided to `style` as a `MotionValue` and then replaced with a number on a subsequent render, we create a new `MotionValue` for it.
+
 ## [2.7.5] 2020-09-26
 
 ### Fixed

--- a/src/motion/__tests__/style-prop.test.tsx
+++ b/src/motion/__tests__/style-prop.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import { motion } from "../.."
+import { motion, useMotionValue } from "../.."
 import * as React from "react"
 
 describe("style prop", () => {
@@ -16,6 +16,60 @@ describe("style prop", () => {
 
         expect(container.firstChild as Element).not.toHaveStyle(
             "position: absolute"
+        )
+    })
+
+    test("should updated transforms when passed a new value", () => {
+        const Component = ({ x = 0 }) => {
+            return <motion.div style={{ x }} />
+        }
+
+        const { container, rerender } = render(<Component />)
+
+        expect(container.firstChild as Element).toHaveStyle("transform: none")
+
+        rerender(<Component x={1} />)
+
+        expect(container.firstChild as Element).toHaveStyle(
+            "transform: translateX(1px) translateZ(0)"
+        )
+
+        rerender(<Component x={0} />)
+
+        expect(container.firstChild as Element).toHaveStyle("transform: none")
+    })
+
+    test("should update when passed new MotionValue", () => {
+        const Component = ({ useX = false }) => {
+            const x = useMotionValue(1)
+            const y = useMotionValue(2)
+
+            return (
+                <motion.div
+                    style={{
+                        x: useX ? x : 0,
+                        y: !useX ? y : 0,
+                    }}
+                />
+            )
+        }
+
+        const { container, rerender } = render(<Component />)
+
+        expect(container.firstChild as Element).toHaveStyle(
+            "transform: translateX(0px) translateY(2px) translateZ(0)"
+        )
+
+        rerender(<Component useX />)
+
+        expect(container.firstChild as Element).toHaveStyle(
+            "transform: translateX(1px) translateY(0px) translateZ(0)"
+        )
+
+        rerender(<Component />)
+
+        expect(container.firstChild as Element).toHaveStyle(
+            "transform: translateX(0px) translateY(2px) translateZ(0)"
         )
     })
 })

--- a/src/motion/utils/use-motion-values.ts
+++ b/src/motion/utils/use-motion-values.ts
@@ -103,11 +103,21 @@ function addMotionValues<P>(
             if (!visualElement.hasValue(key)) {
                 visualElement.addValue(key, motionValue(value))
             } else if (value !== prev[key]) {
-                // If the MotionValue already exists, update it with the
-                // latest incoming value
-                const motion = visualElement.getValue(key)
-                motion!.set(value)
+                if (isMotionValue(prev[key])) {
+                    /**
+                     * If the previous value was a MotionValue, and this value isn't,
+                     * we want to create a new MotionValue rather than update one that's been removed.
+                     */
+                    visualElement.addValue(key, motionValue(value))
+                } else {
+                    /**
+                     * Otherwise, we just want to ensure the MotionValue is of the latest value.
+                     */
+                    const motion = visualElement.getValue(key)
+                    motion!.set(value)
+                }
             }
+
             foundMotionValue = true
         } else if (isStyle) {
             ;(visualElement as any).reactStyle[key] = value


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/447

This PR ensures that if the previous `transform` value in `style` was a `MotionValue` and is subsequently removed, we create a new `MotionValue` for it rather than updating the removed one.