### PR TITLE
add useTransition

### DIFF
--- a/src/animation/animate.ts
+++ b/src/animation/animate.ts
@@ -15,7 +15,7 @@ interface PlaybackLifecycles<V> {
     onStop?: () => void
 }
 
-type AnimationOptions<V> = (Tween | Spring) &
+export type AnimationOptions<V> = (Tween | Spring) &
     PlaybackLifecycles<V> & { delay?: number; type?: "tween" | "spring" }
 
 /**

--- a/src/value/__tests__/use-transition.test.tsx
+++ b/src/value/__tests__/use-transition.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "../../../jest.setup"
+import * as React from "react"
+import { useTransition } from "../use-transition"
+import { useMotionValue } from "../use-motion-value"
+import { motionValue, MotionValue } from ".."
+import { motion } from "../../"
+
+describe("useTransition", () => {
+    test("can create a MotionValue that responds to changes from another MotionValue", async () => {
+        const promise = new Promise((resolve) => {
+            const Component = () => {
+                const x = useMotionValue(0)
+                const y = useTransition(x)
+
+                React.useEffect(() => {
+                    y.onChange((v) => resolve(v))
+                    x.set(100)
+                })
+
+                return null
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        const resolved = await promise
+
+        expect(resolved).not.toBe(0)
+        expect(resolved).not.toBe(100)
+    })
+
+    test("unsubscribes when attached to a new value", () => {
+        const a = motionValue(0)
+        const b = motionValue(0)
+        let y: MotionValue<number>
+        const Component = ({ target }: { target: MotionValue<number> }) => {
+            y = useTransition(target)
+            return <motion.div style={{ y }} />
+        }
+
+        const { rerender } = render(<Component target={a} />)
+        rerender(<Component target={b} />)
+        rerender(<Component target={a} />)
+        rerender(<Component target={b} />)
+        rerender(<Component target={a} />)
+        rerender(<Component target={a} />)
+
+        expect((a!.updateSubscribers! as any).subscriptions.size).toBe(1)
+    })
+})

--- a/src/value/use-transition.ts
+++ b/src/value/use-transition.ts
@@ -1,0 +1,43 @@
+import { useEffect } from "react"
+import { MotionValue } from "../value"
+import { useMotionValue } from "./use-motion-value"
+import { animate, AnimationOptions } from "../animation/animate"
+import { isMotionValue } from "./utils/is-motion-value"
+
+/**
+ * Creates a `MotionValue` that, when `set` on the source, will use a transition animation to animate to its new state.
+ *
+ * @remarks
+ *
+ * ```jsx
+ * const x = useMotionValue(0)
+ * const y = useTransition(x, { duration: 2 })
+ *
+ * x.set(100) // Animates y
+ * ```
+ *
+ * @param source - `MotionValue`. When the input `MotionValue` changes, the created `MotionValue` will transition towards that value.
+ * @param transitionConfig - Configuration options for the transition.
+ * @returns `MotionValue`
+ *
+ * @public
+ */
+export function useTransition<T = number>(
+    source: MotionValue<T>,
+    config: AnimationOptions<T> = {}
+) {
+    const animatedMotionValue = useMotionValue<T>(
+        isMotionValue(source) ? source.get() : source
+    )
+
+    useEffect(() => {
+        let animation: undefined | ReturnType<typeof animate>
+
+        return source.onChange((newValue: T) => {
+            animation?.stop() // Don't know if this is needed
+            animation = animate<T>(animatedMotionValue, newValue, config)
+        })
+    }, [animatedMotionValue, config, source])
+
+    return animatedMotionValue
+}


### PR DESCRIPTION
Already mentioned here in #218 but I thought, let's make a PR with the functionality.
I wanted to copy the useSpring logic, but that doesn't quite fit in how I feel React lifecycles work.

```jsx
const sourceValue = useMotionValue(0);
const x = useTransition(sourceValue, {})

const handleClick = useCallback(() => {
  sourceValue.set(100)
}, [sourceValue])

return <motion.div style={{ x }}>animate me</motion.div>
```

by doing it like this, the user also has the option to directly set a value without the animation (something I've been missing a lot with some of the "ready to use" code in the examples).
This way no need for a separate controller:
```jsx
const handleNoAnimate = useCallback(() => {
  x.set(100)
  sourceValue.set(100)
}, [sourceValue])
```
