### PR TITLE
Adding correct default types for filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.0] Unreleased
+
+### Added
+
+-   Support for hex `alpha`, ie `#FFF0` and `#FFFFFF00`.
+-   Support for default `filter` values. For example, when animating from `brightness(50%)`, the animation will start from `brightness(100%)`rather than`brightness(0%)`.
+
 ## [3.1.5] 2020-01-08
 
 ### Fixed

--- a/dev/examples/Animation-filter.tsx
+++ b/dev/examples/Animation-filter.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import { motion } from "@framer"
+
+/**
+ * An example of animating the filter property.
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "white",
+    opacity: 1,
+    // filter: "brightness(100%)",
+}
+
+export const App = () => {
+    return (
+        <motion.div
+            animate={{ filter: "brightness(0.5)" }}
+            transition={{ duration: 2 }}
+            style={style}
+        />
+    )
+}

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
     "dependencies": {
         "framesync": "^5.0.0",
         "hey-listen": "^1.0.8",
-        "popmotion": "^9.0.2",
-        "style-value-types": "^3.2.0",
+        "popmotion": "^9.1.0",
+        "style-value-types": "^4.0.1",
         "tslib": "^1.10.0"
     },
     "optionalDependencies": {
@@ -121,11 +121,11 @@
     "bundlesize": [
         {
             "path": "./dist/framer-motion.js",
-            "maxSize": "28.6 kB"
+            "maxSize": "28.8 kB"
         },
         {
             "path": "./dist/minimal-component.js",
-            "maxSize": "13.2 kB"
+            "maxSize": "13.3 kB"
         }
     ]
 }

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -9,8 +9,8 @@ import { isEasingArray, easingDefinitionToFunction } from "./easing"
 import { MotionValue } from "../../value"
 import { isAnimatable } from "./is-animatable"
 import { getDefaultTransition } from "./default-transitions"
-import { complex } from "style-value-types"
 import { warning } from "hey-listen"
+import { getAnimatableNone } from "../../render/dom/utils/value-types"
 
 type StopAnimation = { stop: () => void }
 
@@ -169,7 +169,7 @@ function getAnimation(
      * of the target. This could be improved to work both ways.
      */
     if (origin === "none" && isTargetAnimatable && typeof target === "string") {
-        origin = complex.getAnimatableNone(target as string)
+        origin = getAnimatableNone(key, target)
     }
 
     const isOriginAnimatable = isAnimatable(key, origin)

--- a/src/render/VisualElement/utils/setters.ts
+++ b/src/render/VisualElement/utils/setters.ts
@@ -10,7 +10,7 @@ import {
 import { isNumericalString } from "../../../utils/is-numerical-string"
 import { resolveFinalValueInKeyframes } from "../../../utils/resolve-value"
 import { motionValue } from "../../../value"
-import { findValueType } from "../../dom/utils/value-types"
+import { findValueType, getAnimatableNone } from "../../dom/utils/value-types"
 import { ResolvedValues } from "../types"
 import { AnimationDefinition } from "./animation"
 import { resolveVariant } from "./variants"
@@ -112,8 +112,7 @@ export function checkTargetForNewValues(
             // If this is a number read as a string, ie "0" or "200", convert it to a number
             value = parseFloat(value)
         } else if (!findValueType(value) && complex.test(targetValue)) {
-            // If value is not recognised as animatable, ie "none", create an animatable version origin based on the target
-            value = complex.getAnimatableNone(targetValue as string)
+            value = getAnimatableNone(key, targetValue)
         }
 
         visualElement.addValue(key, motionValue(value))

--- a/src/render/dom/utils/value-types.ts
+++ b/src/render/dom/utils/value-types.ts
@@ -11,6 +11,7 @@ import {
     vw,
     vh,
     complex,
+    filter,
 } from "style-value-types"
 
 interface ValueTypeMap {
@@ -22,7 +23,7 @@ interface ValueTypeMap {
  */
 export const auto: ValueType = {
     test: (v: any) => v === "auto",
-    parse: v => v,
+    parse: (v) => v,
 }
 
 /**
@@ -113,6 +114,8 @@ const defaultValueTypes: ValueTypeMap = {
 
     // Misc
     zIndex: int,
+    filter,
+    WebkitFilter: filter,
 
     // SVG
     fillOpacity: alpha,
@@ -158,4 +161,11 @@ export const getValueAsType = (value: any, type?: ValueType) => {
     return type && typeof value === "number"
         ? (type as any).transform(value)
         : value
+}
+
+export function getAnimatableNone(key: string, value: string) {
+    let defaultValueType = getDefaultValueType(key)
+    if (defaultValueType !== filter) defaultValueType = complex
+    // If value is not recognised as animatable, ie "none", create an animatable version origin based on the target
+    return defaultValueType.getAnimatableNone?.(value)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7412,14 +7412,14 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-popmotion@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.0.2.tgz#477650c3b4af97161011809223d9ca6860f3a2b5"
-  integrity sha512-WfSg8IfoUwYIP9uqeqbgncIsMHLAKWqebT2IP1aGAI6gdSJqTPy/H8NvP4ZyDtDCUCx5Yh3Pth/7iUJjIwR7LA==
+popmotion@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.1.0.tgz#4360d06bd18ce8baa8f9284ecec7d55344af6325"
+  integrity sha512-+J7pzzBy5kk2qsP8ilowKs/CH+HoZa3kOGEBNCleCvsPXEF3nKHdfAR3SboMyPvdpIrofaT7ZIy/xWgz446Azw==
   dependencies:
     framesync "5.0.0"
     hey-listen "^1.0.8"
-    style-value-types "3.2.0"
+    style-value-types "^4.0.1"
     tslib "^1.10.0"
 
 portfinder@^1.0.26:
@@ -8981,10 +8981,10 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-style-value-types@3.2.0, style-value-types@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-3.2.0.tgz#eb89cab1340823fa7876f3e289d29d99c92111bb"
-  integrity sha512-ih0mGsrYYmVvdDi++/66O6BaQPRPRMQHoZevNNdMMcPlP/cH28Rnfsqf1UEba/Bwfuw9T8BmIMwbGdzsPwQKrQ==
+style-value-types@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-4.0.1.tgz#23f05dd03e8a850654defc22cf03ebac572aaa00"
+  integrity sha512-aOV/HHyynIyTmU27qfs0oAHhFde6BFIvV4+nMerE2MAPZMwYOeQk1/F3S6djxF2u4HdbiieCPs3ZzWsbNUoc9A==
   dependencies:
     hey-listen "^1.0.8"
     tslib "^1.10.0"


### PR DESCRIPTION
This PR adds `filter` type, which generates correct defaults for `brightness`, `contrast`, `saturation` and `opacity` filters, which should all be `1` or `100%` (depending on the input type) rather than `0`.

What this doesn't do, and will have to be fixed in Framer, is when we read from the DOM `filter` is always returned as numerical type as in `brightness(1)` vs `brightness(100%)`. This means if someone defines a `filter` in `style` as `brightness(100%)` and animates to `brightness(50%)` it'll actually animate from `brightness(1%)` coerced from the read value of `brightness(1)`.