### PR TITLE
Generate stagger order without re-render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.3.0] Unreleased
+## [3.4.0] Unreleased
 
 ### Changed
 
@@ -11,9 +11,10 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 -   Crossfading elements can never fall out of positional/style sync.
--   SVG double translation transform.
+-   Fixing SVG double translation transform (props + transform style).
 -   `animate` `onComplete` now firing correctly.
 -   Only firing keyframe animation when all values have changed.
+-   Removing forced re-renders for variant trees, now passing variants through `VisualElement` and calculating stagger order based on DOM APIs.
 
 ## [3.2.1] 2020-01-11
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -49,16 +49,14 @@ export interface AnimatePresenceProps {
     presenceAffectsLayout?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "VisualElementTree" needs to be exported by the entry point index.d.ts
-// 
 // @public (undocumented)
-export class AnimateSharedLayout extends React.Component<SharedLayoutProps, {}, VisualElementTree> {
+export class AnimateSharedLayout extends React.Component<SharedLayoutProps, {}, VisualElement> {
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    static contextType: React.Context<VisualElementTree>;
+    static contextType: React.Context<VisualElement<any, any> | undefined>;
     // (undocumented)
     render(): JSX.Element;
     // (undocumented)
@@ -842,6 +840,8 @@ export interface VisualElement<Instance = any, MutableState = any> extends Lifec
     addChild(child: VisualElement): () => void;
     // (undocumented)
     addValue(key: string, value: MotionValue<any>): void;
+    // (undocumented)
+    addVariantChild(child: VisualElement): undefined | (() => void);
     // Warning: (ae-forgotten-export) The symbol "AnimationState" needs to be exported by the entry point index.d.ts
     animationState?: AnimationState;
     // (undocumented)
@@ -860,6 +860,8 @@ export interface VisualElement<Instance = any, MutableState = any> extends Lifec
     forEachValue(callback: (value: MotionValue, key: string) => void): void;
     // (undocumented)
     getBaseTarget(key: string): number | string | undefined | null;
+    // (undocumented)
+    getClosestVariantNode(): VisualElement | undefined;
     // (undocumented)
     getDefaultTransition(): Transition | undefined;
     // (undocumented)
@@ -883,9 +885,9 @@ export interface VisualElement<Instance = any, MutableState = any> extends Lifec
     // (undocumented)
     getStaticValue(key: string): number | string | undefined;
     // (undocumented)
-    getValue(key: string): undefined | MotionValue;
-    // (undocumented)
     getValue(key: string, defaultValue: string | number): MotionValue;
+    // (undocumented)
+    getValue(key: string): undefined | MotionValue;
     // (undocumented)
     getValue(key: string, defaultValue?: string | number): undefined | MotionValue;
     // (undocumented)
@@ -979,15 +981,17 @@ export interface VisualElement<Instance = any, MutableState = any> extends Lifec
     // (undocumented)
     snapshotViewportBox(): void;
     // (undocumented)
+    sortNodePosition(element: VisualElement): number;
+    // (undocumented)
     startLayoutAnimation(axis: "x" | "y", transition: Transition): Promise<any>;
     // (undocumented)
     stopLayoutAnimation(): void;
     // (undocumented)
-    subscribeToVariantParent(): void;
-    // (undocumented)
     suspendHoverEvents(): void;
     // (undocumented)
     syncRender(): void;
+    // (undocumented)
+    treeType: string;
     // (undocumented)
     unlockProjectionTarget(): void;
     // (undocumented)
@@ -1006,7 +1010,7 @@ export interface VisualElement<Instance = any, MutableState = any> extends Lifec
 // Warning: (ae-forgotten-export) The symbol "VisualElementOptions" needs to be exported by the entry point index.d.ts
 // 
 // @public (undocumented)
-export const visualElement: <Instance, MutableState, Options>({ createRenderState, build, getBaseTarget, makeTargetAnimatable, measureViewportBox, onMount, render: renderInstance, readValueFromInstance, resetTransform, restoreTransform, removeValueFromMutableState, scrapeMotionValuesFromProps, }: VisualElementConfig<Instance, MutableState, Options>) => ({ parent, variantParent, ref: externalRef, props, isStatic, snapshot, presenceId, blockInitialAnimation, }: VisualElementOptions<Instance>, options: Options) => VisualElement<Instance, any>;
+export const visualElement: <Instance, MutableState, Options>({ treeType, createRenderState, build, getBaseTarget, makeTargetAnimatable, measureViewportBox, onMount, render: renderInstance, readValueFromInstance, resetTransform, restoreTransform, removeValueFromMutableState, sortNodePosition, scrapeMotionValuesFromProps, }: VisualElementConfig<Instance, MutableState, Options>) => ({ parent, ref: externalRef, props, isStatic, snapshot, presenceId, blockInitialAnimation, }: VisualElementOptions<Instance>, options: Options) => VisualElement<Instance, any>;
 
 
 // (No @packageDocumentation comment for this package)

--- a/dev/examples/Animation-stagger.tsx
+++ b/dev/examples/Animation-stagger.tsx
@@ -23,13 +23,24 @@ const itemStyle = {
 }
 
 export const App = () => {
+    const [isOpen, setIsOpen] = useState(true)
     const [items, setItems] = React.useState([0, 1, 2, 3, 4, 5])
     const sidebarPoses = {
         open: {
             x: 0,
-            transition: { when: "beforeChildren", staggerChildren: 0.05 },
+            transition: {
+                when: "beforeChildren",
+                staggerChildren: 0.05,
+                staggerDirection: -1,
+            },
         },
-        closed: { x: -180 },
+        closed: {
+            x: -180,
+            transition: {
+                when: "afterChildren",
+                staggerChildren: 0.05,
+            },
+        },
     }
 
     const itemPoses = {
@@ -45,19 +56,41 @@ export const App = () => {
                 },
             },
         },
-        closed: { scale: 0.5, opacity: 0.1 },
+        closed: { scale: 0.5, opacity: 0.1, duration: 1 },
     }
 
     return (
         <motion.ul
             variants={sidebarPoses}
             initial="closed"
-            animate="open"
+            animate={isOpen ? "open" : "closed"}
             style={sidebarStyle}
+            onClick={() => setIsOpen(!isOpen)}
         >
-            {items.map(i => (
-                <motion.li key={i} variants={itemPoses} style={itemStyle} />
-            ))}
+            {shuffle(items).map((i) => {
+                return (
+                    <motion.li key={i} variants={itemPoses} style={itemStyle} />
+                )
+            })}
         </motion.ul>
     )
+}
+function shuffle(array: any[]) {
+    let currentIndex = array.length,
+        temporaryValue,
+        randomIndex
+
+    // While there remain elements to shuffle...
+    while (0 !== currentIndex) {
+        // Pick a remaining element...
+        randomIndex = Math.floor(Math.random() * currentIndex)
+        currentIndex -= 1
+
+        // And swap it with the current element.
+        temporaryValue = array[currentIndex]
+        array[currentIndex] = array[randomIndex]
+        array[randomIndex] = temporaryValue
+    }
+
+    return array
 }

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         },
         {
             "path": "./dist/minimal-component.js",
-            "maxSize": "13.5 kB"
+            "maxSize": "13.6 kB"
         }
     ]
 }

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -7,10 +7,7 @@ import {
     SyncLayoutLifecycles,
     SharedLayoutContext,
 } from "./SharedLayoutContext"
-import {
-    MotionContext,
-    VisualElementTree,
-} from "../../motion/context/MotionContext"
+import { MotionContext } from "../../motion/context/MotionContext"
 import { resetRotate } from "./utils/rotate"
 import { VisualElement } from "../../render/types"
 
@@ -20,7 +17,7 @@ import { VisualElement } from "../../render/types"
 export class AnimateSharedLayout extends React.Component<
     SharedLayoutProps,
     {},
-    VisualElementTree
+    VisualElement
 > {
     static contextType = MotionContext
 
@@ -122,7 +119,7 @@ export class AnimateSharedLayout extends React.Component<
                     child.notifyLayoutReady()
                 }
             },
-            parent: this.context.parent,
+            parent: this.context,
         }
 
         /**

--- a/src/motion/context/MotionContext.ts
+++ b/src/motion/context/MotionContext.ts
@@ -1,13 +1,8 @@
 import { createContext, useContext } from "react"
 import { VisualElement } from "../../render/types"
 
-export interface VisualElementTree {
-    parent?: VisualElement
-    variantParent?: VisualElement
-}
-
-export const MotionContext = createContext<VisualElementTree>({})
+export const MotionContext = createContext<VisualElement | undefined>(undefined)
 
 export function useVisualElementContext() {
-    return useContext(MotionContext).parent
+    return useContext(MotionContext)
 }

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -44,13 +44,12 @@ export function createMotionComponent<P extends {}, E>(
          * providing a way of rendering to these APIs outside of the React render loop
          * for more performant animations and interactions
          */
-        const motionContext = useVisualElement(
+        const visualElement = useVisualElement(
             Component,
             props,
             isStatic,
             externalRef
         )
-        const visualElement = motionContext.parent!
 
         /**
          * Load features as renderless components unless the component isStatic
@@ -68,7 +67,7 @@ export function createMotionComponent<P extends {}, E>(
         // all plugins and features has to execute.
         return (
             <>
-                <MotionContext.Provider value={motionContext}>
+                <MotionContext.Provider value={visualElement}>
                     {component}
                 </MotionContext.Provider>
                 {features}

--- a/src/render/dom/html-visual-element.ts
+++ b/src/render/dom/html-visual-element.ts
@@ -20,6 +20,8 @@ export const htmlConfig: VisualElementConfig<
     HTMLMutableState,
     DOMVisualElementOptions
 > = {
+    treeType: "dom",
+
     readValueFromInstance(domElement, key) {
         if (isTransformProp(key)) {
             return getDefaultValueType(key)?.default || 0
@@ -39,6 +41,10 @@ export const htmlConfig: VisualElementConfig<
         transformOrigin: {},
         vars: {},
     }),
+
+    sortNodePosition(a, b) {
+        return a.compareDocumentPosition(b) & 2 ? 1 : -1
+    },
 
     getBaseTarget(props, key) {
         return props.style?.[key]

--- a/src/render/dom/use-dom-visual-element.ts
+++ b/src/render/dom/use-dom-visual-element.ts
@@ -14,10 +14,7 @@ import {
     SharedLayoutContext,
 } from "../../components/AnimateSharedLayout/SharedLayoutContext"
 import { MotionProps } from "../../motion"
-import {
-    useVisualElementContext,
-    VisualElementTree,
-} from "../../motion/context/MotionContext"
+import { useVisualElementContext } from "../../motion/context/MotionContext"
 import { useSnapshotOnUnmount } from "../../motion/features/layout/use-snapshot-on-unmount"
 import { useConstant } from "../../utils/use-constant"
 import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
@@ -48,7 +45,7 @@ export function useDomVisualElement<E>(
     props: MotionProps,
     isStatic: boolean,
     ref: Ref<E>
-): VisualElementTree {
+): VisualElement {
     const parent = useVisualElementContext()
     const presenceContext = useContext(PresenceContext)
     const layoutId = useLayoutId(props)

--- a/src/render/dom/use-dom-visual-element.ts
+++ b/src/render/dom/use-dom-visual-element.ts
@@ -4,7 +4,6 @@ import {
     Ref,
     useContext,
     useEffect,
-    useMemo,
     useRef,
 } from "react"
 import { PresenceContext } from "../../components/AnimatePresence/PresenceContext"
@@ -16,14 +15,13 @@ import {
 } from "../../components/AnimateSharedLayout/SharedLayoutContext"
 import { MotionProps } from "../../motion"
 import {
-    MotionContext,
+    useVisualElementContext,
     VisualElementTree,
 } from "../../motion/context/MotionContext"
 import { useSnapshotOnUnmount } from "../../motion/features/layout/use-snapshot-on-unmount"
 import { useConstant } from "../../utils/use-constant"
 import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
 import { VisualElement } from "../types"
-import { checkIfControllingVariants } from "../utils/variants"
 import { htmlVisualElement } from "./html-visual-element"
 import { svgVisualElement } from "./svg-visual-element"
 import { isSVGComponent } from "./utils/is-svg-component"
@@ -51,8 +49,7 @@ export function useDomVisualElement<E>(
     isStatic: boolean,
     ref: Ref<E>
 ): VisualElementTree {
-    const motionContext = useContext(MotionContext)
-    const { parent, variantParent } = motionContext
+    const parent = useVisualElementContext()
     const presenceContext = useContext(PresenceContext)
     const layoutId = useLayoutId(props)
     const snapshot = useSnapshotOfLeadVisualElement(layoutId)
@@ -73,8 +70,6 @@ export function useDomVisualElement<E>(
         visualElementRef.current = factory(
             {
                 parent,
-                variantParent:
-                    props.inherit !== false ? variantParent : undefined,
                 ref: ref as any,
                 isStatic,
                 props: { ...props, layoutId },
@@ -86,27 +81,7 @@ export function useDomVisualElement<E>(
         )
     }
 
-    /**
-     * Create motion context for children to ensure children re-render if new variants
-     * are being passed. This is quite a blunt instrument and will lead to a ton of
-     * unneccessary rerenders. In the future we might prefer something like AnimateSharedLayout
-     * where incoming or re-rendering children trigger a rerender in the immediate
-     * variant parent.
-     */
     const visualElement = visualElementRef.current
-    const isControllingVariants = checkIfControllingVariants(props)
-    const isVariantNode = isControllingVariants || props.variants
-
-    const context = useMemo(
-        () => ({
-            parent: visualElement,
-            variantParent: isVariantNode ? visualElement : variantParent,
-        }),
-        /**
-         * If this is a variant node, always create a new context
-         */
-        [isVariantNode && !isStatic ? {} : motionContext]
-    )
 
     useIsomorphicLayoutEffect(() => {
         visualElement.updateProps({ ...props, layoutId })
@@ -118,23 +93,17 @@ export function useDomVisualElement<E>(
         visualElement.isPresenceRoot =
             !parent || parent.presenceId !== presenceContext?.id
 
-        /**
-         * What we want here is to clear the order of variant children in useLayoutEffect
-         * then children can re-add themselves in useEffect. This should add them in the intended order
-         * for staggerChildren to work correctly.
-         */
-        isPresent(presenceContext) && visualElement.variantChildren?.clear()
-
         // TODO: Fire visualElement layout listeners
         // TODO: Do we need this at all?
         if (!visualElement.isStatic) visualElement.syncRender()
     })
 
-    if (visualElement.isStatic) return context
+    /**
+     * Don't fire unnecessary effects if this is a static component.
+     */
+    if (visualElement.isStatic) return visualElement
 
     useEffect(() => {
-        visualElement.subscribeToVariantParent()
-
         // TODO: visualElement aalready has props, we can do better here
         visualElement.animationState?.setProps(props)
 
@@ -150,5 +119,5 @@ export function useDomVisualElement<E>(
      */
     useSnapshotOnUnmount(visualElement)
 
-    return context
+    return visualElement
 }

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -28,6 +28,7 @@ import { createLayoutState, createVisualState } from "./utils/state"
 import { checkIfControllingVariants, isVariantLabel } from "./utils/variants"
 
 export const visualElement = <Instance, MutableState, Options>({
+    treeType = "",
     createRenderState,
     build,
     getBaseTarget,
@@ -39,6 +40,7 @@ export const visualElement = <Instance, MutableState, Options>({
     resetTransform,
     restoreTransform,
     removeValueFromMutableState,
+    sortNodePosition,
     scrapeMotionValuesFromProps,
 }: VisualElementConfig<Instance, MutableState, Options>) => (
     {
@@ -356,6 +358,8 @@ export const visualElement = <Instance, MutableState, Options>({
     )
 
     const element: VisualElement<Instance> = {
+        treeType,
+
         /**
          * This is a mirror of the internal instance prop, which keeps
          * VisualElement type-compatible with React's RefObject.
@@ -455,6 +459,17 @@ export const visualElement = <Instance, MutableState, Options>({
                 closestVariantNode.variantChildren?.add(child)
                 return () => closestVariantNode.variantChildren!.delete(child)
             }
+        },
+
+        sortNodePosition(other: VisualElement) {
+            /**
+             * If these nodes aren't even of the same type we can't compare their depth.
+             */
+            if (!sortNodePosition || treeType !== other.treeType) return 0
+            return sortNodePosition(
+                element.getInstance() as Instance,
+                other.getInstance()
+            )
         },
 
         /**

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -7,7 +7,6 @@ import {
     CrossfadeState,
     Snapshot,
 } from "../components/AnimateSharedLayout/utils/stack"
-import { VisualElementTree } from "../motion/context/MotionContext"
 import { MotionProps } from "../motion/types"
 import { TargetAndTransition, Transition, Variant } from "../types"
 import { AxisBox2D } from "../types/geometry"
@@ -23,6 +22,7 @@ export interface MotionPoint {
 
 export interface VisualElement<Instance = any, MutableState = any>
     extends LifecycleManager {
+    treeType: string
     depth: number
     current: Instance | null
     manuallyAnimateOnMount: boolean
@@ -37,6 +37,7 @@ export interface VisualElement<Instance = any, MutableState = any>
     path: VisualElement[]
     addChild(child: VisualElement): () => void
     ref: Ref<Instance | null>
+    sortNodePosition(element: VisualElement): number
 
     addVariantChild(child: VisualElement): undefined | (() => void)
     getClosestVariantNode(): VisualElement | undefined
@@ -138,6 +139,7 @@ export interface VisualElement<Instance = any, MutableState = any>
 }
 
 export interface VisualElementConfig<Instance, MutableState, Options> {
+    treeType?: string
     createRenderState(): MutableState
     onMount?: (
         element: VisualElement<Instance>,
@@ -156,6 +158,7 @@ export interface VisualElementConfig<Instance, MutableState, Options> {
         options: Options,
         props: MotionProps
     ): void
+    sortNodePosition?: (a: Instance, b: Instance) => number
     makeTargetAnimatable(
         element: VisualElement<Instance>,
         target: TargetAndTransition,

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -33,11 +33,13 @@ export interface VisualElement<Instance = any, MutableState = any>
     isStatic?: boolean
     isResumingFromSnapshot: boolean
     clearState(props: MotionProps): void
-    subscribeToVariantParent(): void
     getInstance(): Instance | null
     path: VisualElement[]
     addChild(child: VisualElement): () => void
     ref: Ref<Instance | null>
+
+    addVariantChild(child: VisualElement): undefined | (() => void)
+    getClosestVariantNode(): VisualElement | undefined
 
     setCrossfadeState(state: CrossfadeState): void
     layoutSafeToRemove?: () => void
@@ -200,7 +202,7 @@ export type UseVisualElement<E, P = MotionProps> = (
     props: MotionProps & P,
     isStatic?: boolean,
     ref?: Ref<E>
-) => VisualElementTree
+) => VisualElement<E>
 
 /**
  * A generic set of string/number values

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -185,18 +185,24 @@ function animateChildren(
             ? (i = 0) => i * staggerChildren
             : (i = 0) => maxStaggerDuration - i * staggerChildren
 
-    Array.from(visualElement.variantChildren!).forEach((child, i) => {
-        animations.push(
-            animateVariant(child, variant, {
-                ...options,
-                delay: delayChildren + generateStaggerDuration(i),
-            })
-        )
-    })
+    Array.from(visualElement.variantChildren!)
+        .sort(sortByTreeOrder)
+        .forEach((child, i) => {
+            animations.push(
+                animateVariant(child, variant, {
+                    ...options,
+                    delay: delayChildren + generateStaggerDuration(i),
+                })
+            )
+        })
 
     return Promise.all(animations)
 }
 
 export function stopAnimation(visualElement: VisualElement) {
     visualElement.forEachValue((value) => value.stop())
+}
+
+export function sortByTreeOrder(a: VisualElement, b: VisualElement) {
+    return a.sortNodePosition(b)
 }


### PR DESCRIPTION
This removes forced re-renders via context to generate the correct stagger order
