### PR TITLE
Moving forwardMotionProps from props to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.0.0] 2021-02-23
+## [3.7.0] 2021-02-23
 
 ### Added
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -353,22 +353,22 @@ export interface LayoutProps {
 }
 
 // @public (undocumented)
-export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>) => import("./motion").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
-    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>) => import("./motion").CustomDomComponent<Props>;
+export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
+    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>;
 };
 
+// Warning: (ae-forgotten-export) The symbol "DomMotionComponentConfig" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "HTMLMotionComponents" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "SVGMotionComponents" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => CustomDomComponent<Props>) & HTMLMotionComponents & SVGMotionComponents & {
-    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>) => CustomDomComponent<Props>;
+export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>) & HTMLMotionComponents & SVGMotionComponents & {
+    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>;
 };
 
 // @public (undocumented)
 export interface MotionAdvancedProps {
     custom?: any;
-    forwardMotionProps?: boolean;
     inherit?: boolean;
 }
 

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -353,8 +353,8 @@ export interface LayoutProps {
 }
 
 // @public (undocumented)
-export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("react").ForwardRefExoticComponent<import("react").PropsWithoutRef<Props & import("../..").MotionProps> & import("react").RefAttributes<SVGElement | HTMLElement>>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
-    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("react").ForwardRefExoticComponent<import("react").PropsWithoutRef<Props & import("../..").MotionProps> & import("react").RefAttributes<SVGElement | HTMLElement>>;
+export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
+    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "DomMotionComponentConfig" needs to be exported by the entry point index.d.ts
@@ -362,8 +362,8 @@ export const m: (<Props>(Component: string | import("react").ComponentClass<Prop
 // Warning: (ae-forgotten-export) The symbol "SVGMotionComponents" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<SVGElement | HTMLElement>>) & HTMLMotionComponents & SVGMotionComponents & {
-    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<SVGElement | HTMLElement>>;
+export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>) & HTMLMotionComponents & SVGMotionComponents & {
+    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>;
 };
 
 // @public (undocumented)

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -181,7 +181,7 @@ export function createDomMotionComponent<T extends keyof MotionComponents>(key: 
 // Warning: (ae-internal-missing-underscore) The name "createMotionComponent" should be prefixed with an underscore because the declaration is marked as @internal
 // 
 // @internal
-export function createMotionComponent<P extends {}, E>(Component: string | React.ComponentType<P>, { defaultFeatures, createVisualElement, useRender, }: MotionComponentConfig<E>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<E>>;
+export function createMotionComponent<P extends {}, E>({ defaultFeatures, createVisualElement, useRender, }: MotionComponentConfig<E>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<E>>;
 
 // @public
 export type CustomDomComponent<Props> = React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<SVGElement | HTMLElement>>;
@@ -353,8 +353,8 @@ export interface LayoutProps {
 }
 
 // @public (undocumented)
-export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
-    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>;
+export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("react").ForwardRefExoticComponent<import("react").PropsWithoutRef<Props & import("../..").MotionProps> & import("react").RefAttributes<SVGElement | HTMLElement>>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
+    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("react").ForwardRefExoticComponent<import("react").PropsWithoutRef<Props & import("../..").MotionProps> & import("react").RefAttributes<SVGElement | HTMLElement>>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "DomMotionComponentConfig" needs to be exported by the entry point index.d.ts
@@ -362,8 +362,8 @@ export const m: (<Props>(Component: string | import("react").ComponentClass<Prop
 // Warning: (ae-forgotten-export) The symbol "SVGMotionComponents" needs to be exported by the entry point index.d.ts
 // 
 // @public
-export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>) & HTMLMotionComponents & SVGMotionComponents & {
-    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>;
+export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<SVGElement | HTMLElement>>) & HTMLMotionComponents & SVGMotionComponents & {
+    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<SVGElement | HTMLElement>>;
 };
 
 // @public (undocumented)

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "bundlesize": [
         {
             "path": "./dist/framer-motion.js",
-            "maxSize": "29.15 kB"
+            "maxSize": "29.2 kB"
         },
         {
             "path": "./dist/minimal-component.js",

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -65,4 +65,25 @@ describe("motion()", () => {
         expect(animate).toEqual({ x: 100 })
         expect(foo).toBe(true)
     })
+
+    test("forwards MotionProps if deprecated motion.custom used", () => {
+        let animate: any
+        let foo: boolean = false
+        const BaseComponent = React.forwardRef(
+            (props: Props, ref: RefObject<HTMLDivElement>) => {
+                animate = (props as any).animate
+                foo = props.foo
+                return <div ref={ref} />
+            }
+        )
+
+        const MotionComponent = motion.custom<Props>(BaseComponent)
+
+        const Component = () => <MotionComponent foo animate={{ x: 100 }} />
+
+        render(<Component />)
+
+        expect(animate).toEqual({ x: 100 })
+        expect(foo).toBe(true)
+    })
 })

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -2,6 +2,7 @@ import { render } from "../../../jest.setup"
 import { motion } from "../.."
 import * as React from "react"
 import { RefObject } from "react"
+import { MotionProps } from ".."
 
 interface Props {
     foo: boolean
@@ -47,8 +48,8 @@ describe("motion()", () => {
         let animate: any
         let foo: boolean = false
         const BaseComponent = React.forwardRef(
-            (props: Props, ref: RefObject<HTMLDivElement>) => {
-                animate = (props as any).animate
+            (props: Props & MotionProps, ref: RefObject<HTMLDivElement>) => {
+                animate = props.animate
                 foo = props.foo
                 return <div ref={ref} />
             }
@@ -70,8 +71,8 @@ describe("motion()", () => {
         let animate: any
         let foo: boolean = false
         const BaseComponent = React.forwardRef(
-            (props: Props, ref: RefObject<HTMLDivElement>) => {
-                animate = (props as any).animate
+            (props: Props & MotionProps, ref: RefObject<HTMLDivElement>) => {
+                animate = props.animate
                 foo = props.foo
                 return <div ref={ref} />
             }

--- a/src/motion/__tests__/custom.test.tsx
+++ b/src/motion/__tests__/custom.test.tsx
@@ -54,11 +54,11 @@ describe("motion()", () => {
             }
         )
 
-        const MotionComponent = motion<Props>(BaseComponent)
+        const MotionComponent = motion<Props>(BaseComponent, {
+            forwardMotionProps: true,
+        })
 
-        const Component = () => (
-            <MotionComponent foo forwardMotionProps animate={{ x: 100 }} />
-        )
+        const Component = () => <MotionComponent foo animate={{ x: 100 }} />
 
         render(<Component />)
 

--- a/src/motion/features/types.ts
+++ b/src/motion/features/types.ts
@@ -20,8 +20,7 @@ export interface MotionFeature {
     ) => React.ComponentType<FeatureProps> | undefined
 }
 
-export type RenderComponent<P = {}> = (
-    Component: string | React.ComponentType<P>,
+export type RenderComponent = (
     props: MotionProps,
     visualElement: VisualElement
 ) => any

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -26,14 +26,11 @@ export interface MotionComponentConfig<E> {
  *
  * @internal
  */
-export function createMotionComponent<P extends {}, E>(
-    Component: string | React.ComponentType<P>,
-    {
-        defaultFeatures,
-        createVisualElement,
-        useRender,
-    }: MotionComponentConfig<E>
-) {
+export function createMotionComponent<P extends {}, E>({
+    defaultFeatures,
+    createVisualElement,
+    useRender,
+}: MotionComponentConfig<E>) {
     function MotionComponent(props: P & MotionProps, externalRef?: Ref<E>) {
         /**
          * If a component is static, we only visually update it as a
@@ -51,7 +48,6 @@ export function createMotionComponent<P extends {}, E>(
          */
         const visualElement = useVisualElement(
             createVisualElement,
-            Component,
             props,
             isStatic,
             externalRef
@@ -67,7 +63,7 @@ export function createMotionComponent<P extends {}, E>(
             props
         )
 
-        const component = useRender(Component, props, visualElement)
+        const component = useRender(props, visualElement)
 
         // The mount order and hierarchy is specific to ensure our element ref is hydrated by the time
         // all plugins and features has to execute.

--- a/src/motion/types.ts
+++ b/src/motion/types.ts
@@ -330,33 +330,6 @@ export interface MotionAdvancedProps {
      * Set to `false` to prevent inheriting variant changes from its parent.
      */
     inherit?: boolean
-
-    /**
-     * Can be used to forward `motion` props to a custom `motion` component.
-     *
-     * Defaults to `false`.
-     *
-     * ```jsx
-     * const Component = React.forwardRef((props, ref) => {
-     *   console.log(props.animate) // { x: 100 }
-     *
-     *   return <div ref={ref} />
-     * })
-     *
-     * const MotionComponent = motion(Component)
-     *
-     * function Parent() {
-     *   return (
-     *     <MotionComponent
-     *       forwardMotionProps
-     *       animate={{ x: 100 }}
-     *     />
-     * }
-     * ```
-     *
-     * @public
-     */
-    forwardMotionProps?: boolean
 }
 
 /**

--- a/src/motion/utils/use-visual-element.ts
+++ b/src/motion/utils/use-visual-element.ts
@@ -1,11 +1,4 @@
-import {
-    ComponentType,
-    MutableRefObject,
-    Ref,
-    useContext,
-    useEffect,
-    useRef,
-} from "react"
+import { MutableRefObject, Ref, useContext, useEffect, useRef } from "react"
 import { PresenceContext } from "../../components/AnimatePresence/PresenceContext"
 import { isPresent } from "../../components/AnimatePresence/use-presence"
 import { LayoutGroupContext } from "../../components/AnimateSharedLayout/LayoutGroupContext"
@@ -27,7 +20,6 @@ type VisualElementRef = MutableRefObject<VisualElement | null>
 
 export function useVisualElement<E>(
     createVisualElement: CreateVisualElement<E>,
-    Component: string | ComponentType,
     props: MotionProps,
     isStatic: boolean,
     ref?: Ref<E>
@@ -48,7 +40,7 @@ export function useVisualElement<E>(
          */
         visualElementRef.current.clearState(props)
     } else if (!visualElementRef.current) {
-        visualElementRef.current = createVisualElement(Component, isStatic, {
+        visualElementRef.current = createVisualElement(isStatic, {
             parent,
             ref,
             isStatic,

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -20,7 +20,6 @@ const validMotionProps = new Set<keyof MotionProps>([
     "inherit",
     "layout",
     "layoutId",
-    "forwardMotionProps",
     "onLayoutAnimationComplete",
     "onViewportBoxUpdate",
     "onLayoutMeasure",

--- a/src/render/dom/create-dom-visual-element.ts
+++ b/src/render/dom/create-dom-visual-element.ts
@@ -4,17 +4,18 @@ import { htmlVisualElement } from "./html-visual-element"
 import { svgVisualElement } from "./svg-visual-element"
 import { isSVGComponent } from "./utils/is-svg-component"
 
-export function createDomVisualElement(
-    Component: string | ComponentType,
-    isStatic: boolean,
-    options:
-        | VisualElementOptions<SVGElement>
-        | VisualElementOptions<HTMLElement>
-) {
-    const isSVG = isSVGComponent(Component)
-    const factory = isSVG ? svgVisualElement : htmlVisualElement
+export function createDomVisualElement(Component: string | ComponentType) {
+    return (
+        isStatic: boolean,
+        options:
+            | VisualElementOptions<SVGElement>
+            | VisualElementOptions<HTMLElement>
+    ) => {
+        const isSVG = isSVGComponent(Component)
+        const factory = isSVG ? svgVisualElement : htmlVisualElement
 
-    return factory(options as VisualElementOptions<any>, {
-        enableHardwareAcceleration: !isStatic && !isSVG,
-    })
+        return factory(options as VisualElementOptions<any>, {
+            enableHardwareAcceleration: !isStatic && !isSVG,
+        })
+    }
 }

--- a/src/render/dom/motion.ts
+++ b/src/render/dom/motion.ts
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { createDomVisualElement } from "./create-dom-visual-element"
-import { useRender } from "./use-render"
+import { createUseRender } from "./use-render"
 import { HTMLMotionComponents, SVGMotionComponents } from "./types"
 import {
     MotionComponentConfig,
@@ -26,6 +26,10 @@ export type CustomDomComponent<Props> = React.ForwardRefExoticComponent<
         React.RefAttributes<SVGElement | HTMLElement>
 >
 
+export interface DomMotionComponentConfig {
+    forwardMotionProps?: boolean
+}
+
 type MotionComponents = HTMLMotionComponents & SVGMotionComponents
 
 const allMotionFeatures = [
@@ -36,11 +40,6 @@ const allMotionFeatures = [
     Exit,
     AnimateLayout,
 ]
-
-const domBaseConfig = {
-    createVisualElement: createDomVisualElement,
-    useRender,
-}
 
 /**
  * Convert any React component into a `motion` component. The provided component
@@ -65,14 +64,16 @@ export function createMotionProxy(defaultFeatures: MotionFeature[]) {
         MotionComponents &
         DeprecatedCustomMotionComponent
 
-    const config: MotionComponentConfig<HTMLElement | SVGElement> = {
-        ...domBaseConfig,
-        defaultFeatures,
-    }
-
     function custom<Props>(
-        Component: string | React.ComponentType<Props>
+        Component: string | React.ComponentType<Props>,
+        { forwardMotionProps = false }: DomMotionComponentConfig = {}
     ): CustomDomComponent<Props> {
+        const config: MotionComponentConfig<HTMLElement | SVGElement> = {
+            defaultFeatures,
+            createVisualElement: createDomVisualElement,
+            useRender: createUseRender(forwardMotionProps),
+        }
+
         return createMotionComponent(Component, config)
     }
 
@@ -80,7 +81,7 @@ export function createMotionProxy(defaultFeatures: MotionFeature[]) {
         Component: string | React.ComponentType<Props>
     ) {
         warning(false, "motion.custom() is deprecated. Use motion() instead.")
-        return custom(Component)
+        return custom(Component, { forwardMotionProps: true })
     }
 
     /**
@@ -97,7 +98,7 @@ export function createMotionProxy(defaultFeatures: MotionFeature[]) {
          */
         get: (_target, key: string) => {
             /**
-             * Can be removed in 5.0
+             * Can be removed in 4.0
              */
             if (key === "custom") return deprecatedCustom
 
@@ -105,7 +106,7 @@ export function createMotionProxy(defaultFeatures: MotionFeature[]) {
              * If this element doesn't exist in the component cache, create it and cache.
              */
             if (!componentCache.has(key)) {
-                componentCache.set(key, createMotionComponent(key, config))
+                componentCache.set(key, custom(key))
             }
 
             return componentCache.get(key)!
@@ -140,7 +141,8 @@ export function createDomMotionComponent<T extends keyof MotionComponents>(
     key: T
 ) {
     const config: MotionComponentConfig<HTMLElement | SVGElement> = {
-        ...domBaseConfig,
+        createVisualElement: createDomVisualElement,
+        useRender: createUseRender(false),
         defaultFeatures: allMotionFeatures,
     }
     return createMotionComponent(key, config) as MotionComponents[T]

--- a/src/render/dom/motion.ts
+++ b/src/render/dom/motion.ts
@@ -67,7 +67,7 @@ export function createMotionProxy(defaultFeatures: MotionFeature[]) {
     function custom<Props>(
         Component: string | React.ComponentType<Props>,
         { forwardMotionProps = false }: DomMotionComponentConfig = {}
-    ) {
+    ): CustomDomComponent<Props> {
         const config: MotionComponentConfig<HTMLElement | SVGElement> = {
             defaultFeatures,
             createVisualElement: createDomVisualElement(Component),

--- a/src/render/dom/motion.ts
+++ b/src/render/dom/motion.ts
@@ -67,14 +67,14 @@ export function createMotionProxy(defaultFeatures: MotionFeature[]) {
     function custom<Props>(
         Component: string | React.ComponentType<Props>,
         { forwardMotionProps = false }: DomMotionComponentConfig = {}
-    ): CustomDomComponent<Props> {
+    ) {
         const config: MotionComponentConfig<HTMLElement | SVGElement> = {
             defaultFeatures,
-            createVisualElement: createDomVisualElement,
-            useRender: createUseRender(forwardMotionProps),
+            createVisualElement: createDomVisualElement(Component),
+            useRender: createUseRender(Component, forwardMotionProps),
         }
 
-        return createMotionComponent(Component, config)
+        return createMotionComponent<Props, HTMLElement | SVGElement>(config)
     }
 
     function deprecatedCustom<Props>(
@@ -141,9 +141,9 @@ export function createDomMotionComponent<T extends keyof MotionComponents>(
     key: T
 ) {
     const config: MotionComponentConfig<HTMLElement | SVGElement> = {
-        createVisualElement: createDomVisualElement,
-        useRender: createUseRender(false),
+        createVisualElement: createDomVisualElement(key),
+        useRender: createUseRender(key, false),
         defaultFeatures: allMotionFeatures,
     }
-    return createMotionComponent(key, config) as MotionComponents[T]
+    return createMotionComponent(config) as MotionComponents[T]
 }

--- a/src/render/dom/use-render.ts
+++ b/src/render/dom/use-render.ts
@@ -6,12 +6,11 @@ import { filterProps } from "./utils/filter-props"
 import { isSVGComponent } from "./utils/is-svg-component"
 import { useSVGProps } from "./utils/use-svg-props"
 
-export function createUseRender(forwardMotionProps = false) {
-    const useRender = <Props>(
-        Component: string | React.ComponentType<Props>,
-        props: MotionProps,
-        visualElement: VisualElement
-    ) => {
+export function createUseRender<Props>(
+    Component: string | React.ComponentType<Props>,
+    forwardMotionProps = false
+) {
+    const useRender = (props: MotionProps, visualElement: VisualElement) => {
         // Generate props to visually render this component
         const useProps = isSVGComponent(Component) ? useSVGProps : useHTMLProps
         const visualProps = useProps(visualElement, props)

--- a/src/render/dom/use-render.ts
+++ b/src/render/dom/use-render.ts
@@ -6,18 +6,26 @@ import { filterProps } from "./utils/filter-props"
 import { isSVGComponent } from "./utils/is-svg-component"
 import { useSVGProps } from "./utils/use-svg-props"
 
-export function useRender<Props>(
-    Component: string | React.ComponentType<Props>,
-    props: MotionProps,
-    visualElement: VisualElement
-) {
-    // Generate props to visually render this component
-    const useProps = isSVGComponent(Component) ? useSVGProps : useHTMLProps
-    const visualProps = useProps(visualElement, props)
+export function createUseRender(forwardMotionProps = false) {
+    const useRender = <Props>(
+        Component: string | React.ComponentType<Props>,
+        props: MotionProps,
+        visualElement: VisualElement
+    ) => {
+        // Generate props to visually render this component
+        const useProps = isSVGComponent(Component) ? useSVGProps : useHTMLProps
+        const visualProps = useProps(visualElement, props)
 
-    return createElement<any>(Component, {
-        ...filterProps(props, typeof Component === "string"),
-        ref: visualElement.ref,
-        ...visualProps,
-    })
+        return createElement<any>(Component, {
+            ...filterProps(
+                props,
+                typeof Component === "string",
+                forwardMotionProps
+            ),
+            ref: visualElement.ref,
+            ...visualProps,
+        })
+    }
+
+    return useRender
 }

--- a/src/render/dom/utils/filter-props.ts
+++ b/src/render/dom/utils/filter-props.ts
@@ -31,13 +31,17 @@ try {
     // We don't need to actually do anything here - the fallback is the existing `isPropValid`.
 }
 
-export function filterProps(props: MotionProps, isDom: boolean) {
+export function filterProps(
+    props: MotionProps,
+    isDom: boolean,
+    forwardMotionProps: boolean
+) {
     const filteredProps = {}
 
     for (const key in props) {
         if (
             shouldForward(key) ||
-            (props.forwardMotionProps === true && isValidMotionProp(key)) ||
+            (forwardMotionProps === true && isValidMotionProp(key)) ||
             (!isDom && !isValidMotionProp(key))
         ) {
             filteredProps[key] = props[key]

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -191,8 +191,7 @@ export type ExtendVisualElement<
     Element = any
 > = (element: VisualElement<Element>) => Extended
 
-export type CreateVisualElement<E, P = MotionProps> = (
-    Component: string | React.ComponentType<P>,
+export type CreateVisualElement<E> = (
     isStatic: boolean,
     options: VisualElementOptions<E>
 ) => VisualElement<E>


### PR DESCRIPTION
- Adding `forwardMotionProps` as a config option to `motion()`.
- Making `forwardMotionProps` default to `true` for the deprecated `motion.custom()`
- Moving `Component` through as a pre-bound option rather than through the `motion` render path.