### PR TITLE
Adding motion() and filtering MotionProps from motion.custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.0] 2021-02-23
+
+### Added
+
+-   `motion()` creates custom `motion` components.
+-   `forwardMotionProps` boolean to optionally forward `MotionProps` to custom components.
+
+### Changed
+
+-   Custom `motion` components no longer forward `MotionProps` by default.
+
+### Deprecated
+
+-   `motion.custom`
+
 ## [3.6.8] 2021-02-23
 
 ### Fixed
@@ -44,30 +59,11 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   `AnimatePresence` now correctly unmounts children if it contains no `motion` components.
 
-## [4.0.0] 2021-02-23
-
-### Added
-
--   `motion()` creates custom `motion` components.
--   `forwardMotionProps` boolean to optionally forward `MotionProps` to custom components.
-
-### Changed
-
--   Custom `motion` components no longer forward `MotionProps` by default.
-
-### Deprecated
-
--   `motion.custom`
-
 ## [3.6.1] 2021-02-19
 
 ### Fixed
 
-<<<<<<< HEAD
-
--   # `onAnimationComplete` on child variant components now fire as expected.
--   `motion.custom` now filters `MotionProps`.
-    > > > > > > > Filtering MotionProps from motion.custom
+-   `onAnimationComplete` on child variant components now fire as expected.
 
 ## [3.6.0] 2021-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,11 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--   `onAnimationComplete` on child variant components now fire as expected.
+<<<<<<< HEAD
+
+-   # `onAnimationComplete` on child variant components now fire as expected.
+-   `motion.custom` now filters `MotionProps`.
+    > > > > > > > Filtering MotionProps from motion.custom
 
 ## [3.6.0] 2021-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   `AnimatePresence` now correctly unmounts children if it contains no `motion` components.
 
+## [4.0.0] 2021-02-23
+
+### Added
+
+-   `motion()` creates custom `motion` components.
+-   `forwardMotionProps` boolean to optionally forward `MotionProps` to custom components.
+
+### Changed
+
+-   Custom `motion` components no longer forward `MotionProps` by default.
+
+### Deprecated
+
+-   `motion.custom`
+
 ## [3.6.1] 2021-02-19
 
 ### Fixed

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -353,7 +353,7 @@ export interface LayoutProps {
 }
 
 // @public (undocumented)
-export const m: import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
+export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>) => import("./motion").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
     custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>) => import("./motion").CustomDomComponent<Props>;
 };
 
@@ -361,13 +361,14 @@ export const m: import("./types").HTMLMotionComponents & import("./types").SVGMo
 // Warning: (ae-forgotten-export) The symbol "SVGMotionComponents" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export const motion: HTMLMotionComponents & SVGMotionComponents & {
+export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => CustomDomComponent<Props>) & HTMLMotionComponents & SVGMotionComponents & {
     custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => CustomDomComponent<Props>;
 };
 
 // @public (undocumented)
 export interface MotionAdvancedProps {
     custom?: any;
+    forwardMotionProps?: boolean;
     inherit?: boolean;
 }
 

--- a/dev/examples/motion-custom-tag.tsx
+++ b/dev/examples/motion-custom-tag.tsx
@@ -6,7 +6,8 @@ import * as React from "react"
  */
 
 export const App = () => {
-    const CustomComponent = motion.custom("global")
+    console.log(motion)
+    const CustomComponent = motion("global")
 
     return (
         <CustomComponent

--- a/dev/examples/motion-custom-tag.tsx
+++ b/dev/examples/motion-custom-tag.tsx
@@ -6,7 +6,6 @@ import * as React from "react"
  */
 
 export const App = () => {
-    console.log(motion)
     const CustomComponent = motion("global")
 
     return (

--- a/src/motion/__tests__/component.test.tsx
+++ b/src/motion/__tests__/component.test.tsx
@@ -106,7 +106,7 @@ describe("motion component rendering and styles", () => {
                 <button type="submit" disabled ref={ref} />
             )
         )
-        const MotionComponent = motion.custom(Component)
+        const MotionComponent = motion(Component)
 
         const promise = new Promise<Element>((resolve) => {
             const { rerender } = render(
@@ -250,7 +250,7 @@ describe("motion component rendering and styles", () => {
             background-color: #fff;
         `
 
-        const MotionBox = motion.custom(Box)
+        const MotionBox = motion(Box)
         const { container } = render(
             <MotionBox style={{ backgroundColor: "#f00" }} />
         )

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -7,7 +7,7 @@ interface Props {
     foo: boolean
 }
 
-describe("motion.custom", () => {
+describe("motion()", () => {
     test("accepts custom types", () => {
         const BaseComponent = React.forwardRef(
             (_props: Props, ref: RefObject<HTMLDivElement>) => {
@@ -15,7 +15,7 @@ describe("motion.custom", () => {
             }
         )
 
-        const MotionComponent = motion.custom<Props>(BaseComponent)
+        const MotionComponent = motion<Props>(BaseComponent)
 
         const Component = () => <MotionComponent foo />
 
@@ -33,13 +33,36 @@ describe("motion.custom", () => {
             }
         )
 
-        const MotionComponent = motion.custom<Props>(BaseComponent)
+        const MotionComponent = motion<Props>(BaseComponent)
 
         const Component = () => <MotionComponent foo animate={{ x: 100 }} />
 
         render(<Component />)
 
         expect(animate).toBeUndefined()
+        expect(foo).toBe(true)
+    })
+
+    test("forwards MotionProps if forwardMotionProps is defined", () => {
+        let animate: any
+        let foo: boolean = false
+        const BaseComponent = React.forwardRef(
+            (props: Props, ref: RefObject<HTMLDivElement>) => {
+                animate = (props as any).animate
+                foo = props.foo
+                return <div ref={ref} />
+            }
+        )
+
+        const MotionComponent = motion<Props>(BaseComponent)
+
+        const Component = () => (
+            <MotionComponent foo forwardMotionProps animate={{ x: 100 }} />
+        )
+
+        render(<Component />)
+
+        expect(animate).toEqual({ x: 100 })
         expect(foo).toBe(true)
     })
 })

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -22,11 +22,13 @@ describe("motion.custom", () => {
         render(<Component />)
     })
 
-    test("doesn't forward motion props", () => {
+    test("doesn't forward motion props but does forward custom props", () => {
         let animate: any
+        let foo: boolean = false
         const BaseComponent = React.forwardRef(
             (props: Props, ref: RefObject<HTMLDivElement>) => {
                 animate = (props as any).animate
+                foo = props.foo
                 return <div ref={ref} />
             }
         )
@@ -38,5 +40,6 @@ describe("motion.custom", () => {
         render(<Component />)
 
         expect(animate).toBeUndefined()
+        expect(foo).toBe(true)
     })
 })

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -21,4 +21,22 @@ describe("motion.custom", () => {
 
         render(<Component />)
     })
+
+    test("doesn't forward motion props", () => {
+        let animate: any
+        const BaseComponent = React.forwardRef(
+            (props: Props, ref: RefObject<HTMLDivElement>) => {
+                animate = (props as any).animate
+                return <div ref={ref} />
+            }
+        )
+
+        const MotionComponent = motion.custom<Props>(BaseComponent)
+
+        const Component = () => <MotionComponent foo animate={{ x: 100 }} />
+
+        render(<Component />)
+
+        expect(animate).toBeUndefined()
+    })
 })

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -38,7 +38,7 @@ function runTests(render: (components: any) => string) {
 
     test("correctly renders custom HTML tag", () => {
         const y = motionValue(200)
-        const CustomComponent = motion.custom("element-test")
+        const CustomComponent = motion("element-test")
         const customElement = render(
             <AnimatePresence>
                 <CustomComponent

--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -330,6 +330,33 @@ export interface MotionAdvancedProps {
      * Set to `false` to prevent inheriting variant changes from its parent.
      */
     inherit?: boolean
+
+    /**
+     * Can be used to forward `motion` props to a custom `motion` component.
+     *
+     * Defaults to `false`.
+     *
+     * ```jsx
+     * const Component = React.forwardRef((props, ref) => {
+     *   console.log(props.animate) // { x: 100 }
+     *
+     *   return <div ref={ref} />
+     * })
+     *
+     * const MotionComponent = motion(Component)
+     *
+     * function Parent() {
+     *   return (
+     *     <MotionComponent
+     *       forwardMotionProps
+     *       animate={{ x: 100 }}
+     *     />
+     * }
+     * ```
+     *
+     * @public
+     */
+    forwardMotionProps?: boolean
 }
 
 /**

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -20,6 +20,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "inherit",
     "layout",
     "layoutId",
+    "forwardMotionProps",
     "onLayoutAnimationComplete",
     "onViewportBoxUpdate",
     "onLayoutMeasure",

--- a/src/render/dom/use-render.ts
+++ b/src/render/dom/use-render.ts
@@ -16,7 +16,7 @@ export function useRender<Props>(
     const visualProps = useProps(visualElement, props)
 
     return createElement<any>(Component, {
-        ...filterProps(props),
+        ...filterProps(props, typeof Component === "string"),
         ref: visualElement.ref,
         ...visualProps,
     })

--- a/src/render/dom/use-render.ts
+++ b/src/render/dom/use-render.ts
@@ -16,7 +16,7 @@ export function useRender<Props>(
     const visualProps = useProps(visualElement, props)
 
     return createElement<any>(Component, {
-        ...filterProps(props, typeof Component === "string"),
+        ...filterProps(props),
         ref: visualElement.ref,
         ...visualProps,
     })

--- a/src/render/dom/use-render.ts
+++ b/src/render/dom/use-render.ts
@@ -11,17 +11,12 @@ export function useRender<Props>(
     props: MotionProps,
     visualElement: VisualElement
 ) {
-    // Only filter props from components we control, ie `motion.div`. If this
-    // is a custom component pass along everything provided to it.
-    const forwardedProps =
-        typeof Component === "string" ? filterProps(props) : props
-
     // Generate props to visually render this component
     const useProps = isSVGComponent(Component) ? useSVGProps : useHTMLProps
     const visualProps = useProps(visualElement, props)
 
     return createElement<any>(Component, {
-        ...forwardedProps,
+        ...filterProps(props, typeof Component === "string"),
         ref: visualElement.ref,
         ...visualProps,
     })

--- a/src/render/dom/utils/filter-props.ts
+++ b/src/render/dom/utils/filter-props.ts
@@ -1,8 +1,7 @@
 import { MotionProps } from "../../../motion/types"
 import { isValidMotionProp } from "../../../motion/utils/valid-prop"
 
-const filterValidMotionProps = (key: string) => !isValidMotionProp(key)
-let filterAllProps = filterValidMotionProps
+let shouldForward = (key: string) => !isValidMotionProp(key)
 
 /**
  * Emotion and Styled Components both allow users to pass through arbitrary props to their components
@@ -20,7 +19,7 @@ let filterAllProps = filterValidMotionProps
 try {
     const emotionIsPropValid = require("@emotion/is-prop-valid").default
 
-    filterAllProps = (key: string) => {
+    shouldForward = (key: string) => {
         // Handle events explicitly as Emotion validates them all as true
         if (key.startsWith("on")) {
             return !isValidMotionProp(key)
@@ -32,18 +31,17 @@ try {
     // We don't need to actually do anything here - the fallback is the existing `isPropValid`.
 }
 
-export function filterProps(
-    props: MotionProps,
-    shouldFilterAllProps: boolean = true
-) {
-    const filter = shouldFilterAllProps
-        ? filterAllProps
-        : filterValidMotionProps
-    const domProps = {}
+export function filterProps(props: MotionProps) {
+    const filteredProps = {}
 
     for (const key in props) {
-        if (filter(key)) domProps[key] = props[key]
+        if (
+            shouldForward(key) ||
+            (props.forwardMotionProps === true && isValidMotionProp(key))
+        ) {
+            filteredProps[key] = props[key]
+        }
     }
 
-    return domProps
+    return filteredProps
 }

--- a/src/render/dom/utils/filter-props.ts
+++ b/src/render/dom/utils/filter-props.ts
@@ -31,13 +31,14 @@ try {
     // We don't need to actually do anything here - the fallback is the existing `isPropValid`.
 }
 
-export function filterProps(props: MotionProps) {
+export function filterProps(props: MotionProps, isDom: boolean) {
     const filteredProps = {}
 
     for (const key in props) {
         if (
             shouldForward(key) ||
-            (props.forwardMotionProps === true && isValidMotionProp(key))
+            (props.forwardMotionProps === true && isValidMotionProp(key)) ||
+            (!isDom && !isValidMotionProp(key))
         ) {
             filteredProps[key] = props[key]
         }

--- a/src/render/dom/utils/filter-props.ts
+++ b/src/render/dom/utils/filter-props.ts
@@ -1,7 +1,8 @@
 import { MotionProps } from "../../../motion/types"
 import { isValidMotionProp } from "../../../motion/utils/valid-prop"
 
-let isPropValid = (key: string) => !isValidMotionProp(key)
+const filterValidMotionProps = (key: string) => !isValidMotionProp(key)
+let filterAllProps = filterValidMotionProps
 
 /**
  * Emotion and Styled Components both allow users to pass through arbitrary props to their components
@@ -19,7 +20,7 @@ let isPropValid = (key: string) => !isValidMotionProp(key)
 try {
     const emotionIsPropValid = require("@emotion/is-prop-valid").default
 
-    isPropValid = (key: string) => {
+    filterAllProps = (key: string) => {
         // Handle events explicitly as Emotion validates them all as true
         if (key.startsWith("on")) {
             return !isValidMotionProp(key)
@@ -31,11 +32,17 @@ try {
     // We don't need to actually do anything here - the fallback is the existing `isPropValid`.
 }
 
-export function filterProps(props: MotionProps) {
+export function filterProps(
+    props: MotionProps,
+    shouldFilterAllProps: boolean = true
+) {
+    const filter = shouldFilterAllProps
+        ? filterAllProps
+        : filterValidMotionProps
     const domProps = {}
 
     for (const key in props) {
-        if (isPropValid(key)) domProps[key] = props[key]
+        if (filter(key)) domProps[key] = props[key]
     }
 
     return domProps


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/497
Fixes https://github.com/framer/motion/issues/394

This PR deprecated `motion.custom()` in favour of `motion()`. It also filters out `MotionProps` from being forwarded to `motion.custom` components.