### PR TITLE
Only start a new layout animation when viewport box target changes

### DIFF
--- a/cypress/integration/layout.ts
+++ b/cypress/integration/layout.ts
@@ -69,7 +69,7 @@ describe("Layout animation", () => {
             })
     })
 
-    it.skip("Doesn't initiate a new animation if the viewport box hasn't updated between renders", () => {
+    it("Doesn't initiate a new animation if the viewport box hasn't updated between renders", () => {
         cy.visit("?test=layout-interrupt")
             .wait(50)
             .get("#box")

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "bundlesize": [
         {
             "path": "./dist/framer-motion.js",
-            "maxSize": "29.3 kB"
+            "maxSize": "29.4 kB"
         },
         {
             "path": "./dist/minimal-component.js",


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/807
Fixes https://github.com/framer/motion/issues/732
Closes https://github.com/framer/motion/pull/821

This PR ensures layout animations can't be interrupted by renders unless the target viewport box has changed.