### PR TITLE
Fix path in motion-proxy

### DIFF
--- a/src/render/dom/motion-proxy.ts
+++ b/src/render/dom/motion-proxy.ts
@@ -4,7 +4,7 @@ import {
     MotionComponentConfig,
     MotionProps,
 } from "../../motion"
-import { MotionFeature } from "motion/features/types"
+import { MotionFeature } from "../../motion/features/types"
 import { createDomVisualElement } from "./create-dom-visual-element"
 import { MotionComponents } from "./types"
 import { createUseRender } from "./use-render"


### PR DESCRIPTION
There is wrong path in motion-proxy that trigger typescript when library imported.