### PR TITLE
Feature/restore css prefixes

### DIFF
--- a/src/render/dom/HTMLVisualElement.ts
+++ b/src/render/dom/HTMLVisualElement.ts
@@ -36,6 +36,7 @@ import {
 import { isMotionValue } from "../../value/utils/is-motion-value"
 import { MotionProps } from "../../motion"
 import { isCSSVariable } from "./utils/is-css-variable"
+import prefixer from "./utils/prefixer"
 
 export type LayoutUpdateHandler = (
     layout: AxisBox2D,
@@ -683,13 +684,22 @@ export class HTMLVisualElement<
         // Rebuild the latest animated values into style and vars caches.
         this.build()
 
+        const tempStyle = {}
+        for (const unprefixedStyleKey in this.style) {
+            tempStyle[
+                prefixer(unprefixedStyleKey, false, this.element as HTMLElement)
+            ] = this.style[unprefixedStyleKey]
+        }
         // Directly assign style into the Element's style prop. In tests Object.assign is the
         // fastest way to assign styles.
-        Object.assign(this.element.style, this.style)
+        Object.assign(this.element.style, tempStyle)
 
         // Loop over any CSS variables and assign those.
         for (const key in this.vars) {
-            this.element.style.setProperty(key, this.vars[key] as string)
+            this.element.style.setProperty(
+                prefixer(key, false, this.element as HTMLElement),
+                this.vars[key] as string
+            )
         }
     }
 }

--- a/src/render/dom/__tests__/prefixer.test.ts
+++ b/src/render/dom/__tests__/prefixer.test.ts
@@ -1,0 +1,15 @@
+import "../../../../jest.setup"
+import prefixer from "../utils/prefixer"
+
+const div = () => document.createElement("div")
+
+describe("prefixer", () => {
+    test("prefix raw css property (dashed)", () => {
+        const prefixedCss = prefixer("transform", true, div())
+        expect(prefixedCss).toEqual("-webkit-transform")
+    })
+    test("prefix css object key (CSSProperties)", () => {
+        const cssPropKey = prefixer("transform", false, div())
+        expect(cssPropKey).toEqual("webkitTransform")
+    })
+})

--- a/src/render/dom/utils/prefixer.ts
+++ b/src/render/dom/utils/prefixer.ts
@@ -1,0 +1,73 @@
+import { camelToDash } from "./camel-to-dash"
+
+const camelCache = new Map<string, string>()
+const dashCache = new Map<string, string>()
+const prefixes: string[] = ["webkit", "woz", "o", "ms"]
+const numPrefixes = prefixes.length
+const isBrowser = typeof document !== "undefined"
+
+let testElement: HTMLElement
+
+const setDashPrefix = (key: string, prefixed: string) =>
+    dashCache.set(key, camelToDash(prefixed))
+
+/*
+  Test style property for prefixed version
+
+  @param [string]: Style property
+  @return [string]: Cached property name
+*/
+const testPrefix = (key: string, testElement: HTMLElement) => {
+    let isNativelySupported = false
+    let prefixedPropertyName = key
+
+    // Natively Supported CSS property
+    if (key in testElement.style) {
+        isNativelySupported = true
+    }
+
+    for (let i = 0; i < numPrefixes; i++) {
+        const prefix = prefixes[i]
+        const latestPropertyName =
+            prefix + key.charAt(0).toUpperCase() + key.slice(1)
+        if (latestPropertyName in testElement.style) {
+            prefixedPropertyName = latestPropertyName
+            break
+        }
+    }
+
+    // Vendor prefixed properties has priority over natively supported
+    if (prefixedPropertyName !== key) {
+        camelCache.set(key, prefixedPropertyName)
+        setDashPrefix(key, `-${camelToDash(prefixedPropertyName)}`)
+    } else if (isNativelySupported) {
+        camelCache.set(key, key)
+        setDashPrefix(key, `${camelToDash(key)}`)
+    }
+}
+
+const setServerProperty = (key: string) => setDashPrefix(key, key)
+
+const prefixer = (
+    key: string,
+    asDashCase: boolean = false,
+    element?: HTMLElement
+) => {
+    const cache = asDashCase ? dashCache : camelCache
+
+    if (!cache.has(key)) {
+        if (isBrowser) {
+            if (!element) {
+                if (!testElement) testElement = document.createElement("div")
+                element = testElement
+            }
+            testPrefix(key, element)
+        } else {
+            setServerProperty(key)
+        }
+    }
+
+    return cache.get(key) || key
+}
+
+export default prefixer


### PR DESCRIPTION
Hello there, this working draft resolves #920 (Please, read the issue for the concerns)

Not sure about lots of things:
- I kept `HTMLVisualElements` style separated on render method, calling prefixer on every render
In older version of motion, seems to be implemented directly inside of what is not called `buildHTMLStyles`, but i don't want to mess up something by touching something in there
Current client-tests still passes as they refer to `buildHTMLStyles` directly and other tests pass as jest DOM abstraction lib `jsdom` uses `cssom` and `cssstyle` (Refer back to #920) so prefixer does not find any prefixed property needs (Maybe, in the future, changing to headless browser test may be lead to client test failure as `prefixer` gives priority to vendorized (and certainly supported) css properties)
- The only test wrote is client-side, as old prefixer code uses dashCase only for SSR
This can lead to problems in some ways, as (eg) `Object.assign(this.element.style, {"transform-origin": "..."})` does not sound correct
- `prefixer` changes may be unsupported in some envs?
Using `key in testElement.style` may require additional iterator support that i suspect is missing from older browser/older ES implementation... sorry i cannot find something that says it does or it doesn't work

Please, let me know if this is possible to be done, and if so, if that can be done better than my garbage