### PR TITLE
Enable framer magic motion transitions

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -260,6 +260,11 @@ export interface FeatureProps extends MotionProps {
 // @public (undocumented)
 export type ForwardRefComponent<T, P> = ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
+// Warning: (ae-internal-missing-underscore) The name "FramerTreeContext" should be prefixed with an underscore because the declaration is marked as @internal
+// 
+// @internal (undocumented)
+export const FramerTreeContext: import("react").Context<SyncLayoutBatcher | SharedLayoutSyncMethods>;
+
 // @public (undocumented)
 export type GestureHandlers = PanHandlers & TapHandlers & HoverHandlers;
 

--- a/src/components/AnimateSharedLayout/SharedLayoutContext.ts
+++ b/src/components/AnimateSharedLayout/SharedLayoutContext.ts
@@ -101,6 +101,6 @@ export const SharedLayoutContext = createContext<
 /**
  * @internal
  */
-export const FramerTreeContext = createContext<
+export const FramerTreeLayoutContext = createContext<
     SyncLayoutBatcher | SharedLayoutSyncMethods
 >(createBatcher())

--- a/src/components/AnimateSharedLayout/SharedLayoutContext.ts
+++ b/src/components/AnimateSharedLayout/SharedLayoutContext.ts
@@ -97,3 +97,10 @@ export function isSharedLayout(
 export const SharedLayoutContext = createContext<
     SyncLayoutBatcher | SharedLayoutSyncMethods
 >(createBatcher())
+
+/**
+ * @internal
+ */
+export const FramerTreeContext = createContext<
+    SyncLayoutBatcher | SharedLayoutSyncMethods
+>(createBatcher())

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export {
 export {
     SharedLayoutSyncMethods,
     SharedLayoutContext,
+    FramerTreeContext,
     SyncLayoutLifecycles,
     createBatcher,
 } from "./components/AnimateSharedLayout/SharedLayoutContext"

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export {
 export {
     SharedLayoutSyncMethods,
     SharedLayoutContext,
-    FramerTreeContext,
+    FramerTreeLayoutContext,
     SyncLayoutLifecycles,
     createBatcher,
 } from "./components/AnimateSharedLayout/SharedLayoutContext"

--- a/src/motion/features/layout/Measure.tsx
+++ b/src/motion/features/layout/Measure.tsx
@@ -6,12 +6,12 @@ import {
     SharedLayoutSyncMethods,
     isSharedLayout,
     SharedLayoutContext,
-    FramerTreeContext,
+    FramerTreeLayoutContext,
 } from "../../../components/AnimateSharedLayout/SharedLayoutContext"
 
 interface SyncProps extends FeatureProps {
     syncLayout: SharedLayoutSyncMethods | SyncLayoutBatcher
-    framerTreeSync: SharedLayoutSyncMethods | SyncLayoutBatcher
+    framerSyncLayout: SharedLayoutSyncMethods | SyncLayoutBatcher
 }
 
 /**
@@ -22,9 +22,10 @@ class Measure extends React.Component<SyncProps> {
      * If this is a child of a SyncContext, register the VisualElement with it on mount.
      */
     componentDidMount() {
-        const { syncLayout, framerTreeSync, visualElement } = this.props
+        const { syncLayout, framerSyncLayout, visualElement } = this.props
         isSharedLayout(syncLayout) && syncLayout.register(visualElement)
-        isSharedLayout(framerTreeSync) && framerTreeSync.register(visualElement)
+        isSharedLayout(framerSyncLayout) &&
+            framerSyncLayout.register(visualElement)
     }
 
     /**
@@ -65,12 +66,12 @@ class Measure extends React.Component<SyncProps> {
 
 function MeasureContextProvider(props: FeatureProps) {
     const syncLayout = useContext(SharedLayoutContext)
-    const framerTreeSync = useContext(FramerTreeContext)
+    const framerSyncLayout = useContext(FramerTreeLayoutContext)
     return (
         <Measure
             {...props}
             syncLayout={syncLayout}
-            framerTreeSync={framerTreeSync}
+            framerSyncLayout={framerSyncLayout}
         />
     )
 }

--- a/src/motion/features/layout/Measure.tsx
+++ b/src/motion/features/layout/Measure.tsx
@@ -6,10 +6,12 @@ import {
     SharedLayoutSyncMethods,
     isSharedLayout,
     SharedLayoutContext,
+    FramerTreeContext,
 } from "../../../components/AnimateSharedLayout/SharedLayoutContext"
 
 interface SyncProps extends FeatureProps {
     syncLayout: SharedLayoutSyncMethods | SyncLayoutBatcher
+    framerTreeSync: SharedLayoutSyncMethods | SyncLayoutBatcher
 }
 
 /**
@@ -20,8 +22,9 @@ class Measure extends React.Component<SyncProps> {
      * If this is a child of a SyncContext, register the VisualElement with it on mount.
      */
     componentDidMount() {
-        const { syncLayout, visualElement } = this.props
+        const { syncLayout, framerTreeSync, visualElement } = this.props
         isSharedLayout(syncLayout) && syncLayout.register(visualElement)
+        isSharedLayout(framerTreeSync) && framerTreeSync.register(visualElement)
     }
 
     /**
@@ -62,7 +65,14 @@ class Measure extends React.Component<SyncProps> {
 
 function MeasureContextProvider(props: FeatureProps) {
     const syncLayout = useContext(SharedLayoutContext)
-    return <Measure {...props} syncLayout={syncLayout} />
+    const framerTreeSync = useContext(FramerTreeContext)
+    return (
+        <Measure
+            {...props}
+            syncLayout={syncLayout}
+            framerTreeSync={framerTreeSync}
+        />
+    )
 }
 
 export const MeasureLayout: MotionFeature = {

--- a/src/motion/features/layout/use-snapshot-on-unmount.ts
+++ b/src/motion/features/layout/use-snapshot-on-unmount.ts
@@ -2,17 +2,23 @@ import { VisualElement } from "../../../render/VisualElement"
 import { useContext } from "react"
 import {
     SharedLayoutContext,
+    FramerTreeContext,
     isSharedLayout,
 } from "../../../components/AnimateSharedLayout/SharedLayoutContext"
 import { useIsomorphicLayoutEffect } from "../../../utils/use-isomorphic-effect"
 
 export function useSnapshotOnUnmount(visualElement: VisualElement) {
     const syncLayout = useContext(SharedLayoutContext)
+    const framerTreeSync = useContext(FramerTreeContext)
 
     useIsomorphicLayoutEffect(
         () => () => {
             if (isSharedLayout(syncLayout)) {
                 syncLayout.remove(visualElement as any)
+            }
+
+            if (isSharedLayout(framerTreeSync)) {
+                framerTreeSync.remove(visualElement as any)
             }
         },
         []

--- a/src/motion/features/layout/use-snapshot-on-unmount.ts
+++ b/src/motion/features/layout/use-snapshot-on-unmount.ts
@@ -2,14 +2,14 @@ import { VisualElement } from "../../../render/VisualElement"
 import { useContext } from "react"
 import {
     SharedLayoutContext,
-    FramerTreeContext,
+    FramerTreeLayoutContext,
     isSharedLayout,
 } from "../../../components/AnimateSharedLayout/SharedLayoutContext"
 import { useIsomorphicLayoutEffect } from "../../../utils/use-isomorphic-effect"
 
 export function useSnapshotOnUnmount(visualElement: VisualElement) {
     const syncLayout = useContext(SharedLayoutContext)
-    const framerTreeSync = useContext(FramerTreeContext)
+    const framerSyncLayout = useContext(FramerTreeLayoutContext)
 
     useIsomorphicLayoutEffect(
         () => () => {
@@ -17,8 +17,8 @@ export function useSnapshotOnUnmount(visualElement: VisualElement) {
                 syncLayout.remove(visualElement as any)
             }
 
-            if (isSharedLayout(framerTreeSync)) {
-                framerTreeSync.remove(visualElement as any)
+            if (isSharedLayout(framerSyncLayout)) {
+                framerSyncLayout.remove(visualElement as any)
             }
         },
         []


### PR DESCRIPTION
- Add's a duplicate `SharedLayoutContext` called `FramerTreeContext`. This enables `Measure` to add the VisualElement to both the existing SharedLayoutContext (created as a batcher, or by any AnimateSharedLayout), but now also to `FramerTreeContext` which ensures that any motion element anywhere in the Framer tree still gets added to SharedLayoutTree's children map, so that they are flushed animate callbacks when there is a magic motion transition.