### PR TITLE
Adding dragElastic as an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.9.0] 2021-03-02
+
+### Added
+
+-   `dragElastic` now accepts per-axis elastic settings.
+
 ## [3.8.2] 2021-03-01
 
 ### Fixed

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -218,7 +218,8 @@ export interface DraggableProps extends DragHandlers {
     dragConstraints?: false | Partial<BoundingBox2D> | RefObject<Element>;
     dragControls?: DragControls;
     dragDirectionLock?: boolean;
-    dragElastic?: boolean | number;
+    // Warning: (ae-forgotten-export) The symbol "DragElastic" needs to be exported by the entry point index.d.ts
+    dragElastic?: DragElastic;
     dragListener?: boolean;
     dragMomentum?: boolean;
     dragPropagation?: boolean;

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -210,6 +210,9 @@ export class DragControls {
 }
 
 // @public (undocumented)
+export type DragElastic = boolean | number | Partial<BoundingBox2D>;
+
+// @public (undocumented)
 export const DragFeature: MotionFeature;
 
 // @public (undocumented)
@@ -218,7 +221,6 @@ export interface DraggableProps extends DragHandlers {
     dragConstraints?: false | Partial<BoundingBox2D> | RefObject<Element>;
     dragControls?: DragControls;
     dragDirectionLock?: boolean;
-    // Warning: (ae-forgotten-export) The symbol "DragElastic" needs to be exported by the entry point index.d.ts
     dragElastic?: DragElastic;
     dragListener?: boolean;
     dragMomentum?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "3.8.2",
+    "version": "3.9.0",
     "description": "A simple and powerful React animation library",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.js",

--- a/src/gestures/drag/types.ts
+++ b/src/gestures/drag/types.ts
@@ -311,7 +311,7 @@ export interface DraggableProps extends DragHandlers {
      * Set to `0.5` by default. Can also be set as `false` to disable movement.
      *
      * By passing an object of `top`/`right`/`bottom`/`left`, individual values can be set
-     * per constraint.
+     * per constraint. Any missing values will be set to `0`.
      *
      * @library
      *

--- a/src/gestures/drag/types.ts
+++ b/src/gestures/drag/types.ts
@@ -11,7 +11,7 @@ export type DragHandler = (
     info: PanInfo
 ) => void
 
-export type DragElastic = false | number | Partial<BoundingBox2D>
+export type DragElastic = boolean | number | Partial<BoundingBox2D>
 
 export interface ResolvedConstraints {
     x: Partial<Axis>

--- a/src/gestures/drag/types.ts
+++ b/src/gestures/drag/types.ts
@@ -1,7 +1,7 @@
 import { RefObject } from "react"
 import { PanInfo } from "../PanSession"
 import { Inertia, TargetAndTransition } from "../../types"
-import { BoundingBox2D } from "../../types/geometry"
+import { Axis, BoundingBox2D } from "../../types/geometry"
 import { DragControls } from "./use-drag-controls"
 import { MotionValue } from "../../value"
 import { VariantLabels } from "../../motion/types"
@@ -10,6 +10,18 @@ export type DragHandler = (
     event: MouseEvent | TouchEvent | PointerEvent,
     info: PanInfo
 ) => void
+
+export type DragElastic = false | number | Partial<BoundingBox2D>
+
+export interface ResolvedConstraints {
+    x: Partial<Axis>
+    y: Partial<Axis>
+}
+
+export interface ResolvedElastic {
+    x: Axis
+    y: Axis
+}
 
 /**
  * @public
@@ -294,7 +306,12 @@ export interface DraggableProps extends DragHandlers {
 
     /**
      * The degree of movement allowed outside constraints. 0 = no movement, 1 =
-     * full movement. Set to `0.5` by default.
+     * full movement.
+     *
+     * Set to `0.5` by default. Can also be set as `false` to disable movement.
+     *
+     * By passing an object of `top`/`right`/`bottom`/`left`, individual values can be set
+     * per constraint.
      *
      * @library
      *
@@ -316,7 +333,7 @@ export interface DraggableProps extends DragHandlers {
      * />
      * ```
      */
-    dragElastic?: boolean | number
+    dragElastic?: DragElastic
 
     /**
      * Apply momentum from the pan gesture to the component when dragging

--- a/src/gestures/drag/utils/__tests__/constraints.test.ts
+++ b/src/gestures/drag/utils/__tests__/constraints.test.ts
@@ -37,8 +37,8 @@ describe("resolveDragElastic", () => {
             y: { min: 0.1, max: 0.3 },
         })
         expect(resolveDragElastic({ top: 0.1, right: 0.4 })).toEqual({
-            x: { min: 0.35, max: 0.4 },
-            y: { min: 0.1, max: 0.35 },
+            x: { min: 0, max: 0.4 },
+            y: { min: 0.1, max: 0 },
         })
     })
 })

--- a/src/gestures/drag/utils/__tests__/constraints.test.ts
+++ b/src/gestures/drag/utils/__tests__/constraints.test.ts
@@ -15,6 +15,12 @@ describe("resolveDragElastic", () => {
             y: { min: 0, max: 0 },
         })
     })
+    test("Resolves true as default", () => {
+        expect(resolveDragElastic(true)).toEqual({
+            x: { min: 0.35, max: 0.35 },
+            y: { min: 0.35, max: 0.35 },
+        })
+    })
 
     test("Resolves number as object filled with number", () => {
         expect(resolveDragElastic(0.5)).toEqual({

--- a/src/gestures/drag/utils/__tests__/constraints.test.ts
+++ b/src/gestures/drag/utils/__tests__/constraints.test.ts
@@ -5,27 +5,73 @@ import {
     calcViewportAxisConstraints,
     calcPositionFromProgress,
     rebaseAxisConstraints,
+    resolveDragElastic,
 } from "../constraints"
+
+describe("resolveDragElastic", () => {
+    test("Resolves false as 0", () => {
+        expect(resolveDragElastic(false)).toEqual({
+            x: { min: 0, max: 0 },
+            y: { min: 0, max: 0 },
+        })
+    })
+
+    test("Resolves number as object filled with number", () => {
+        expect(resolveDragElastic(0.5)).toEqual({
+            x: { min: 0.5, max: 0.5 },
+            y: { min: 0.5, max: 0.5 },
+        })
+    })
+
+    test("Resolves object as object, with default values for missing values", () => {
+        expect(
+            resolveDragElastic({ top: 0.1, left: 0.2, bottom: 0.3, right: 0.4 })
+        ).toEqual({
+            x: { min: 0.2, max: 0.4 },
+            y: { min: 0.1, max: 0.3 },
+        })
+        expect(resolveDragElastic({ top: 0.1, right: 0.4 })).toEqual({
+            x: { min: 0.35, max: 0.4 },
+            y: { min: 0.1, max: 0.35 },
+        })
+    })
+})
 
 describe("applyConstraints", () => {
     test("Returns points within the defined constraints", () => {
         expect(applyConstraints(10, { min: 0, max: 20 })).toBe(10)
     })
-    test("Returns points outside the defined constraints when elastic is set to 1", () => {
-        expect(applyConstraints(25, { min: 0, max: 20 }, 1)).toBe(25)
-        expect(applyConstraints(-5, { min: 0, max: 20 }, 1)).toBe(-5)
-    })
-    test("Clamps points outside the defined constraints when elastic is set to 0", () => {
-        expect(applyConstraints(25, { min: 0, max: 20 }, 0)).toBe(20)
-        expect(applyConstraints(-5, { min: 0, max: 20 }, 0)).toBe(0)
-    })
-    test("Applies elastic factor if defined", () => {
-        expect(applyConstraints(25, { min: 0, max: 20 }, 0.5)).toBe(22.5)
-        expect(applyConstraints(-5, { min: 0, max: 20 }, 0.5)).toBe(-2.5)
-        expect(applyConstraints(25, { min: 0, max: 20 }, 1)).toBe(25)
-        expect(applyConstraints(-5, { min: 0, max: 20 }, 1)).toBe(-5)
-        expect(applyConstraints(25, { min: 0, max: 20 }, 0)).toBe(20)
-        expect(applyConstraints(-5, { min: 0, max: 20 }, 0)).toBe(0)
+    test("Applies elastic factor", () => {
+        expect(
+            applyConstraints(25, { min: 0, max: 20 }, { min: 0.5, max: 0.5 })
+        ).toBe(22.5)
+        expect(
+            applyConstraints(25, { min: 0, max: 20 }, { min: 1, max: 0.5 })
+        ).toBe(22.5)
+        expect(
+            applyConstraints(-5, { min: 0, max: 20 }, { min: 0.5, max: 0.5 })
+        ).toBe(-2.5)
+        expect(
+            applyConstraints(-5, { min: 0, max: 20 }, { min: 0.5, max: 1 })
+        ).toBe(-2.5)
+        expect(
+            applyConstraints(25, { min: 0, max: 20 }, { min: 1, max: 1 })
+        ).toBe(25)
+        expect(
+            applyConstraints(-5, { min: 0, max: 20 }, { min: 1, max: 1 })
+        ).toBe(-5)
+        expect(
+            applyConstraints(25, { min: 0, max: 20 }, { min: 0, max: 0 })
+        ).toBe(20)
+        expect(
+            applyConstraints(25, { min: 0, max: 20 }, { min: 1, max: 0 })
+        ).toBe(20)
+        expect(
+            applyConstraints(-5, { min: 0, max: 20 }, { min: 0, max: 0 })
+        ).toBe(0)
+        expect(
+            applyConstraints(-5, { min: 0, max: 20 }, { min: 0, max: 1 })
+        ).toBe(0)
     })
 })
 

--- a/src/gestures/drag/utils/constraints.ts
+++ b/src/gestures/drag/utils/constraints.ts
@@ -177,7 +177,11 @@ export const defaultElastic = 0.35
  * Accepts a dragElastic prop and returns resolved elastic values for each axis.
  */
 export function resolveDragElastic(dragElastic: DragElastic): AxisBox2D {
-    if (dragElastic === false) dragElastic = 0
+    if (dragElastic === false) {
+        dragElastic = 0
+    } else if (dragElastic === true) {
+        dragElastic = defaultElastic
+    }
 
     return {
         x: resolveAxisElastic(dragElastic, "left", "right"),

--- a/src/gestures/drag/utils/constraints.ts
+++ b/src/gestures/drag/utils/constraints.ts
@@ -206,5 +206,5 @@ export function resolvePointElastic(
 ): number {
     return typeof dragElastic === "number"
         ? dragElastic
-        : dragElastic[label] ?? defaultElastic
+        : dragElastic[label] ?? 0
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,11 @@ export {
 export { EventInfo } from "./events/types"
 export { VisualElementLifecycles } from "./render/utils/lifecycles"
 export { MotionFeature, FeatureProps } from "./motion/features/types"
-export { DraggableProps, DragHandlers } from "./gestures/drag/types"
+export {
+    DraggableProps,
+    DragHandlers,
+    DragElastic,
+} from "./gestures/drag/types"
 export { LayoutProps } from "./motion/features/layout/types"
 export { AnimatePresenceProps } from "./components/AnimatePresence/types"
 export { SharedLayoutProps } from "./components/AnimateSharedLayout/types"


### PR DESCRIPTION
Replaces https://github.com/framer/motion/pull/549
Fixes https://github.com/framer/motion/issues/190

Allows `dragElastic` to be defined as an object.

```
<motion.div drag dragElastic={{ top: 0.5 }} />
```