### PR TITLE
Layout projection improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   Correctly applying `transform` on SVG elements.
 -   Lazy-initialising viewport scroll, VisualElement.axisProgress, and reduced motion `MotionValue`s, for increased startup performance.
+-   Improved measurement scheduling for `drag` components and nested `AnimateSharedLayout` trees.
+-   Robust calculation of `treeScale`.
 
 ## [2.9.5] 2020-11-16
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -59,6 +59,8 @@ export class AnimateSharedLayout extends React.Component<SharedLayoutProps> {
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(): void;
+    // (undocumented)
+    static contextType: React.Context<import("../../motion/context/MotionContext").MotionContextProps>;
     // Warning: (ae-forgotten-export) The symbol "LayoutStack" needs to be exported by the entry point index.d.ts
     getStack(id?: string): LayoutStack | undefined;
     // (undocumented)
@@ -385,6 +387,8 @@ export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement>
     updateTransformDeltas(): void;
     vars: ResolvedValues;
     viewportScroll: Point2D;
+    // (undocumented)
+    withoutTransform(callback: () => void): void;
 }
 
 // @public
@@ -756,6 +760,8 @@ export interface SyncLayoutLifecycles {
     layoutReady: (child: HTMLVisualElement) => void;
     // (undocumented)
     measureLayout: (child: HTMLVisualElement) => void;
+    // (undocumented)
+    parent?: HTMLVisualElement;
 }
 
 // @public (undocumented)

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -9,11 +9,14 @@ import {
     SyncLayoutLifecycles,
     SharedLayoutContext,
 } from "./SharedLayoutContext"
+import { MotionContext } from "../../motion/context/MotionContext"
 
 /**
  * @public
  */
 export class AnimateSharedLayout extends React.Component<SharedLayoutProps> {
+    static contextType = MotionContext
+
     /**
      * A list of all the children in the shared layout
      */
@@ -122,6 +125,7 @@ export class AnimateSharedLayout extends React.Component<SharedLayoutProps> {
                     createAnimation(child, this.getStack(layoutId))
                 )
             },
+            parent: this.context.visualElement,
         }
 
         /**

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -276,14 +276,13 @@ export class VisualElementDragControls {
      * Ensure the component's layout and target bounding boxes are up-to-date.
      */
     prepareBoundingBox() {
-        const element = this.visualElement.getInstance()
-        const transform = element.style.transform
-        this.visualElement.resetTransform()
-        this.visualElement.measureLayout()
-        element.style.transform = transform
-        this.visualElement.rebaseTargetBox(
+        const { visualElement } = this
+        visualElement.withoutTransform(() => {
+            visualElement.measureLayout()
+        })
+        visualElement.rebaseTargetBox(
             true,
-            this.visualElement.getBoundingBoxWithoutTransforms()
+            visualElement.getBoundingBoxWithoutTransforms()
         )
     }
 

--- a/src/motion/context/MotionContext.ts
+++ b/src/motion/context/MotionContext.ts
@@ -12,7 +12,7 @@ export interface VariantContextProps {
     exit?: VariantLabels
 }
 
-interface MotionContextProps {
+export interface MotionContextProps {
     visualElement?: VisualElement
     variantContext: VariantContextProps
 }

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -16,10 +16,7 @@ import {
     applyBoxTransforms,
     removeBoxTransforms,
 } from "../../utils/geometry/delta-apply"
-import {
-    updateBoxDelta,
-    updateTreeScale,
-} from "../../utils/geometry/delta-calc"
+import { updateBoxDelta } from "../../utils/geometry/delta-calc"
 import { TargetAndTransition, Transition } from "../../types"
 import { eachAxis } from "../../utils/each-axis"
 import { motionValue, MotionValue } from "../../value"
@@ -286,7 +283,6 @@ export class HTMLVisualElement<
      * This is considered mutable to avoid object creation on each frame.
      */
     treeScale: Point2D = { x: 1, y: 1 }
-    private prevTreeScale: Point2D = { x: 1, y: 1 }
 
     /**
      * The delta between the boxCorrected and the desired
@@ -552,26 +548,14 @@ export class HTMLVisualElement<
          */
         resetBox(this.boxCorrected, this.box)
 
-        /**
-         * If this component has a parent, update this treeScale by incorporating the parent's
-         * delta into its treeScale.
-         */
-        if (this.parent) {
-            this.prevTreeScale.x = this.treeScale.x
-            this.prevTreeScale.y = this.treeScale.y
-
-            updateTreeScale(
-                this.treeScale,
-                (this.parent as any).treeScale,
-                (this.parent as any).delta
-            )
-        }
+        const prevTreeScaleX = this.treeScale.x
+        const prevTreeScaleY = this.treeScale.y
 
         /**
          * Apply all the parent deltas to this box to produce the corrected box. This
          * is the layout box, as it will appear on screen as a result of the transforms of its parents.
          */
-        applyTreeDeltas(this.boxCorrected, this.treePath as any)
+        applyTreeDeltas(this.boxCorrected, this.treeScale, this.treePath as any)
 
         /**
          * Update the delta between the corrected box and the target box before user-set transforms were applied.
@@ -607,8 +591,8 @@ export class HTMLVisualElement<
         if (
             deltaTransform !== this.deltaTransform ||
             // Also compare calculated treeScale, for values that rely on only this for scale correction.
-            this.prevTreeScale.x !== this.treeScale.x ||
-            this.prevTreeScale.y !== this.treeScale.y
+            prevTreeScaleX !== this.treeScale.x ||
+            prevTreeScaleY !== this.treeScale.y
         ) {
             this.scheduleRender()
         }

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -529,6 +529,18 @@ export class HTMLVisualElement<
         this.children.forEach(fireUpdateLayoutDelta)
     }
 
+    withoutTransform(callback: () => void) {
+        this.resetTransform()
+
+        if (this.parent) {
+            ;(this.parent as any).withoutTransform(callback)
+        } else {
+            callback()
+        }
+
+        this.element.style.transform = this.style.transform as string
+    }
+
     /**
      * Update the layout deltas to reflect the relative positions of the layout
      * and the desired target box

--- a/src/utils/geometry/__tests__/delta-apply.test.ts
+++ b/src/utils/geometry/__tests__/delta-apply.test.ts
@@ -196,18 +196,20 @@ describe("applyTreeDeltas", () => {
         }
 
         const delta = {
-            x: { translate: 100, scale: 2, origin: 0.5, originPoint: 150 },
+            x: { translate: 100, scale: 4, origin: 0.5, originPoint: 150 },
             y: { translate: -100, scale: 0.5, origin: 0.5, originPoint: 350 },
         }
 
         const element = new HTMLVisualElement()
         element.delta = delta
 
-        applyTreeDeltas(box, [element, element])
+        const treeScale = { x: 1, y: 1 }
+        applyTreeDeltas(box, treeScale, [element, element])
 
         expect(box).toEqual({
-            x: { min: 250, max: 650 },
+            x: { min: -150, max: 1450 },
             y: { min: 187.5, max: 212.5 },
         })
+        expect(treeScale).toEqual({ x: 16, y: 0.25 })
     })
 })

--- a/src/utils/geometry/__tests__/delta-calc.test.ts
+++ b/src/utils/geometry/__tests__/delta-calc.test.ts
@@ -1,10 +1,4 @@
-import {
-    isNear,
-    calcOrigin,
-    updateAxisDelta,
-    updateTreeScale,
-} from "../delta-calc"
-import { HTMLVisualElement } from "../../../render/dom/HTMLVisualElement"
+import { isNear, calcOrigin, updateAxisDelta } from "../delta-calc"
 
 describe("isNear", () => {
     test("Correctly indicate when the provided value is within maxDistance of the provided target", () => {
@@ -60,21 +54,5 @@ describe("updateAxisDelta", () => {
             scale: 2,
             translate: 300,
         })
-    })
-})
-
-describe("updateTreeScale", () => {
-    test("Correctly updates a treeScale object by incorporating a parent delta into its scale", () => {
-        const treeScale = { x: 1, y: 1 }
-        const element = new HTMLVisualElement()
-        element.delta = {
-            x: { scale: 2, translate: 0, origin: 0, originPoint: 0 },
-            y: { scale: 0.5, translate: 0, origin: 0, originPoint: 0 },
-        }
-        element.treeScale = { x: 2, y: 2 }
-
-        updateTreeScale(treeScale, element.treeScale, element.delta)
-
-        expect(treeScale).toEqual({ x: 4, y: 1 })
     })
 })

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -225,11 +225,17 @@ export function applyTreeDeltas(
     const treeLength = treePath.length
     if (!treeLength) return
 
+    // Reset the treeScale
     treeScale.x = treeScale.y = 1
+
     for (let i = 0; i < treeLength; i++) {
         const { delta } = treePath[i]
+
+        // Incoporate each ancestor's scale into a culmulative treeScale for this component
         treeScale.x *= delta.x.scale
         treeScale.y *= delta.y.scale
+
+        // Apply each ancestor's calculated delta into this component's recorded layout box
         applyBoxDelta(box, delta)
     }
 }

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -1,4 +1,4 @@
-import { Axis, AxisBox2D, BoxDelta } from "../../types/geometry"
+import { Axis, AxisBox2D, BoxDelta, Point2D } from "../../types/geometry"
 import { mix } from "popmotion"
 import { HTMLVisualElement } from "../../render/dom/HTMLVisualElement"
 import { ResolvedValues } from "../../render/VisualElement/types"
@@ -217,9 +217,19 @@ export function removeBoxTransforms(
  *
  * This is the final nested loop within HTMLVisualElement.updateLayoutDelta
  */
-export function applyTreeDeltas(box: AxisBox2D, treePath: HTMLVisualElement[]) {
+export function applyTreeDeltas(
+    box: AxisBox2D,
+    treeScale: Point2D,
+    treePath: HTMLVisualElement[]
+) {
     const treeLength = treePath.length
+    if (!treeLength) return
+
+    treeScale.x = treeScale.y = 1
     for (let i = 0; i < treeLength; i++) {
-        applyBoxDelta(box, treePath[i].delta)
+        const { delta } = treePath[i]
+        treeScale.x *= delta.x.scale
+        treeScale.y *= delta.y.scale
+        applyBoxDelta(box, delta)
     }
 }

--- a/src/utils/geometry/delta-calc.ts
+++ b/src/utils/geometry/delta-calc.ts
@@ -1,10 +1,4 @@
-import {
-    Axis,
-    AxisDelta,
-    BoxDelta,
-    AxisBox2D,
-    Point2D,
-} from "../../types/geometry"
+import { Axis, AxisDelta, BoxDelta, AxisBox2D } from "../../types/geometry"
 import { mix, progress, clamp, distance } from "popmotion"
 
 const clampProgress = (v: number) => clamp(0, 1, v)
@@ -75,16 +69,4 @@ export function updateBoxDelta(
 ): void {
     updateAxisDelta(delta.x, source.x, target.x, origin)
     updateAxisDelta(delta.y, source.y, target.y, origin)
-}
-
-/**
- * Update the treeScale by incorporating the parent's latest scale into its treeScale.
- */
-export function updateTreeScale(
-    treeScale: Point2D,
-    parentTreeScale: Point2D,
-    parentDelta: BoxDelta
-) {
-    treeScale.x = parentTreeScale.x * parentDelta.x.scale
-    treeScale.y = parentTreeScale.y * parentDelta.y.scale
 }


### PR DESCRIPTION
This PR makes two improvements to layout projection:

## `withoutTransform`

This is a new method on `VisualElement` that will synchronously run a callback **after** unsetting the `transform` of an element and all of its ancestors and **before** restoring it.

This allows an element to be cleanly measured without the transform of any layout projected parent.

It's used here by `AnimateSharedLayout` to ensure a tree is measured only when its ancestors are reset, for instance those in another ASL tree or `LayoutTree` tree.

It's also used by `drag` components to ensure the current transform of a parent isn't taken into account for the layout measurement. This is currently an experimental feature but it means we can do things like resize a container as we drag an element out of it.

## Tree scale

This was currently being calculated by keeping a cumulative `treeScale` during `updateLayoutDeltas`. This has been changed to calculate a new tree scale from all of a component's ancestors in case the immediate parent isn't being projected.

