### PR TITLE
Fixing perspective as style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.8.2] 2021-03-01
+
+### Fixed
+
+-   `perspective` now correctly set as its own `style`. `transformPerspective` still builds into `transform`.
+
 ## [3.8.1] 2021-03-01
 
 ### Changed

--- a/src/render/dom/utils/__tests__/build-html-styles.test.ts
+++ b/src/render/dom/utils/__tests__/build-html-styles.test.ts
@@ -32,6 +32,17 @@ describe("buildHTMLStyles", () => {
         })
     })
 
+    test("Builds perspective into the CSS perspective style", () => {
+        const latest = { perspective: 100, transform: "translateX(100px)" }
+        const style = {}
+        build(latest, { style })
+
+        expect(style).toEqual({
+            perspective: "100px",
+            transform: "translateX(100px)",
+        })
+    })
+
     test("Builds transform with defined value types", () => {
         const latest = { x: "1vw", y: "2%", rotateX: "90turn" }
         const style = {}

--- a/src/render/dom/utils/__tests__/build-transform.test.ts
+++ b/src/render/dom/utils/__tests__/build-transform.test.ts
@@ -1,5 +1,17 @@
 import "../../../../../jest.setup"
 import { buildTransform } from "../build-transform"
+import { isTransformProp } from "../transform"
+
+describe("isTransformProp", () => {
+    it("Correctly identifies only transformPerspective as a transform prop", () => {
+        expect(isTransformProp("perspective")).toBe(false)
+        expect(isTransformProp("transformPerspective")).toBe(true)
+    })
+    it("Correctly identifies translate and alias to be true", () => {
+        expect(isTransformProp("x")).toBe(true)
+        expect(isTransformProp("translateX")).toBe(true)
+    })
+})
 
 describe("buildTransform", () => {
     it("Outputs 'none' when transformIsDefault is true", () => {

--- a/src/render/dom/utils/transform.ts
+++ b/src/render/dom/utils/transform.ts
@@ -8,17 +8,18 @@ export const transformAxes = ["", "X", "Y", "Z"]
  * An ordered array of each transformable value. By default, transform values
  * will be sorted to this order.
  */
-const order = ["perspective", "translate", "scale", "rotate", "skew"]
+const order = ["translate", "scale", "rotate", "skew"]
 
 /**
  * Generate a list of every possible transform key.
  */
-export const transformProps = ["transformPerspective", "x", "y", "z"]
+export const transformProps = ["x", "y", "z"]
 order.forEach((operationKey) => {
     transformAxes.forEach((axesKey) => {
         const key = operationKey + axesKey
         transformProps.push(key)
     })
+    transformProps.unshift("transformPerspective")
 })
 
 /**

--- a/src/render/dom/utils/transform.ts
+++ b/src/render/dom/utils/transform.ts
@@ -13,14 +13,12 @@ const order = ["translate", "scale", "rotate", "skew"]
 /**
  * Generate a list of every possible transform key.
  */
-export const transformProps = ["x", "y", "z"]
-order.forEach((operationKey) => {
-    transformAxes.forEach((axesKey) => {
-        const key = operationKey + axesKey
-        transformProps.push(key)
-    })
-    transformProps.unshift("transformPerspective")
-})
+export const transformProps = ["transformPerspective", "x", "y", "z"]
+order.forEach((operationKey) =>
+    transformAxes.forEach((axesKey) =>
+        transformProps.push(operationKey + axesKey)
+    )
+)
 
 /**
  * A function to use with Array.sort to sort transform keys by their default order.


### PR DESCRIPTION
Currently, setting `style={{ perspective: 100 }}` outputs `transform: perspective(100px)`. This PR fixes it so it outputs `perspective: 100px`, and `transform` perspective must still be set as `transformPerspective`.