### PR TITLE
Adding animate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.0] 2020-10-08
+
+### Added
+
+-   `animate` function for low-level single `MotionValue` or arbitrary value animations.
+
 ## [2.7.8] 2020-10-07
 
 ### Changed

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -26,6 +26,12 @@ import { SVGAttributes } from 'react';
 // @internal (undocumented)
 export function addScaleCorrection(correctors: ScaleCorrectionDefinitionMap): void;
 
+// Warning: (ae-forgotten-export) The symbol "AnimationOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "PlaybackControls" needs to be exported by the entry point index.d.ts
+// 
+// @public
+export function animate<V>(from: MotionValue<V> | V, to: V | V[], transition?: AnimationOptions_2<V>): PlaybackControls;
+
 // @public (undocumented)
 export const AnimateLayoutFeature: MotionFeature;
 

--- a/dev/examples/Animation-animate.tsx
+++ b/dev/examples/Animation-animate.tsx
@@ -1,0 +1,40 @@
+import * as React from "react"
+import { useEffect, useState } from "react"
+import { motion, useMotionValue, animate } from "@framer"
+
+/**
+ * An example of the tween transition type
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "white",
+}
+
+export const App = () => {
+    const x = useMotionValue(0)
+    const [target, setTarget] = useState(0)
+    const transition = {
+        type: "spring",
+        duration: 0.4,
+        dampingRatio: 0.4,
+    }
+
+    useEffect(() => {
+        const controls = animate(x, target, {
+            ...transition,
+            onUpdate: (v) => console.log(v),
+            onComplete: () => console.log("complete"),
+        })
+
+        return () => controls.stop()
+    })
+
+    return (
+        <motion.div
+            style={{ x, ...style }}
+            onTap={() => setTarget(target + 100)}
+        />
+    )
+}

--- a/src/animation/__tests__/animate.test.tsx
+++ b/src/animation/__tests__/animate.test.tsx
@@ -1,0 +1,85 @@
+import { render } from "../../../jest.setup"
+import * as React from "react"
+import { useEffect } from "react"
+import { motion } from "../.."
+import { animate } from "../animate"
+import { useMotionValue } from "../../value/use-motion-value"
+import { MotionValue } from "../../value"
+
+describe("animate", () => {
+    test("correctly animates MotionValues", async () => {
+        const promise = new Promise<[MotionValue, Element]>((resolve) => {
+            const Component = () => {
+                const x = useMotionValue(0)
+                useEffect(() => {
+                    animate(x, 200, {
+                        duration: 0.1,
+                        onComplete: () => {
+                            resolve([x, element])
+                        },
+                    })
+                }, [])
+                return <motion.div style={{ x }} />
+            }
+
+            const { container, rerender } = render(<Component />)
+            const element = container.firstChild as Element
+            rerender(<Component />)
+        })
+
+        const [value, element] = await promise
+        expect(value.get()).toBe(200)
+        expect(element).toHaveStyle(
+            "transform: translateX(200px) translateZ(0)"
+        )
+    })
+
+    test("correctly animates normal values", async () => {
+        const promise = new Promise<number>((resolve) => {
+            const Component = () => {
+                let latest = 0
+                useEffect(() => {
+                    animate(0, 200, {
+                        duration: 0.1,
+                        onUpdate: (v) => (latest = v),
+                        onComplete: () => {
+                            resolve(latest)
+                        },
+                    })
+                }, [])
+                return null
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(promise).resolves.toBe(200)
+    })
+    test("correctly hydrates keyframes null with current MotionValue", async () => {
+        const promise = new Promise<number[]>((resolve) => {
+            const output: number[] = []
+            const Component = () => {
+                const x = useMotionValue(100)
+                useEffect(() => {
+                    animate(x, [null, 50], {
+                        duration: 0.1,
+                        onComplete: () => {
+                            resolve(output)
+                        },
+                    })
+                }, [])
+                return null
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        const output = await promise
+        const incorrect = output.filter((v) => v < 50)
+        // The default would be to animate from 0 here so if theres no values
+        // less than 50 the keyframes were correctly hydrated
+        expect(incorrect.length).toBe(0)
+    })
+})

--- a/src/animation/animate.ts
+++ b/src/animation/animate.ts
@@ -1,0 +1,65 @@
+import { Transition } from "../types"
+import { motionValue, MotionValue } from "../value"
+import { isMotionValue } from "../value/utils/is-motion-value"
+import { startAnimation } from "./utils/transitions"
+
+interface PlaybackControls {
+    stop: () => void
+}
+
+interface PlaybackLifecycles<V> {
+    onUpdate?: (latest: V) => void
+    onPlay?: () => void
+    onComplete?: () => void
+    onRepeat?: () => void
+    onStop?: () => void
+}
+
+/**
+ * Animate a value or a `MotionValue`.
+ *
+ * Returns `PlaybackControls`, currently a `stop` method.
+ *
+ * ```javascript
+ * const x = useMotionValue(0)
+ *
+ * useEffect(() => {
+ *   const controls = animate(x, 100, {
+ *     type: "spring",
+ *     stiffness: 2000,
+ *     onComplete: v => {}
+ *   })
+ *
+ *   return controls.stop
+ * })
+ * ```
+ */
+export function animate<V>(
+    from: MotionValue<V> | V,
+    to: V | V[],
+    {
+        onStop,
+        onComplete,
+        ...transition
+    }: Transition & PlaybackLifecycles<V> = {},
+    onChange?: (v: V) => void
+): PlaybackControls {
+    const value = isMotionValue(from) ? from : motionValue(from)
+    const unsubscribe = onChange && value.onChange(onChange)
+
+    transition.onStop = () => {
+        unsubscribe?.()
+        onStop?.()
+    }
+
+    transition.onComplete = () => {
+        unsubscribe?.()
+        onComplete?.()
+    }
+
+    startAnimation("", value, to as any, transition)
+
+    return {
+        stop: () => value.stop(),
+    }
+}

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -133,19 +133,9 @@ export function getPopmotionAnimationOptions(
         }
     }
 
-    const transitionOptions = convertTransitionToAnimationOptions(transition)
-
     return {
         ...options,
-        ...transitionOptions,
-        onUpdate: (v: any) => {
-            options.onUpdate(v)
-            transitionOptions.onUpdate?.(v)
-        },
-        onComplete: () => {
-            options.onComplete()
-            transitionOptions.onComplete?.()
-        },
+        ...convertTransitionToAnimationOptions(transition),
     }
 }
 
@@ -192,15 +182,27 @@ function getAnimation(
         return valueTransition.type === "inertia" ||
             valueTransition.type === "decay"
             ? inertia({ ...options, ...valueTransition })
-            : animate(
-                  getPopmotionAnimationOptions(valueTransition, options, key)
-              )
+            : animate({
+                  ...getPopmotionAnimationOptions(
+                      valueTransition,
+                      options,
+                      key
+                  ),
+                  onUpdate: (v: any) => {
+                      options.onUpdate(v)
+                      valueTransition.onUpdate?.(v)
+                  },
+                  onComplete: () => {
+                      options.onComplete()
+                      valueTransition.onComplete?.()
+                  },
+              })
     }
 
     function set(): StopAnimation {
         value.set(target)
         onComplete()
-        transition?.onComplete()
+        valueTransition?.onComplete?.()
         return { stop: () => {} }
     }
 

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -133,9 +133,19 @@ export function getPopmotionAnimationOptions(
         }
     }
 
+    const transitionOptions = convertTransitionToAnimationOptions(transition)
+
     return {
         ...options,
-        ...convertTransitionToAnimationOptions(transition),
+        ...transitionOptions,
+        onUpdate: (v: any) => {
+            options.onUpdate(v)
+            transitionOptions.onUpdate?.(v)
+        },
+        onComplete: () => {
+            options.onComplete()
+            transitionOptions.onComplete?.()
+        },
     }
 }
 
@@ -190,6 +200,7 @@ function getAnimation(
     function set(): StopAnimation {
         value.set(target)
         onComplete()
+        transition?.onComplete()
         return { stop: () => {} }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export {
     animationControls,
 } from "./animation/AnimationControls"
 export { useAnimation } from "./animation/use-animation"
+export { animate } from "./animation/animate"
 export {
     HoverHandlers,
     TapHandlers,


### PR DESCRIPTION
Closes https://github.com/framer/motion/issues/353
Closes https://github.com/framer/motion/issues/218

This PR introduces a headless or extremely low-level animation API with the `animate` function.

It is essentially a skin around the Popmotion `animate` fuction.

It can imperatively animate single values:

```javascript
animate(0, 100, {
  type: "spring",
  duration: 0.8,
  onUpdate: (latest) => console.log(latest)
})

animate("#fff", "#000", {
  ease: "linear",
  onUpdate: (latest) => console.log(latest)
})
```

Or `MotionValue`s:

```javascript
animate(x, 100, type: "spring", duration: 0.8 })

animate(backgroundColor, "#000", { ease: "linear" })
```