### PR TITLE
Use a ref with relative constraints for drag constraints

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -225,7 +225,7 @@ export const DragFeature: MotionFeature;
 // @public (undocumented)
 export interface DraggableProps extends DragHandlers {
     drag?: boolean | "x" | "y";
-    dragConstraints?: false | Partial<BoundingBox2D> | RefObject<Element>;
+    dragConstraints?: false | Partial<BoundingBox2D> | RefObject<BoundingBox2D> | RefObject<Element>;
     dragControls?: DragControls;
     dragDirectionLock?: boolean;
     dragElastic?: boolean | number;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "3.2.2-rc.0",
+    "version": "3.2.2-rc.1",
     "description": "An open source and production-ready motion library for React on the web",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/framer-motion.es.js",

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -30,7 +30,7 @@ import { startAnimation } from "../../animation/utils/transitions"
 import { Transition } from "../../types"
 import { MotionProps } from "../../motion"
 import { AnimationType } from "../../render/VisualElement/utils/animation-state"
-import { isBoundingBoxRefObject } from "utils/is-bounding-box-ref"
+import { isBoundingBoxRefObject } from "../../utils/is-bounding-box-ref"
 
 export const elementDragControls = new WeakMap<
     HTMLVisualElement,

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -8,12 +8,7 @@ import { invariant } from "hey-listen"
 import { progress } from "popmotion"
 import { addDomEvent } from "../../events/use-dom-event"
 import { getViewportPointFromEvent } from "../../events/event-info"
-import {
-    TransformPoint2D,
-    AxisBox2D,
-    Point2D,
-    BoundingBox2D,
-} from "../../types/geometry"
+import { TransformPoint2D, AxisBox2D, Point2D } from "../../types/geometry"
 import {
     convertBoundingBoxToAxisBox,
     convertAxisBoxToBoundingBox,
@@ -36,7 +31,6 @@ import { Transition } from "../../types"
 import { MotionProps } from "../../motion"
 import { AnimationType } from "../../render/VisualElement/utils/animation-state"
 import { isBoundingBoxRefObject } from "utils/is-bounding-box-ref"
-import { VisualElement } from "render/VisualElement"
 
 export const elementDragControls = new WeakMap<
     HTMLVisualElement,

--- a/src/gestures/drag/types.ts
+++ b/src/gestures/drag/types.ts
@@ -290,7 +290,11 @@ export interface DraggableProps extends DragHandlers {
      * }
      * ```
      */
-    dragConstraints?: false | Partial<BoundingBox2D> | RefObject<Element>
+    dragConstraints?:
+        | false
+        | Partial<BoundingBox2D>
+        | RefObject<BoundingBox2D>
+        | RefObject<Element>
 
     /**
      * The degree of movement allowed outside constraints. 0 = no movement, 1 =

--- a/src/utils/is-bounding-box-ref.ts
+++ b/src/utils/is-bounding-box-ref.ts
@@ -1,0 +1,13 @@
+import { RefObject } from "react"
+import { BoundingBox2D } from "types/geometry"
+
+export const isBoundingBoxRefObject = (
+    ref: any
+): ref is RefObject<BoundingBox2D> => {
+    return (
+        typeof ref === "object" &&
+        ref.hasOwnProperty("current") &&
+        ref.current.hasOwnProperty("top") &&
+        ref.current.hasOwnProperty("left")
+    )
+}


### PR DESCRIPTION
Using ref with relative drag constraints makes it easier to update relative drag constraints without triggering a react render, especially when the constraints have to be passed through props.