### PR TITLE
Adding support for SVG fallback

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -318,6 +318,8 @@ export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement>
     getBoundingBoxWithoutTransforms(): AxisBox2D;
     getComputedStyle(): CSSStyleDeclaration;
     // (undocumented)
+    getFallbackValue(key: string, props: MotionProps): any;
+    // (undocumented)
     hide(): void;
     isLayoutProjectionEnabled: boolean;
     // (undocumented)

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -313,12 +313,12 @@ export class HTMLVisualElement<E extends HTMLElement | SVGElement = HTMLElement>
     // 
     // (undocumented)
     getAxisProgress(): MotionPoint;
+    // (undocumented)
+    getBaseValue(key: string, props: MotionProps): any;
     getBoundingBox(): AxisBox2D;
     // (undocumented)
     getBoundingBoxWithoutTransforms(): AxisBox2D;
     getComputedStyle(): CSSStyleDeclaration;
-    // (undocumented)
-    getFallbackValue(key: string, props: MotionProps): any;
     // (undocumented)
     hide(): void;
     isLayoutProjectionEnabled: boolean;

--- a/src/render/VisualElement/index.ts
+++ b/src/render/VisualElement/index.ts
@@ -219,7 +219,7 @@ export abstract class VisualElement<E = any> {
         parseDOMValues?: boolean
     ): TargetAndTransition
 
-    getFallbackValue(key: string, _props: MotionProps) {
+    getBaseValue(key: string, _props: MotionProps) {
         return this.baseTarget[key]
     }
 

--- a/src/render/VisualElement/index.ts
+++ b/src/render/VisualElement/index.ts
@@ -9,6 +9,7 @@ import { Snapshot } from "../../components/AnimateSharedLayout/stack"
 import { Target, TargetAndTransition, Variants } from "../../types"
 import { startAnimation } from "../../animation/utils/transitions"
 import { AnimationState } from "./utils/animation-state"
+import { MotionProps } from "../../motion/types"
 
 type Subscriptions = Map<string, () => void>
 
@@ -217,6 +218,10 @@ export abstract class VisualElement<E = any> {
         targetAndTransition: TargetAndTransition,
         parseDOMValues?: boolean
     ): TargetAndTransition
+
+    getFallbackValue(key: string, _props: MotionProps) {
+        return this.baseTarget[key]
+    }
 
     // Set a single `latest` value
     private setSingleStaticValue(key: string, value: string | number) {

--- a/src/render/VisualElement/utils/__tests__/animation-state.test.ts
+++ b/src/render/VisualElement/utils/__tests__/animation-state.test.ts
@@ -25,11 +25,11 @@ class StateVisualElement extends VisualElement {
         return { x: { min: 0, max: 0 }, y: { min: 0, max: 0 } }
     }
 
-    getFallbackValue(key: string, props: MotionProps) {
+    getBaseValue(key: string, props: MotionProps) {
         const style = props.style?.[key]
         return style !== undefined && !isMotionValue(style)
             ? style
-            : super.getFallbackValue(key, props)
+            : super.getBaseValue(key, props)
     }
 
     readNativeValue(key: string) {

--- a/src/render/VisualElement/utils/__tests__/animation-state.test.ts
+++ b/src/render/VisualElement/utils/__tests__/animation-state.test.ts
@@ -1,4 +1,6 @@
 import { VisualElement } from "../.."
+import { MotionProps } from "../../../../motion/types"
+import { isMotionValue } from "../../../../value/utils/is-motion-value"
 import { ResolvedValues } from "../../types"
 import {
     AnimationState,
@@ -21,6 +23,13 @@ class StateVisualElement extends VisualElement {
 
     getBoundingBox() {
         return { x: { min: 0, max: 0 }, y: { min: 0, max: 0 } }
+    }
+
+    getFallbackValue(key: string, props: MotionProps) {
+        const style = props.style?.[key]
+        return style !== undefined && !isMotionValue(style)
+            ? style
+            : super.getFallbackValue(key, props)
     }
 
     readNativeValue(key: string) {

--- a/src/render/VisualElement/utils/animation-state.ts
+++ b/src/render/VisualElement/utils/animation-state.ts
@@ -5,7 +5,6 @@ import { VariantContextProps } from "../../../motion/context/MotionContext"
 import { VariantLabels } from "../../../motion/types"
 import { TargetAndTransition } from "../../../types"
 import { shallowCompare } from "../../../utils/shallow-compare"
-import { isMotionValue } from "../../../value/utils/is-motion-value"
 import {
     animateVisualElement,
     AnimationDefinition,
@@ -340,11 +339,10 @@ export function createAnimationState(
         if (removedKeys.size) {
             const fallbackAnimation = {}
             removedKeys.forEach((key) => {
-                const styleValue = props.style?.[key]
-                const fallbackTarget =
-                    styleValue !== undefined && !isMotionValue(styleValue)
-                        ? styleValue
-                        : visualElement.baseTarget[key]
+                const fallbackTarget = visualElement.getFallbackValue(
+                    key,
+                    props
+                )
 
                 if (fallbackTarget !== undefined) {
                     fallbackAnimation[key] = fallbackTarget

--- a/src/render/VisualElement/utils/animation-state.ts
+++ b/src/render/VisualElement/utils/animation-state.ts
@@ -339,10 +339,7 @@ export function createAnimationState(
         if (removedKeys.size) {
             const fallbackAnimation = {}
             removedKeys.forEach((key) => {
-                const fallbackTarget = visualElement.getFallbackValue(
-                    key,
-                    props
-                )
+                const fallbackTarget = visualElement.getBaseValue(key, props)
 
                 if (fallbackTarget !== undefined) {
                     fallbackAnimation[key] = fallbackTarget

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -158,11 +158,11 @@ export class HTMLVisualElement<
         }
     }
 
-    getFallbackValue(key: string, props: MotionProps) {
+    getBaseValue(key: string, props: MotionProps) {
         const style = props.style?.[key]
         return style !== undefined && !isMotionValue(style)
             ? style
-            : super.getFallbackValue(key, props)
+            : super.getBaseValue(key, props)
     }
 
     /**

--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -36,6 +36,8 @@ import {
     checkTargetForNewValues,
     getOrigin,
 } from "../VisualElement/utils/setters"
+import { isMotionValue } from "../../value/utils/is-motion-value"
+import { MotionProps } from "../../motion"
 
 export type LayoutUpdateHandler = (
     layout: AxisBox2D,
@@ -154,6 +156,13 @@ export class HTMLVisualElement<
         } else {
             return this.read(key)
         }
+    }
+
+    getFallbackValue(key: string, props: MotionProps) {
+        const style = props.style?.[key]
+        return style !== undefined && !isMotionValue(style)
+            ? style
+            : super.getFallbackValue(key, props)
     }
 
     /**

--- a/src/render/dom/SVGVisualElement.ts
+++ b/src/render/dom/SVGVisualElement.ts
@@ -80,11 +80,11 @@ export class SVGVisualElement extends HTMLVisualElement<
         sync.render(() => this.render())
     }
 
-    getFallbackValue(key: string, props: MotionProps) {
+    getBaseValue(key: string, props: MotionProps) {
         const prop = props[key]
         return prop !== undefined && !isMotionValue(prop)
             ? prop
-            : super.getFallbackValue(key, props)
+            : super.getBaseValue(key, props)
     }
 
     /**

--- a/src/render/dom/SVGVisualElement.ts
+++ b/src/render/dom/SVGVisualElement.ts
@@ -5,6 +5,8 @@ import { ResolvedValues } from "../VisualElement/types"
 import { camelCaseAttributes } from "./utils/svg-camel-case-attributes"
 import { camelToDash } from "./utils/camel-to-dash"
 import sync from "framesync"
+import { isMotionValue } from "../../value/utils/is-motion-value"
+import { MotionProps } from "../../motion"
 
 /**
  * A VisualElement for SVGElements. Inherits from and extends HTMLVisualElement as the two
@@ -76,6 +78,13 @@ export class SVGVisualElement extends HTMLVisualElement<
          * Preferably this would happen synchronously but we put it in rAF to prevent layout thrashing.
          */
         sync.render(() => this.render())
+    }
+
+    getFallbackValue(key: string, props: MotionProps) {
+        const prop = props[key]
+        return prop !== undefined && !isMotionValue(prop)
+            ? prop
+            : super.getFallbackValue(key, props)
     }
 
     /**


### PR DESCRIPTION
This PR checks props for SVG fallback values so removing a value from `animate` behaves the same across SVG and HTML components. 