### PR TITLE
Reset only translate and scale when drag start

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -345,6 +345,7 @@ export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement>
     rebaseTargetBox(force?: boolean, box?: AxisBox2D): void;
     removeValue(key: string): void;
     render(): void;
+    resetSomeTransform(props: TransformKey[]): void;
     resetTransform(): void;
     setAxisTarget(axis: "x" | "y", min: number, max: number): void;
     // (undocumented)
@@ -363,8 +364,10 @@ export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement>
     style: ResolvedValues;
     targetBox: AxisBox2D;
     protected targetBoxFinal: AxisBox2D;
-    protected transform: ResolvedValues;
-    protected transformKeys: string[];
+    // Warning: (ae-forgotten-export) The symbol "Transform" needs to be exported by the entry point index.d.ts
+    protected transform: Transform;
+    // Warning: (ae-forgotten-export) The symbol "TransformKey" needs to be exported by the entry point index.d.ts
+    protected transformKeys: TransformKey[];
     // Warning: (ae-forgotten-export) The symbol "TransformOrigin" needs to be exported by the entry point index.d.ts
     protected transformOrigin: TransformOrigin;
     treeScale: Point2D;

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -273,7 +273,13 @@ export class VisualElementDragControls {
     prepareBoundingBox() {
         const element = this.visualElement.getInstance()
         const transform = element.style.transform
-        this.visualElement.resetTransform()
+        this.visualElement.resetSomeTransform([
+            "x",
+            "y",
+            "scale",
+            "scaleX",
+            "scaleY",
+        ])
         this.visualElement.measureLayout()
         element.style.transform = transform
         this.visualElement.rebaseTargetBox(

--- a/src/render/dom/types.ts
+++ b/src/render/dom/types.ts
@@ -11,6 +11,7 @@ import { MotionProps, MakeMotion } from "../../motion/types"
 import { TransformPoint2D } from "../../types/geometry"
 import { HTMLElements, SVGElements } from "./utils/supported-elements"
 import { VisualElementConfig } from "../VisualElement/types"
+import { TransformProperties } from "../../motion/types"
 
 /**
  * Configuration for the HTML and SVGVisualElement renderers.
@@ -60,6 +61,10 @@ export interface TransformOrigin {
     originY?: number | string
     originZ?: number | string
 }
+
+export type Transform = Omit<TransformProperties, keyof TransformOrigin>
+
+export type TransformKey = keyof Transform
 
 /**
  * Measured dimensions of an SVG component.

--- a/src/render/dom/utils/__tests__/build-html-styles.test.ts
+++ b/src/render/dom/utils/__tests__/build-html-styles.test.ts
@@ -1,6 +1,11 @@
 import "../../../../../jest.setup"
 import { buildHTMLStyles } from "../build-html-styles"
-import { TransformOrigin, DOMVisualElementConfig } from "../../types"
+import {
+    DOMVisualElementConfig,
+    TransformOrigin,
+    Transform,
+    TransformKey,
+} from "../../types"
 import { BoxDelta, Point2D, AxisBox2D } from "../../../../types/geometry"
 import { ResolvedValues } from "../../../VisualElement/types"
 
@@ -214,9 +219,9 @@ describe("buildHTMLStyles", () => {
 interface BuildProps {
     style: ResolvedValues
     vars: ResolvedValues
-    transform: ResolvedValues
+    transform: Transform
     transformOrigin: TransformOrigin
-    transformKeys: string[]
+    transformKeys: TransformKey[]
     config: DOMVisualElementConfig
     isLayoutProjectionEnabled: boolean
     delta?: BoxDelta

--- a/src/render/dom/utils/build-html-styles.ts
+++ b/src/render/dom/utils/build-html-styles.ts
@@ -1,5 +1,10 @@
 import { ResolvedValues } from "../../VisualElement/types"
-import { DOMVisualElementConfig, TransformOrigin } from "../types"
+import {
+    DOMVisualElementConfig,
+    TransformOrigin,
+    Transform,
+    TransformKey,
+} from "../types"
 import { getDefaultValueType, getValueAsType } from "./value-types"
 import { isTransformProp, isTransformOriginProp } from "./transform"
 import {
@@ -38,9 +43,9 @@ export function buildHTMLStyles(
     latest: ResolvedValues,
     style: ResolvedValues,
     vars: ResolvedValues,
-    transform: ResolvedValues,
+    transform: Transform,
     transformOrigin: TransformOrigin,
-    transformKeys: string[],
+    transformKeys: TransformKey[],
     {
         enableHardwareAcceleration,
         transformTemplate,
@@ -80,7 +85,7 @@ export function buildHTMLStyles(
             // If this is a transform, flag and enable further transform processing
             hasTransform = true
             transform[key] = valueAsType
-            transformKeys.push(key)
+            transformKeys.push(key as TransformKey)
 
             if (!transformIsNone) continue
 

--- a/src/render/dom/utils/build-svg-attrs.ts
+++ b/src/render/dom/utils/build-svg-attrs.ts
@@ -1,4 +1,10 @@
-import { Dimensions, TransformOrigin, DOMVisualElementConfig } from "../types"
+import {
+    Dimensions,
+    TransformOrigin,
+    DOMVisualElementConfig,
+    Transform,
+    TransformKey,
+} from "../types"
 import { ResolvedValues } from "../../VisualElement/types"
 import { calcSVGTransformOrigin } from "./svg-transform-origin"
 import { buildSVGPath } from "./build-svg-path"
@@ -25,9 +31,9 @@ export function buildSVGAttrs(
     style: ResolvedValues,
     vars: ResolvedValues,
     attrs: ResolvedValues,
-    transform: ResolvedValues,
+    transform: Transform,
     transformOrigin: TransformOrigin,
-    transformKeys: string[],
+    transformKeys: TransformKey[],
     config: DOMVisualElementConfig,
     dimensions: Dimensions,
     totalPathLength: number,

--- a/src/render/dom/utils/build-transform.ts
+++ b/src/render/dom/utils/build-transform.ts
@@ -1,8 +1,7 @@
 import { TransformTemplate } from "../../../motion/types"
-import { ResolvedValues } from "../../VisualElement/types"
 import { sortTransformProps, boxDistortingKeys } from "./transform"
 import { Point2D, BoxDelta } from "../../../types/geometry"
-import { TransformOrigin } from "../types"
+import { TransformOrigin, Transform, TransformKey } from "../types"
 import { delta } from "../../../utils/geometry"
 
 const translateAlias: { [key: string]: string } = {
@@ -19,8 +18,8 @@ const translateAlias: { [key: string]: string } = {
  * providing a transformTemplate function.
  */
 export function buildTransform(
-    transform: ResolvedValues,
-    transformKeys: string[],
+    transform: Transform,
+    transformKeys: TransformKey[],
     transformTemplate: TransformTemplate | undefined,
     transformIsDefault: boolean,
     enableHardwareAcceleration = true,
@@ -114,8 +113,8 @@ export function buildLayoutProjectionTransformOrigin({ x, y }: BoxDelta) {
  * (rotate and skew)
  */
 export function buildBoxDistortingTransforms(
-    transform: ResolvedValues,
-    transformKeys: string[]
+    transform: Transform,
+    transformKeys: TransformKey[]
 ) {
     let transformString = ""
 


### PR DESCRIPTION
Fixes #833 (and some type improvement around `HTMLVisualElement.transform`)

I changed to reset only translate and scale instead of whole transform when drag starts.
Translate and scale are recalculated using delta after drag starts, but rotate and skew are not recalculated so there is no need to be reset. And if they are reset, the size of the element used for delta value is wrongly measured.



