### PR TITLE
onBeforeLayoutMeasure

### DIFF
--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -23,6 +23,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "onLayoutAnimationComplete",
     "onViewportBoxUpdate",
     "onLayoutMeasure",
+    "onBeforeLayoutMeasure",
     "onAnimationStart",
     "onAnimationComplete",
     "onUpdate",

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -808,6 +808,8 @@ export const visualElement = <Instance, MutableState, Options>({
          * should be called after resetting any layout-affecting transforms.
          */
         updateLayoutMeasurement() {
+            element.notifyBeforeLayoutMeasure(layoutState.layout)
+
             layoutState.isHydrated = true
             layoutState.layout = element.measureViewportBox()
             layoutState.layoutCorrected = copyAxisBox(layoutState.layout)

--- a/src/render/utils/lifecycles.ts
+++ b/src/render/utils/lifecycles.ts
@@ -6,6 +6,7 @@ import { ResolvedValues } from "../types"
 
 const names = [
     "LayoutMeasure",
+    "BeforeLayoutMeasure",
     "LayoutUpdate",
     "ViewportBoxUpdate",
     "Update",
@@ -20,6 +21,7 @@ export type LayoutMeasureListener = (
     layout: AxisBox2D,
     prevLayout: AxisBox2D
 ) => void
+export type BeforeLayoutMeasureListener = (layout: AxisBox2D) => void
 export type LayoutUpdateListener = (
     layout: AxisBox2D,
     prevLayout: AxisBox2D,
@@ -42,6 +44,8 @@ export interface VisualElementLifecycles {
      * @public
      */
     onViewportBoxUpdate?(box: AxisBox2D, delta: BoxDelta): void
+
+    onBeforeLayoutMeasure?(box: AxisBox2D): void
 
     onLayoutMeasure?(box: AxisBox2D, prevBox: AxisBox2D): void
 
@@ -129,6 +133,8 @@ export interface VisualElementLifecycles {
 export interface LifecycleManager {
     onLayoutMeasure: (callback: LayoutMeasureListener) => () => void
     notifyLayoutMeasure: LayoutMeasureListener
+    onBeforeLayoutMeasure: (callback: BeforeLayoutMeasureListener) => () => void
+    notifyBeforeLayoutMeasure: BeforeLayoutMeasureListener
     onLayoutUpdate: (callback: LayoutUpdateListener) => () => void
     notifyLayoutUpdate: LayoutUpdateListener
     onViewportBoxUpdate: (callback: OnViewportBoxUpdate) => () => void


### PR DESCRIPTION
In Framer, we sometimes need to reset motion values before a Magic Motion transition occurs, and we want motion to measure after the reset has occurred. Adding this `onBeforeLayoutMeasure` (name can be improved) lifecycle handler allows us to perform resets right before motion runs measurements.