### PR TITLE
useVelocity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export { MotionValue, motionValue, PassiveEffect, Subscriber } from "./value"
 export { resolveMotionValue } from "./value/utils/resolve-motion-value"
 export { useTransform } from "./value/use-transform"
 export { useSpring } from "./value/use-spring"
+export { useVelocity } from "./value/use-velocity"
 export { useElementScroll } from "./value/scroll/use-element-scroll"
 export { useViewportScroll } from "./value/scroll/use-viewport-scroll"
 

--- a/src/value/__tests__/use-velocity.test.tsx
+++ b/src/value/__tests__/use-velocity.test.tsx
@@ -1,0 +1,132 @@
+import { render } from "../../../jest.setup"
+import * as React from "react"
+import { useVelocity } from "../use-velocity"
+import { useMotionValue } from "../use-motion-value"
+import { animate } from "../../animation/animate"
+import sync, { getFrameData } from "framesync"
+
+const setFrameData = (interval: number, time: number) => {
+    const data = getFrameData()
+    data.timestamp = time
+    data.delta = interval
+}
+
+const syncDriver = (interval = 10) => (update: (v: number) => void) => {
+    let isRunning = true
+    return {
+        start: () => {
+            let time = 0
+            setTimeout(() => {
+                update(0)
+                while (isRunning) {
+                    time += interval
+                    setFrameData(interval, time)
+                    console.log(interval, time)
+                    update(interval)
+                }
+            }, 0)
+        },
+        stop: () => (isRunning = false),
+    }
+}
+
+describe("useVelocity", () => {
+    test("creates a motion value that updates with the velocity of the provided motion value", async () => {
+        const output: number[] = []
+        const outputVelocity: number[] = []
+        const outputAcceleration: number[] = []
+
+        const promise = new Promise((resolve) => {
+            const Component = () => {
+                const x = useMotionValue(0)
+                const xVelocity = useVelocity(x)
+                const xAcceleration = useVelocity(xVelocity)
+
+                React.useEffect(() => {
+                    x.onChange((v) => {
+                        output.push(Math.round(v))
+                    })
+                    xVelocity.onChange((v) => {
+                        outputVelocity.push(Math.round(v))
+                    })
+                    xAcceleration.onChange((v) => {
+                        outputAcceleration.push(Math.round(v))
+                    })
+
+                    animate(x, 1000, {
+                        duration: 0.1,
+                        ease: "easeInOut",
+                        driver: syncDriver(),
+                        onComplete: () => {
+                            /**
+                             * This stack is basically waiting x frames to allow
+                             * the derived values to "settle", as when a motion value
+                             * is set it sets a velocity check for the end of the following frame.
+                             * The more derivatives we have the more frames it'll take for
+                             * all values to settle.
+                             */
+                            sync.postRender(() => {
+                                setFrameData(10, 110)
+                                sync.postRender(() => {
+                                    setFrameData(10, 120)
+                                    sync.postRender(() => {
+                                        setFrameData(10, 130)
+                                        sync.postRender(() => {
+                                            setFrameData(10, 140)
+                                            resolve(undefined)
+                                        })
+                                    })
+                                })
+                            })
+                        },
+                    } as any)
+                }, [])
+
+                return null
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        await promise
+        expect(output).toEqual([
+            20,
+            80,
+            180,
+            320,
+            500,
+            680,
+            820,
+            920,
+            980,
+            1000,
+        ])
+        expect(outputVelocity).toEqual([
+            2000,
+            6000,
+            10000,
+            14000,
+            18000,
+            18000,
+            14000,
+            10000,
+            6000,
+            2000,
+            0,
+        ])
+        expect(outputAcceleration).toEqual([
+            200000,
+            400000,
+            400000,
+            400000,
+            400000,
+            -0,
+            -400000,
+            -400000,
+            -400000,
+            -50000,
+            0,
+        ])
+    })
+})

--- a/src/value/__tests__/use-velocity.test.tsx
+++ b/src/value/__tests__/use-velocity.test.tsx
@@ -21,7 +21,6 @@ const syncDriver = (interval = 10) => (update: (v: number) => void) => {
                 while (isRunning) {
                     time += interval
                     setFrameData(interval, time)
-                    console.log(interval, time)
                     update(interval)
                 }
             }, 0)

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -301,8 +301,6 @@ export class MotionValue<V = any> {
      * @public
      */
     getVelocity() {
-        // console.log(this.current, this.prev)
-
         // This could be isFloat(this.prev) && isFloat(this.current), but that would be wasteful
         return this.canTrackVelocity
             ? // These casts could be avoided if parseFloat would be typed better

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -62,6 +62,13 @@ export class MotionValue<V = any> {
     private updateSubscribers = subscriptionManager<Subscriber<V>>()
 
     /**
+     * Functions to notify when the velocity updates.
+     *
+     * @internal
+     */
+    public velocityUpdateSubscribers = subscriptionManager<Subscriber<V>>()
+
+    /**
      * Functions to notify when the `MotionValue` updates and `render` is set to `true`.
      *
      * @internal
@@ -246,6 +253,7 @@ export class MotionValue<V = any> {
 
         if (this.prev !== this.current) {
             this.updateSubscribers.notify(this.current)
+            this.velocityUpdateSubscribers.notify(this.getVelocity())
         }
 
         if (render) {
@@ -321,6 +329,7 @@ export class MotionValue<V = any> {
     private velocityCheck = ({ timestamp }: FrameData) => {
         if (timestamp !== this.lastUpdated) {
             this.prev = this.current
+            this.velocityUpdateSubscribers.notify(this.getVelocity())
         }
     }
 

--- a/src/value/use-on-change.ts
+++ b/src/value/use-on-change.ts
@@ -6,9 +6,9 @@ export function useOnChange<T>(
     value: MotionValue<T> | number | string,
     callback: Subscriber<T>
 ) {
-    useEffect(() =>
-        isMotionValue(value) ? value.onChange(callback) : undefined
-    )
+    useEffect(() => {
+        if (isMotionValue(value)) return value.onChange(callback)
+    }, [callback])
 }
 
 export function useMultiOnChange(values: MotionValue[], handler: () => void) {

--- a/src/value/use-velocity.ts
+++ b/src/value/use-velocity.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react"
+import { MotionValue } from "."
+import { useMotionValue } from "./use-motion-value"
+/**
+ * Creates a `MotionValue` that updates when the velocity of the provided `MotionValue` changes.
+ *
+ * ```javascript
+ * const x = useMotionValue(0)
+ * const xVelocity = useVelocity(x)
+ * const xAcceleration = useVelocity(xVelocity)
+ * ```
+ *
+ * @public
+ */
+export function useVelocity(value: MotionValue<number>): MotionValue<number> {
+    const velocity = useMotionValue(value.getVelocity())
+
+    useEffect(() => {
+        return value.velocityUpdateSubscribers.add((newVelocity) => {
+            velocity.set(newVelocity)
+        })
+    }, [value])
+
+    return velocity
+}


### PR DESCRIPTION
This PR adds a `useVelocity` hook. It accepts a motion value and returns a new one that updates with its velocity.

```javascript
const x = useMotionValue(0)
const xVelocity = useVelocity(x)
const scale = useTransform(xVelocity, [0, 1000], [1, 2], { clamp: false })
```

Fixes https://github.com/framer/motion/issues/1003

Demo: https://codesandbox.io/s/framer-motion-310-usevelocity-nw1dn?file=/src/Example.tsx