### PR TITLE
Add MotionContext to exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export {
 } from "./motion/context/MotionConfigContext"
 export { PresenceContext } from "./components/AnimatePresence/PresenceContext"
 export { LayoutGroupContext } from "./components/AnimateSharedLayout/LayoutGroupContext"
+export { MotionContext } from "./motion/context/MotionContext"
 
 /**
  * Types


### PR DESCRIPTION
I am working on project that utilizes framer-motion, but I'm hitting an issue because this context is not exposed. Can we just export this variable publicly, or is there a reason for it to be left unexposed?