### PR TITLE
Improving start-up performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 -   Correctly applying `transform` on SVG elements.
+-   Lazy-initialising viewport scroll, VisualElement.axisProgress, and reduced motion `MotionValue`s, for increased startup performance.
 
 ## [2.9.5] 2020-11-16
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -295,10 +295,6 @@ export type HTMLMotionProps<TagName extends keyof ReactHTML> = HTMLAttributesWit
 export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement> extends VisualElement<E> {
     // (undocumented)
     addValue(key: string, value: MotionValue): void;
-    // Warning: (ae-forgotten-export) The symbol "MotionPoint" needs to be exported by the entry point index.d.ts
-    // 
-    // (undocumented)
-    axisProgress: MotionPoint;
     box: AxisBox2D;
     build(): void;
     clean(): void;
@@ -313,6 +309,10 @@ export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement>
     deltaTransform: string;
     // (undocumented)
     enableLayoutProjection(): void;
+    // Warning: (ae-forgotten-export) The symbol "MotionPoint" needs to be exported by the entry point index.d.ts
+    // 
+    // (undocumented)
+    getAxisProgress(): MotionPoint;
     getBoundingBox(): AxisBox2D;
     // (undocumented)
     getBoundingBoxWithoutTransforms(): AxisBox2D;

--- a/dev/examples/MotionConfig-isStatic.tsx
+++ b/dev/examples/MotionConfig-isStatic.tsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+import { motion, MotionConfig } from "@framer"
+
+/**
+ * An example of a motion tree set to static mode, like on the Framer canvas
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "white",
+    x: 30,
+    borderRadius: 20,
+}
+
+export const App = () => {
+    return (
+        <MotionConfig isStatic>
+            <motion.div
+                animate={{
+                    width: [null, 50, 200, 100],
+                }}
+                transition={{
+                    duration: 2,
+                    easings: ["circOut", "circOut", "circOut"],
+                    times: [0, 0.1, 0.9, 1],
+                }}
+                style={style}
+            />
+        </MotionConfig>
+    )
+}

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -156,7 +156,7 @@ class Animate extends React.Component<AnimateProps> {
 
         const { visualElement } = this.props
         const frameTarget = this.frameTarget[axis]
-        const layoutProgress = visualElement.axisProgress[axis]
+        const layoutProgress = visualElement.getAxisProgress()[axis]
 
         /**
          * Set layout progress back to 0. We set it twice to hard-reset any velocity that might

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -408,7 +408,7 @@ export class HTMLVisualElement<
     }
 
     rebaseTargetBox(force = false, box: AxisBox2D = this.box) {
-        const { x, y } = this.axisProgress
+        const { x, y } = this.getAxisProgress()
         const shouldRebase =
             this.box &&
             !this.isTargetBoxLocked &&
@@ -484,19 +484,23 @@ export class HTMLVisualElement<
         this.rootParent.scheduleUpdateLayoutDelta()
     }
 
-    /**
-     *
-     */
-    axisProgress: MotionPoint = {
-        x: motionValue(0),
-        y: motionValue(0),
+    private axisProgress?: MotionPoint
+    getAxisProgress(): MotionPoint {
+        if (!this.axisProgress) {
+            this.axisProgress = {
+                x: motionValue(0),
+                y: motionValue(0),
+            }
+        }
+
+        return this.axisProgress as MotionPoint
     }
 
     /**
      *
      */
     startLayoutAxisAnimation(axis: "x" | "y", transition: Transition) {
-        const progress = this.axisProgress[axis]
+        const progress = this.getAxisProgress()[axis]
 
         const { min, max } = this.targetBox[axis]
         const length = max - min
@@ -510,7 +514,7 @@ export class HTMLVisualElement<
     }
 
     stopLayoutAnimation() {
-        eachAxis((axis) => this.axisProgress[axis].stop())
+        eachAxis((axis) => this.getAxisProgress()[axis].stop())
     }
 
     updateLayoutDelta = () => {

--- a/src/utils/use-reduced-motion.ts
+++ b/src/utils/use-reduced-motion.ts
@@ -1,11 +1,15 @@
 import { useState } from "react"
-import { motionValue } from "../value"
+import { motionValue, MotionValue } from "../value"
 import { useOnChange } from "../value/use-on-change"
 
 // Does this device prefer reduced motion? Returns `null` server-side.
-export const prefersReducedMotion = motionValue<boolean | null>(null)
+let prefersReducedMotion: MotionValue<boolean | null>
 
-if (typeof window !== "undefined") {
+function initPrefersReducedMotion() {
+    prefersReducedMotion = motionValue(null)
+
+    if (typeof window === "undefined") return
+
     if (window.matchMedia) {
         const motionMediaQuery = window.matchMedia("(prefers-reduced-motion)")
 
@@ -47,6 +51,11 @@ if (typeof window !== "undefined") {
  * @public
  */
 export function useReducedMotion() {
+    /**
+     * Lazy initialisation of prefersReducedMotion
+     */
+    !prefersReducedMotion && initPrefersReducedMotion()
+
     const [shouldReduceMotion, setShouldReduceMotion] = useState(
         prefersReducedMotion.get()
     )

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -104,7 +104,7 @@ export class MotionValue<V = any> {
      * @internal
      */
     constructor(init: V) {
-        this.set(init, false)
+        this.current = init
         this.canTrackVelocity = isFloat(this.current)
     }
 
@@ -340,7 +340,7 @@ export class MotionValue<V = any> {
     start(animation: StartAnimation) {
         this.stop()
 
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
             this.stopAnimation = animation(resolve)
         }).then(() => this.clearAnimation())
     }

--- a/src/value/scroll/use-viewport-scroll.ts
+++ b/src/value/scroll/use-viewport-scroll.ts
@@ -6,7 +6,7 @@ import {
 import { addDomEvent } from "../../events/use-dom-event"
 import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
 
-const viewportScrollValues = createScrollMotionValues()
+let viewportScrollValues: ScrollMotionValues
 
 function getViewportScrollOffsets() {
     return {
@@ -68,6 +68,13 @@ function addEventListeners() {
  * @public
  */
 export function useViewportScroll(): ScrollMotionValues {
+    /**
+     * Lazy-initialise the viewport scroll values
+     */
+    if (!viewportScrollValues) {
+        viewportScrollValues = createScrollMotionValues()
+    }
+
     useIsomorphicLayoutEffect(() => {
         !hasListeners && addEventListeners()
     }, [])


### PR DESCRIPTION
Following the discovery of canvas work from MotionValue initialisation, this PR:

1. Lazy-initialises any MotionValue that was previously being created on page load
2. Directly applies the init value of a `MotionValue` to `current` rather than running the more expensive `updateAndNotify` (which also schedules a velocity check for the following frame)