### PR TITLE
Reverting matchMedia addListener to legacy for Safari compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.9.0] 2020-10-11
+## [2.9.1] 2020-10-12
+
+### Fixed
+
+-   Reverting `matchMedia` listener to legacy `addListener` to fix in Safari.
+
+## [2.9.0] 2020-10-12
 
 ### Added
 

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -12,7 +12,7 @@ if (typeof window !== "undefined") {
         const setReducedMotionPreferences = () =>
             prefersReducedMotion.set(motionMediaQuery.matches)
 
-        motionMediaQuery.addEventListener("change", setReducedMotionPreferences)
+        motionMediaQuery.addListener(setReducedMotionPreferences)
 
         setReducedMotionPreferences()
     } else {


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/805