### PR TITLE
Add "exports" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "A simple and powerful React animation library",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.js",
+    "exports": "./dist/es/index.js",
     "types": "types/index.d.ts",
     "author": "Framer",
     "license": "MIT",


### PR DESCRIPTION
Add "exports" field to package.json. This allows CDNs like https://jspm.org/ to use the esm version of the library to serve a better optimized bundle.

More info: https://jspm.org/docs/cdn#module-cdn-semantics