### PR TITLE
Fix tree-shaking under Webpack

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -183,8 +183,11 @@ export function createDomMotionComponent<T extends keyof MotionComponents>(key: 
 // @internal
 export function createMotionComponent<P extends {}, E>({ defaultFeatures, createVisualElement, useRender, }: MotionComponentConfig<E>): React.ForwardRefExoticComponent<React.PropsWithoutRef<P & MotionProps> & React.RefAttributes<E>>;
 
-// @public
-export type CustomDomComponent<Props> = React.ForwardRefExoticComponent<React.PropsWithoutRef<Props & MotionProps> & React.RefAttributes<SVGElement | HTMLElement>>;
+// Warning: (ae-forgotten-export) The symbol "React" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-missing-underscore) The name "CustomDomComponent" should be prefixed with an underscore because the declaration is marked as @internal
+// 
+// @internal
+export type CustomDomComponent<Props> = React_2.ForwardRefExoticComponent<React_2.PropsWithoutRef<Props & MotionProps> & React_2.RefAttributes<SVGElement | HTMLElement>>;
 
 // @public (undocumented)
 export interface CustomValueType {
@@ -353,17 +356,13 @@ export interface LayoutProps {
 }
 
 // @public (undocumented)
-export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
-    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion").DomMotionComponentConfig) => import("./motion").CustomDomComponent<Props>;
+export const m: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion-proxy").DomMotionComponentConfig) => import("./motion-proxy").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
+    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion-proxy").DomMotionComponentConfig) => import("./motion-proxy").CustomDomComponent<Props>;
 };
 
-// Warning: (ae-forgotten-export) The symbol "DomMotionComponentConfig" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "HTMLMotionComponents" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "SVGMotionComponents" needs to be exported by the entry point index.d.ts
-// 
 // @public
-export const motion: (<Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>) & HTMLMotionComponents & SVGMotionComponents & {
-    custom: <Props>(Component: string | React.ComponentClass<Props, any> | React.FunctionComponent<Props>, { forwardMotionProps }?: DomMotionComponentConfig) => CustomDomComponent<Props>;
+export const motion: (<Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion-proxy").DomMotionComponentConfig) => import("./motion-proxy").CustomDomComponent<Props>) & import("./types").HTMLMotionComponents & import("./types").SVGMotionComponents & {
+    custom: <Props>(Component: string | import("react").ComponentClass<Props, any> | import("react").FunctionComponent<Props>, { forwardMotionProps }?: import("./motion-proxy").DomMotionComponentConfig) => import("./motion-proxy").CustomDomComponent<Props>;
 };
 
 // @public (undocumented)
@@ -586,8 +585,6 @@ export const SharedLayoutContext: import("react").Context<SyncLayoutBatcher | Sh
 
 // @public (undocumented)
 export interface SharedLayoutProps {
-    // Warning: (ae-forgotten-export) The symbol "React" needs to be exported by the entry point index.d.ts
-    // 
     // (undocumented)
     children: React_2.ReactNode;
     type?: "switch" | "crossfade";
@@ -870,9 +867,9 @@ export interface VisualElement<Instance = any, MutableState = any> extends Lifec
     // (undocumented)
     getStaticValue(key: string): number | string | undefined;
     // (undocumented)
-    getValue(key: string, defaultValue: string | number): MotionValue;
-    // (undocumented)
     getValue(key: string): undefined | MotionValue;
+    // (undocumented)
+    getValue(key: string, defaultValue: string | number): MotionValue;
     // (undocumented)
     getValue(key: string, defaultValue?: string | number): undefined | MotionValue;
     // (undocumented)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "3.7.0",
     "description": "An open source and production-ready motion library for React on the web",
     "main": "dist/framer-motion.cjs.js",
-    "module": "dist/framer-motion.es.js",
+    "module": "dist/es/index.js",
     "types": "types/index.d.ts",
     "author": "Framer Motion",
     "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,9 +63,10 @@ const cjs = Object.assign({}, config, {
 
 const es = Object.assign({}, config, {
     output: {
-        file: `dist/${pkg.name}.es.js`,
         format: "es",
         exports: "named",
+        preserveModules: true,
+        dir: "dist/es",
     },
     plugins: [resolve()],
     external,

--- a/src/gestures/types.ts
+++ b/src/gestures/types.ts
@@ -1,1 +1,21 @@
+import { GestureHandlers } from "./use-gestures"
+
 export type RemoveEvent = () => void
+
+/**
+ * @internal
+ */
+export const gestureProps: Array<keyof GestureHandlers> = [
+    "onPan",
+    "onPanStart",
+    "onPanEnd",
+    "onPanSessionStart",
+    "onTap",
+    "onTapStart",
+    "onTapCancel",
+    "onHoverStart",
+    "onHoverEnd",
+    "whileFocus",
+    "whileTap",
+    "whileHover",
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export {
     SVGAttributesAsMotionValues,
     ForwardRefComponent,
 } from "./render/dom/types"
-export { CustomDomComponent } from "./render/dom/motion"
+export { CustomDomComponent } from "./render/dom/motion-proxy"
 export { ScrollMotionValues } from "./value/scroll/utils"
 export {
     AnimationProps,

--- a/src/motion/features/gestures.ts
+++ b/src/motion/features/gestures.ts
@@ -1,22 +1,8 @@
 import { MotionProps } from "../types"
-import { GestureHandlers, useGestures } from "../../gestures"
+import { useGestures } from "../../gestures"
+import { gestureProps } from "../../gestures/types"
 import { FeatureProps, MotionFeature } from "./types"
 import { makeRenderlessComponent } from "../utils/make-renderless-component"
-
-export const gestureProps: Array<keyof GestureHandlers> = [
-    "onPan",
-    "onPanStart",
-    "onPanEnd",
-    "onPanSessionStart",
-    "onTap",
-    "onTapStart",
-    "onTapCancel",
-    "onHoverStart",
-    "onHoverEnd",
-    "whileFocus",
-    "whileTap",
-    "whileHover",
-]
 
 const GestureComponent = makeRenderlessComponent(
     ({ visualElement, ...props }: FeatureProps) => {

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -1,4 +1,4 @@
-import { gestureProps } from "../features/gestures"
+import { gestureProps } from "../../gestures/types"
 import { MotionProps } from "../types"
 
 /**

--- a/src/render/dom/motion-minimal.ts
+++ b/src/render/dom/motion-minimal.ts
@@ -1,5 +1,5 @@
 import { MeasureLayout } from "../../motion/features/layout/Measure"
-import { createMotionProxy } from "./motion"
+import { createMotionProxy } from "./motion-proxy"
 
 /**
  * @public

--- a/src/render/dom/motion-proxy.ts
+++ b/src/render/dom/motion-proxy.ts
@@ -1,0 +1,99 @@
+import { warning } from "hey-listen"
+import {
+    createMotionComponent,
+    MotionComponentConfig,
+    MotionProps,
+} from "../../motion"
+import { MotionFeature } from "motion/features/types"
+import { createDomVisualElement } from "./create-dom-visual-element"
+import { MotionComponents } from "./types"
+import { createUseRender } from "./use-render"
+
+/**
+ * I'd rather the return type of `custom` to be implicit but this throws
+ * incorrect relative paths in the exported types and API Extractor throws
+ * a wobbly.
+ *
+ * @internal
+ */
+export type CustomDomComponent<Props> = React.ForwardRefExoticComponent<
+    React.PropsWithoutRef<Props & MotionProps> &
+        React.RefAttributes<SVGElement | HTMLElement>
+>
+
+export interface DomMotionComponentConfig {
+    forwardMotionProps?: boolean
+}
+
+/**
+ * Convert any React component into a `motion` component. The provided component
+ * **must** use `React.forwardRef` to the underlying DOM component you want to animate.
+ *
+ * ```jsx
+ * const Component = React.forwardRef((props, ref) => {
+ *   return <div ref={ref} />
+ * })
+ *
+ * const MotionComponent = motion(Component)
+ * ```
+ *
+ * @public
+ */
+export function createMotionProxy(defaultFeatures: MotionFeature[]) {
+    type DeprecatedCustomMotionComponent = {
+        custom: typeof custom
+    }
+
+    type Motion = typeof custom &
+        MotionComponents &
+        DeprecatedCustomMotionComponent
+
+    function custom<Props>(
+        Component: string | React.ComponentType<Props>,
+        { forwardMotionProps = false }: DomMotionComponentConfig = {}
+    ): CustomDomComponent<Props> {
+        const config: MotionComponentConfig<HTMLElement | SVGElement> = {
+            defaultFeatures,
+            createVisualElement: createDomVisualElement(Component),
+            useRender: createUseRender(Component, forwardMotionProps),
+        }
+
+        return createMotionComponent<Props, HTMLElement | SVGElement>(config)
+    }
+
+    function deprecatedCustom<Props>(
+        Component: string | React.ComponentType<Props>
+    ) {
+        warning(false, "motion.custom() is deprecated. Use motion() instead.")
+        return custom(Component, { forwardMotionProps: true })
+    }
+
+    /**
+     * A cache of generated `motion` components, e.g `motion.div`, `motion.input` etc.
+     * Rather than generating them anew every render.
+     */
+    const componentCache = new Map<string, any>()
+
+    return new Proxy(custom, {
+        /**
+         * Called when `motion` is referenced with a prop: `motion.div`, `motion.input` etc.
+         * The prop name is passed through as `key` and we can use that to generate a `motion`
+         * DOM component with that name.
+         */
+        get: (_target, key: string) => {
+            /**
+             * Can be removed in 4.0
+             */
+            if (key === "custom") return deprecatedCustom
+
+            /**
+             * If this element doesn't exist in the component cache, create it and cache.
+             */
+            if (!componentCache.has(key)) {
+                componentCache.set(key, custom(key))
+            }
+
+            return componentCache.get(key)!
+        },
+    }) as Motion
+}

--- a/src/render/dom/motion.ts
+++ b/src/render/dom/motion.ts
@@ -1,36 +1,14 @@
-import * as React from "react"
 import { createDomVisualElement } from "./create-dom-visual-element"
 import { createUseRender } from "./use-render"
-import { HTMLMotionComponents, SVGMotionComponents } from "./types"
-import {
-    MotionComponentConfig,
-    MotionProps,
-    createMotionComponent,
-} from "../../motion"
+import { MotionComponents } from "./types"
+import { MotionComponentConfig, createMotionComponent } from "../../motion"
 import { Drag } from "../../motion/features/drag"
 import { Gestures } from "../../motion/features/gestures"
 import { Exit } from "../../motion/features/exit"
 import { Animation } from "../../motion/features/animation"
 import { AnimateLayout } from "../../motion/features/layout/Animate"
 import { MeasureLayout } from "../../motion/features/layout/Measure"
-import { MotionFeature } from "../../motion/features/types"
-import { warning } from "hey-listen"
-
-/**
- * I'd rather the return type of `custom` to be implicit but this throws
- * incorrect relative paths in the exported types and API Extractor throws
- * a wobbly.
- */
-export type CustomDomComponent<Props> = React.ForwardRefExoticComponent<
-    React.PropsWithoutRef<Props & MotionProps> &
-        React.RefAttributes<SVGElement | HTMLElement>
->
-
-export interface DomMotionComponentConfig {
-    forwardMotionProps?: boolean
-}
-
-type MotionComponents = HTMLMotionComponents & SVGMotionComponents
+import { createMotionProxy } from "./motion-proxy"
 
 const allMotionFeatures = [
     MeasureLayout,
@@ -40,79 +18,6 @@ const allMotionFeatures = [
     Exit,
     AnimateLayout,
 ]
-
-/**
- * Convert any React component into a `motion` component. The provided component
- * **must** use `React.forwardRef` to the underlying DOM component you want to animate.
- *
- * ```jsx
- * const Component = React.forwardRef((props, ref) => {
- *   return <div ref={ref} />
- * })
- *
- * const MotionComponent = motion(Component)
- * ```
- *
- * @public
- */
-export function createMotionProxy(defaultFeatures: MotionFeature[]) {
-    type DeprecatedCustomMotionComponent = {
-        custom: typeof custom
-    }
-
-    type Motion = typeof custom &
-        MotionComponents &
-        DeprecatedCustomMotionComponent
-
-    function custom<Props>(
-        Component: string | React.ComponentType<Props>,
-        { forwardMotionProps = false }: DomMotionComponentConfig = {}
-    ): CustomDomComponent<Props> {
-        const config: MotionComponentConfig<HTMLElement | SVGElement> = {
-            defaultFeatures,
-            createVisualElement: createDomVisualElement(Component),
-            useRender: createUseRender(Component, forwardMotionProps),
-        }
-
-        return createMotionComponent<Props, HTMLElement | SVGElement>(config)
-    }
-
-    function deprecatedCustom<Props>(
-        Component: string | React.ComponentType<Props>
-    ) {
-        warning(false, "motion.custom() is deprecated. Use motion() instead.")
-        return custom(Component, { forwardMotionProps: true })
-    }
-
-    /**
-     * A cache of generated `motion` components, e.g `motion.div`, `motion.input` etc.
-     * Rather than generating them anew every render.
-     */
-    const componentCache = new Map<string, any>()
-
-    return new Proxy(custom, {
-        /**
-         * Called when `motion` is referenced with a prop: `motion.div`, `motion.input` etc.
-         * The prop name is passed through as `key` and we can use that to generate a `motion`
-         * DOM component with that name.
-         */
-        get: (_target, key: string) => {
-            /**
-             * Can be removed in 4.0
-             */
-            if (key === "custom") return deprecatedCustom
-
-            /**
-             * If this element doesn't exist in the component cache, create it and cache.
-             */
-            if (!componentCache.has(key)) {
-                componentCache.set(key, custom(key))
-            }
-
-            return componentCache.get(key)!
-        },
-    }) as Motion
-}
 
 /**
  * HTML & SVG components, optimised for use with gestures and animation. These can be used as

--- a/src/render/dom/types.ts
+++ b/src/render/dom/types.ts
@@ -180,3 +180,5 @@ export type SVGMotionComponents = {
         SVGMotionProps<UnwrapSVGFactoryElement<JSX.IntrinsicElements[K]>>
     >
 }
+
+export type MotionComponents = HTMLMotionComponents & SVGMotionComponents


### PR DESCRIPTION
Currently `framer-motion` doesn't tree-shake under Webpack. This is very noticable in component libraries such as Chakra-UI, where `framer-motion` is used very sparingly, but has a [large effect](https://github.com/chakra-ui/chakra-ui/issues/2693#issuecomment-758249931) on final bundle size.

In this minimal example:

```tsx
import { AnimationFeature, m as motion, MotionConfig } from 'framer-motion';

function App() {
  return (
     <MotionConfig features={[AnimationFeature]}>
       <motion.div
         className="container"
         initial={{ scale: 0 }}
         animate={{ rotate: 180, scale: 1 }}
         transition={{
           type: "spring",
           stiffness: 260,
           damping: 20
         }}
       />
     </MotionConfig>
  );
}
```

`framer-motion` takes 26.57 kB gzipped.

This PR does a couple of things:

1. Disables bundling entire library into a single ES module.
  I don't know about other bundlers, but Webpack [doesn't like](https://github.com/webpack/webpack/issues/9337#issuecomment-524966201) bundled libraries. 
  This effectively enabled tree-shaking and reduces bundle size to 20.05 kB gzipped.
  
2. Splits `motion.ts` into `motion-proxy.ts` . 
  Originally, `motion-minimal.ts` imported `motion.ts` in order to use `createMotionProxy`. Moving this function into a separate file allows Webpack to prune `motion.ts`.
  This reduces bundle size to 16.66 kB gzipped.
  
3. Moves `gestureProps` to `types.ts`.
  `gestureProps` were imported in `valid-prop.ts`, which inadvertly caused entire gesture feature to be bundled.
  This reduces bundle size to 14.91 kB gzipped.
  

In this minimal example, we saved a little over 11 kB gzipped.