### PR TITLE
Support duplicate features in nested configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.2] Unreleased
+
+### Fixed
+
+-   De-duplicating features in nested `MotionConfig`s to avoid key error
+
 ## [3.2.1] 2020-01-11
 
 ### Added

--- a/src/motion/__tests__/m-feature.test.tsx
+++ b/src/motion/__tests__/m-feature.test.tsx
@@ -45,4 +45,27 @@ describe("Dynamic feature loading", () => {
 
         return expect(promise).resolves.toBe(20)
     })
+
+    test("Does support duplicate features in nested contexts", async () => {
+        const promise = new Promise(resolve => {
+            const x = motionValue(0)
+            const onComplete = () => resolve(x.get())
+            const Component = () => (
+                <MotionConfig features={[AnimationFeature]}>
+                    <MotionConfig features={[AnimationFeature]}>
+                        <m.div
+                            animate={{ x: 20 }}
+                            transition={{ duration: 0.01 }}
+                            style={{ x }}
+                            onAnimationComplete={onComplete}
+                        />
+                    </MotionConfig>
+                </MotionConfig>
+            )
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        return expect(promise).resolves.toBe(20)
+    })
 })

--- a/src/motion/context/MotionConfigContext.tsx
+++ b/src/motion/context/MotionConfigContext.tsx
@@ -69,7 +69,9 @@ export function MotionConfig({
     ...props
 }: MotionConfigProps) {
     const pluginContext = useContext(MotionConfigContext)
-    const loadedFeatures = [...pluginContext.features, ...features]
+    const loadedFeatures = [
+        ...new Set([...pluginContext.features, ...features]),
+    ]
 
     // We do want to rerender children when the number of loaded features changes
     const value = useMemo(() => ({ features: loadedFeatures }), [


### PR DESCRIPTION
To [reduce the bundle size](https://www.framer.com/api/motion/guide-reduce-bundle-size/) (introduced in `2.2.0`), it would be helpful to be able to use multiple nested `MotionConfig`s. Then each one can import only the features that it needs. 

However there is an issue in doing this, detailed in framer/motion#933. Importing the same feature twice causes a key error.

Simply de-duping the list of features stops this from happening and allows you to nest configs.

Fixes https://github.com/framer/motion/issues/933