### PR TITLE
Add type overloads to be able to remove cast

### DIFF
--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -56,11 +56,7 @@ export function animateVisualElement(
     } else {
         const resolvedDefinition =
             typeof definition === "function"
-                ? (resolveVariant(
-                      visualElement,
-                      definition,
-                      options.custom
-                  ) as TargetAndTransition)
+                ? resolveVariant(visualElement, definition, options.custom)
                 : definition
         animation = animateTarget(visualElement, resolvedDefinition, options)
     }

--- a/src/render/utils/variants.ts
+++ b/src/render/utils/variants.ts
@@ -39,6 +39,20 @@ function getVelocity(visualElement: VisualElement) {
 
 export function resolveVariantFromProps(
     props: MotionProps,
+    definition: TargetAndTransition | TargetResolver,
+    custom?: any,
+    currentValues?: ResolvedValues,
+    currentVelocity?: ResolvedValues
+): TargetAndTransition
+export function resolveVariantFromProps(
+    props: MotionProps,
+    definition?: string | TargetAndTransition | TargetResolver,
+    custom?: any,
+    currentValues?: ResolvedValues,
+    currentVelocity?: ResolvedValues
+): undefined | TargetAndTransition
+export function resolveVariantFromProps(
+    props: MotionProps,
     definition?: string | TargetAndTransition | TargetResolver,
     custom?: any,
     currentValues: ResolvedValues = {},
@@ -56,6 +70,16 @@ export function resolveVariantFromProps(
 /**
  * Resovles a variant if it's a variant resolver
  */
+export function resolveVariant(
+    visualElement: VisualElement,
+    definition: TargetAndTransition | TargetResolver,
+    custom?: any
+): TargetAndTransition
+export function resolveVariant(
+    visualElement: VisualElement,
+    definition?: string | TargetAndTransition | TargetResolver,
+    custom?: any
+): TargetAndTransition | undefined
 export function resolveVariant(
     visualElement: VisualElement,
     definition?: string | TargetAndTransition | TargetResolver,


### PR DESCRIPTION
Fixes cast that was introduced here: https://github.com/framer/motion/pull/1014/files/c7ed186e70c25406b18a7b165b87137223283803#diff-16da2fe8f2bdf28120c951cce3e9fcefd9ea31e7fcdf6511a520ba3cb4b45558R57-R63