### PR TITLE
Using pre-existing types in createDomMotionComponent to get the same proxied motion object types

### DIFF
--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "../../../jest.setup"
 import { fireEvent } from "@testing-library/react"
-import { motion } from "../../"
+import { motion, createDomMotionComponent } from "../../"
 import * as React from "react"
 import styled from "styled-components"
 
@@ -8,6 +8,20 @@ describe("motion component rendering and styles", () => {
     it("renders", () => {
         const { container } = render(<motion.div />)
         expect(container.firstChild).toBeTruthy()
+    })
+
+    it("renders motion div component (using createDomMotionComponent) without type errors ", () => {
+        // onTap is a motion component specific prop
+        const MotionDiv = createDomMotionComponent("div")
+        render(
+            <MotionDiv
+                id={"myCreatedMotionDiv"}
+                onTap={() => {
+                    console.log("Just tapping on div")
+                }}
+            />
+        )
+        expect(true).toBe(true)
     })
 
     it("renders HTML and SVG attributes without type errors", () => {
@@ -94,9 +108,9 @@ describe("motion component rendering and styles", () => {
         )
         const MotionComponent = motion.custom(Component)
 
-        const promise = new Promise<Element>(resolve => {
+        const promise = new Promise<Element>((resolve) => {
             const { rerender } = render(
-                <MotionComponent ref={ref => resolve(ref as Element)} />
+                <MotionComponent ref={(ref) => resolve(ref as Element)} />
             )
             rerender(<Component />)
         })
@@ -105,7 +119,7 @@ describe("motion component rendering and styles", () => {
     })
 
     it("accepts createref", async () => {
-        const promise = new Promise<Element>(resolve => {
+        const promise = new Promise<Element>((resolve) => {
             const ref = React.createRef<HTMLButtonElement>()
             const Component = () => {
                 React.useEffect(() => {

--- a/src/render/dom/index.ts
+++ b/src/render/dom/index.ts
@@ -11,7 +11,7 @@ import { Animation } from "../../motion/features/animation"
 import { AnimateLayout } from "../../motion/features/layout/Animate"
 import { MeasureLayout } from "../../motion/features/layout/Measure"
 import { MotionFeature } from "../../motion/features/types"
-import { HTMLElements } from "./utils/supported-elements"
+import { HTMLElements, SVGElements } from "./utils/supported-elements"
 
 /**
  * I'd rather the return type of `custom` to be implicit but this throws
@@ -22,6 +22,8 @@ export type CustomDomComponent<Props> = React.ForwardRefExoticComponent<
     React.PropsWithoutRef<Props & MotionProps> &
         React.RefAttributes<SVGElement | HTMLElement>
 >
+
+type MotionComponents = HTMLMotionComponents & SVGMotionComponents
 
 const allMotionFeatures = [
     MeasureLayout,
@@ -52,10 +54,10 @@ const domBaseConfig = {
  * @public
  */
 export function createMotionProxy(defaultFeatures: MotionFeature[]) {
-    type CustomMotionComponent = { custom: typeof custom }
-    type Motion = HTMLMotionComponents &
-        SVGMotionComponents &
-        CustomMotionComponent
+    type CustomMotionComponent = {
+        custom: typeof custom
+    }
+    type Motion = MotionComponents & CustomMotionComponent
 
     const config: MotionComponentConfig<HTMLElement | SVGElement> = {
         ...domBaseConfig,
@@ -105,13 +107,15 @@ export const motion = /*@__PURE__*/ createMotionProxy(allMotionFeatures)
  *
  * @public
  */
-export function createDomMotionComponent(key: HTMLElements) {
-    type motionTypes = HTMLMotionComponents & SVGMotionComponents
-    type motionTypesKeys = keyof motionTypes
-    type motionTypesValues = motionTypes[motionTypesKeys]
-
-    return createMotionComponent(key, {
+export function createDomMotionComponent(
+    key: HTMLElements | SVGElements | string
+) {
+    const config: MotionComponentConfig<HTMLElement | SVGElement> = {
         ...domBaseConfig,
         defaultFeatures: allMotionFeatures,
-    }) as motionTypesValues
+    }
+    return createMotionComponent(
+        key,
+        config
+    ) as MotionComponents[keyof MotionComponents]
 }

--- a/src/render/dom/index.ts
+++ b/src/render/dom/index.ts
@@ -11,6 +11,7 @@ import { Animation } from "../../motion/features/animation"
 import { AnimateLayout } from "../../motion/features/layout/Animate"
 import { MeasureLayout } from "../../motion/features/layout/Measure"
 import { MotionFeature } from "../../motion/features/types"
+import { HTMLElements } from "./utils/supported-elements"
 
 /**
  * I'd rather the return type of `custom` to be implicit but this throws
@@ -104,9 +105,13 @@ export const motion = /*@__PURE__*/ createMotionProxy(allMotionFeatures)
  *
  * @public
  */
-export function createDomMotionComponent(key: string) {
+export function createDomMotionComponent(key: HTMLElements) {
+    type motionTypes = HTMLMotionComponents & SVGMotionComponents
+    type motionTypesKeys = keyof motionTypes
+    type motionTypesValues = motionTypes[motionTypesKeys]
+
     return createMotionComponent(key, {
         ...domBaseConfig,
         defaultFeatures: allMotionFeatures,
-    })
+    }) as motionTypesValues
 }


### PR DESCRIPTION
Hello there
I'm currently working in a javascript proxyless env. Searching inside the source code (as i cannot use proxy-polyfill) i noticed the `createDomMotionComponent` function being exposed.
Unfortunately, even as the function name suggests the creation of purely motion dom components, the resulting return types seems to be a little off compared to the one obtained via classic motion exposed object.
I took the existing types of motion, removing "typeof motion.custom" as it's doesn't fit with the wanted "createDom..." behavior

Please let me know if there is a better way to do this, or even if i'am missing something