### PR TITLE
Resolving drag constraints on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.8] 2020-10-05
+
+### Changed
+
+-   If `dragConstraints` is set to a ref on a non-draggable component, we resolve the constraints on mount in order to pass them to `onMeasureDragConstraints`.
+
 ## [2.7.7] 2020-10-01
 
 ### Fixed

--- a/dev/examples/Drag-constraints-ref.tsx
+++ b/dev/examples/Drag-constraints-ref.tsx
@@ -25,9 +25,10 @@ export const App = () => {
     return (
         <div ref={ref} style={container}>
             <motion.div
-                drag
+                //drag
                 //dragElastic
                 dragConstraints={ref}
+                onMeasureDragConstraints={(v) => console.log(v)}
                 whileTap={{ scale: 0.95 }}
                 whileHover={{ scale: 1.1 }}
                 style={child}

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -653,6 +653,11 @@ export class VisualElementDragControls {
                 cursorProgress: prevSnapshot.cursorProgress,
             })
 
+        if (expectsResolvedDragConstraints(this.props)) {
+            this.prepareBoundingBox()
+            this.resolveDragConstraints()
+        }
+
         /**
          * Return a function that will teardown the drag gesture
          */
@@ -696,4 +701,11 @@ function getCurrentDirection(
     }
 
     return direction
+}
+
+export function expectsResolvedDragConstraints({
+    dragConstraints,
+    onMeasureDragConstraints,
+}: MotionProps) {
+    return isRefObject(dragConstraints) && !!onMeasureDragConstraints
 }

--- a/src/motion/features/drag.ts
+++ b/src/motion/features/drag.ts
@@ -2,6 +2,7 @@ import { MotionProps } from "../types"
 import { useDrag } from "../../gestures/drag/use-drag"
 import { makeRenderlessComponent } from "../utils/make-renderless-component"
 import { FeatureProps, MotionFeature } from "./types"
+import { expectsResolvedDragConstraints } from "../../gestures/drag/VisualElementDragControls"
 
 const Component = makeRenderlessComponent(
     ({ visualElement, ...props }: FeatureProps) => {
@@ -14,6 +15,7 @@ const Component = makeRenderlessComponent(
  */
 export const Drag: MotionFeature = {
     key: "drag",
-    shouldRender: (props: MotionProps) => !!props.drag,
+    shouldRender: (props: MotionProps) =>
+        !!props.drag || expectsResolvedDragConstraints(props),
     getComponent: () => Component,
 }


### PR DESCRIPTION
This PR ensures that if drag constraints are set as a ref, and are actively expected to be provided from onMeasureDragConstraints, that we resolve these on mount