### PR TITLE
Fixing isControllingVariant bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--   `useMotionValue` now forces re-render on the Framer canvas.
+-   `useMotionValue` now forces re-render on the Framer canvas when the underlying `MotionValue` updates.
 
 ## [3.10.3] 2021-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.10.6] 2021-03-18
+
+### Fixed
+
+-   Various variant bugs.
+
 ## [3.10.5] 2021-03-15
 
 ### Fixed

--- a/src/motion/utils/use-visual-state.ts
+++ b/src/motion/utils/use-visual-state.ts
@@ -7,6 +7,7 @@ import {
 import { ResolvedValues, ScrapeMotionValuesFromProps } from "../../render/types"
 import {
     checkIfControllingVariants,
+    checkIfVariantNode,
     resolveVariantFromProps,
 } from "../../render/utils/variants"
 import { useConstant } from "../../utils/use-constant"
@@ -92,7 +93,7 @@ function makeLatestValues(
 
     let { initial, animate } = props
     const isControllingVariants = checkIfControllingVariants(props)
-    const isVariantNode = isControllingVariants || props.variants
+    const isVariantNode = checkIfVariantNode(props)
 
     if (
         context &&

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -641,7 +641,7 @@ export const visualElement = <Instance, MutableState, Options>({
          */
         getVariantContext(startAtParent = false) {
             if (startAtParent) return parent?.getVariantContext()
-            console.log(isControllingVariants)
+            // TODO Make this dynamic to fix
             if (!isControllingVariants) {
                 const context = parent?.getVariantContext() || {}
                 if (props.initial !== undefined) {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -328,7 +328,7 @@ export const visualElement = <Instance, MutableState, Options>({
          * any children that are also part of the tree. This is essentially
          * a shadow tree to simplify logic around how to stagger over children.
          */
-        variantChildren: undefined,
+        variantChildren: isVariantNode ? new Set() : undefined,
 
         /**
          * Whether this instance is visible. This can be changed imperatively
@@ -373,6 +373,10 @@ export const visualElement = <Instance, MutableState, Options>({
             instance = element.current = newInstance
             element.pointTo(element)
             removeFromMotionTree = parent?.addChild(element)
+
+            if (isVariantNode && parent && !isControllingVariants) {
+                removeFromVariantTree = parent?.addVariantChild(element)
+            }
         },
 
         /**

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -290,10 +290,7 @@ export const visualElement = <Instance, MutableState, Options>({
      * Determine what role this visual element should take in the variant tree.
      */
     const isControllingVariants = checkIfControllingVariants(props)
-    const definesInitialVariant = isVariantLabel(props.initial)
-    const isVariantNode = Boolean(
-        definesInitialVariant || isControllingVariants || props.variants
-    )
+    const isVariantNode = Boolean(isControllingVariants || props.variants)
 
     const element: VisualElement<Instance> = {
         treeType,

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -641,7 +641,7 @@ export const visualElement = <Instance, MutableState, Options>({
          */
         getVariantContext(startAtParent = false) {
             if (startAtParent) return parent?.getVariantContext()
-
+            console.log(isControllingVariants)
             if (!isControllingVariants) {
                 const context = parent?.getVariantContext() || {}
                 if (props.initial !== undefined) {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -641,8 +641,8 @@ export const visualElement = <Instance, MutableState, Options>({
          */
         getVariantContext(startAtParent = false) {
             if (startAtParent) return parent?.getVariantContext()
-            // TODO Make this dynamic to fix
-            if (!isControllingVariants) {
+
+            if (!checkIfControllingVariants(props)) {
                 const context = parent?.getVariantContext() || {}
                 if (props.initial !== undefined) {
                     context.initial = props.initial as any

--- a/src/render/utils/__tests__/animation-state.test.ts
+++ b/src/render/utils/__tests__/animation-state.test.ts
@@ -545,9 +545,9 @@ describe("Animation state - Setting props", () => {
         )
     })
 
-    test("Removing values, inherited variant changed from starting at undefined", () => {
+    test("Removing values, inherited variant changed from starting at empty variant", () => {
         const { element: parent, state: parentState } = createTest({
-            animate: undefined,
+            animate: "",
         })
         const { element: child, state: childState } = createTest({}, parent)
         child.manuallyAnimateOnMount = false
@@ -629,16 +629,11 @@ describe("Animation state - Setting props", () => {
             undefined,
             false
         )
-        parentState.setProps(
-            { animate: undefined },
-            undefined,
-            undefined,
-            false
-        )
+        parentState.setProps({ animate: "" }, undefined, undefined, false)
 
         child.animationState!.animateChanges()
         parent.animationState!.animateChanges()
-        expect(parentAnimate).not.toBeCalled()
+        expect(parentAnimate).toBeCalledWith([""])
         expect(childAnimate).toBeCalledWith([{ opacity: 0 }])
         expect(
             childState.getState()[AnimationType.Animate].protectedKeys

--- a/src/render/utils/__tests__/animation-state.test.ts
+++ b/src/render/utils/__tests__/animation-state.test.ts
@@ -140,7 +140,8 @@ describe("Animation state - Initiating props", () => {
         const { element: parent } = createTest({
             animate: "test",
         })
-        const { state } = createTest({}, parent)
+        const { element: child, state } = createTest({}, parent)
+        child.manuallyAnimateOnMount = false
 
         const animate = mockAnimate(state)
         state.setProps({
@@ -545,9 +546,8 @@ describe("Animation state - Setting props", () => {
     })
 
     test("Removing values, inherited variant changed from starting at undefined", () => {
-        console.log("++++ Test 3 ++++")
         const { element: parent, state: parentState } = createTest({
-            animate: "",
+            animate: undefined,
         })
         const { element: child, state: childState } = createTest({}, parent)
         child.manuallyAnimateOnMount = false

--- a/src/render/utils/__tests__/animation-state.test.ts
+++ b/src/render/utils/__tests__/animation-state.test.ts
@@ -22,6 +22,10 @@ const stateVisualElement = visualElement<
         return {}
     },
 
+    getBaseTarget(props, key) {
+        return props.style?.[key]
+    },
+
     readValueFromInstance(_state, key, options) {
         return options.initialState[key] || 0
     },
@@ -52,13 +56,22 @@ function createTest(
     )
     element.animationState = createAnimationState(element)
 
+    element.mount({})
+
     return {
         element: element,
         state: {
             ...element.animationState,
-            setProps(newProps: any, options: any, type: any): any {
+            setProps(
+                newProps: any,
+                options: any,
+                type: any,
+                animateChanges = true
+            ): any {
                 element.setProps(newProps)
-                return element.animationState?.animateChanges(options, type)
+                return animateChanges === true
+                    ? element.animationState?.animateChanges(options, type)
+                    : undefined
             },
         },
     }
@@ -74,582 +87,672 @@ function mockAnimate(state: AnimationState) {
     return mocked
 }
 
-describe("Animation state - Initiating props", () => {
-    test("Initial animation", () => {
-        const { state } = createTest()
+// describe("Animation state - Initiating props", () => {
+//     test("Initial animation", () => {
+//         const { state } = createTest()
 
-        const animate = mockAnimate(state)
-        state.setProps({
-            animate: { opacity: 1 },
-        })
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             animate: { opacity: 1 },
+//         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).toBeCalledWith([{ opacity: 1 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).toBeCalledWith([{ opacity: 1 }])
+//     })
+
+//     test("Initial animation with prop as variant", () => {
+//         const { state } = createTest()
+
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             animate: "test",
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).toBeCalledWith(["test"])
+//     })
+
+//     test("Initial animation with prop as variant list", () => {
+//         const { state } = createTest()
+
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             animate: ["test", "heyoo"],
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).toBeCalledWith(["test", "heyoo"])
+//     })
+
+//     test("Initial animation with prop as inherited variant", () => {
+//         const { element: parent } = createTest({
+//             animate: "test",
+//         })
+//         const { state } = createTest({}, parent)
+
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).not.toBeCalled()
+//     })
+
+//     test("Initial animation with initial=false", () => {
+//         const { state } = createTest()
+
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             initial: false,
+//             animate: { opacity: 1 },
+//         })
+
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).not.toBeCalled()
+//     })
+
+//     test("Initial animation with prop as variant with initial=false", () => {
+//         const { state } = createTest()
+
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             initial: false,
+//             animate: "test",
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).not.toBeCalled()
+//     })
+
+//     test("Initial animation with prop as variant list with initial=false", () => {
+//         const { state } = createTest()
+
+//         const animate = mockAnimate(state)
+//         state.setProps({
+//             initial: false,
+//             animate: ["test", "heyoo"],
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(animate).not.toBeCalled()
+//     })
+// })
+
+// describe("Animation state - Setting props", () => {
+//     test("No change, target", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: 1 },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: { opacity: 1 },
+//         })
+
+//         expect(animate).not.toBeCalled()
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+//             opacity: true,
+//         })
+//     })
+//     test("No change, target keyframes", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: [0, 1] },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: { opacity: [0, 1] },
+//         })
+
+//         expect(animate).not.toBeCalled()
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+//             opacity: true,
+//         })
+//     })
+
+//     test("No change, variant", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: "test",
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: "test",
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(animate).not.toBeCalled()
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+//             opacity: true,
+//         })
+//     })
+
+//     test("No change, variant list", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: ["test", "test2"],
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: ["test", "test2"],
+//             variants: {
+//                 test: { opacity: 1 },
+//             },
+//         })
+
+//         expect(animate).not.toBeCalled()
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+//             opacity: true,
+//         })
+//     })
+
+//     test("Change single value, target", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: 1 },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: { opacity: 0 },
+//         })
+
+//         expect(animate).toBeCalledWith([{ opacity: 0 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Change single value, keyframes", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: [0, 1] },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: { opacity: [0.5, 1] },
+//         })
+
+//         expect(animate).toBeCalledWith([{ opacity: [0.5, 1] }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Change single value, variant", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: "a",
+//             variants: {
+//                 a: { opacity: 0 },
+//                 b: { opacity: 1 },
+//             },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: "b",
+//             variants: {
+//                 a: { opacity: 0 },
+//                 b: { opacity: 1 },
+//             },
+//         })
+
+//         expect(animate).toBeCalledWith(["b"])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Change single value, variant list", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: ["a"],
+//             variants: {
+//                 a: { opacity: 0 },
+//                 b: { opacity: 1 },
+//             },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: ["b"],
+//             variants: {
+//                 a: { opacity: 0 },
+//                 b: { opacity: 1 },
+//             },
+//         })
+
+//         expect(animate).toBeCalledWith(["b"])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Swap between value in target and transitionEnd, target", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             style: { opacity: 0.1 },
+//             animate: { opacity: 0.2 },
+//         })
+
+//         let animate = mockAnimate(state)
+
+//         state.setProps({
+//             style: { opacity: 0.1 },
+//             animate: { transitionEnd: { opacity: 0.3 } },
+//         })
+
+//         expect(animate).toBeCalledWith([{ transitionEnd: { opacity: 0.3 } }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+
+//         animate = mockAnimate(state)
+
+//         state.setProps({
+//             style: { opacity: 0.1 },
+//             animate: { opacity: 0.2 },
+//         })
+//         expect(animate).toBeCalledWith([{ opacity: 0.2 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Change single value, target, with unchanging values", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: 1, x: 0 },
+//         })
+
+//         let animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: { opacity: 0, x: 0 },
+//         })
+
+//         expect(animate).toBeCalledWith([{ opacity: 0, x: 0 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+//             x: true,
+//         })
+
+//         animate = mockAnimate(state)
+
+//         state.setProps({
+//             animate: { opacity: 0, x: 100 },
+//         })
+
+//         expect(animate).toBeCalledWith([{ opacity: 0, x: 100 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+//             opacity: true,
+//         })
+//     })
+
+//     test("Removing values, target changed", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: 1 },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             style: { opacity: 0 },
+//             animate: {},
+//         })
+
+//         expect(animate).toBeCalledWith([{ opacity: 0 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Removing values, target undefined", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: { opacity: 1 },
+//         })
+
+//         const animate = mockAnimate(state)
+
+//         state.setProps({
+//             style: { opacity: 0 },
+//             animate: undefined,
+//         })
+
+//         expect(animate).toBeCalledWith([{ opacity: 0 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+// test("Removing values, variant changed", () => {
+//     const { state } = createTest()
+
+//     state.setProps({
+//         animate: "a",
+//         variants: {
+//             a: { opacity: 0 },
+//             b: { x: 1 },
+//         },
+//     })
+
+//     const animate = mockAnimate(state)
+
+//     state.setProps({
+//         style: { opacity: 1 },
+//         animate: "b",
+//         variants: {
+//             a: { opacity: 0 },
+//             b: { x: 1 },
+//         },
+//     })
+
+//     expect(animate).toBeCalledWith(["b", { opacity: 1 }])
+//     expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({})
+// })
+
+// test("Removing values, inherited variant changed", () => {
+//     const { element: parent } = createTest({ animate: "a" })
+//     const { state } = createTest({}, parent)
+
+//     state.setProps({
+//         variants: {
+//             a: { opacity: 0 },
+//             b: { x: 1 },
+//         },
+//     })
+
+//     const animate = mockAnimate(state)
+//     parent.setProps({ animate: "b" })
+//     state.setProps({
+//         style: { opacity: 1 },
+//         variants: {
+//             a: { opacity: 0 },
+//             b: { x: 1 },
+//         },
+//     })
+
+//     expect(animate).toBeCalledWith([{ opacity: 1 }])
+//     expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({})
+// })
+
+test("Removing values, inherited variant changed from starting at undefined", () => {
+    console.log("++++ Test 3 ++++")
+    const { element: parent, state: parentState } = createTest({
+        animate: "",
     })
+    const { element: child, state: childState } = createTest({}, parent)
 
-    test("Initial animation with prop as variant", () => {
-        const { state } = createTest()
-
-        const animate = mockAnimate(state)
-        state.setProps({
-            animate: "test",
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).toBeCalledWith(["test"])
-    })
-
-    test("Initial animation with prop as variant list", () => {
-        const { state } = createTest()
-
-        const animate = mockAnimate(state)
-        state.setProps({
-            animate: ["test", "heyoo"],
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).toBeCalledWith(["test", "heyoo"])
-    })
-
-    test("Initial animation with prop as inherited variant", () => {
-        const { element: parent } = createTest({
-            animate: "test",
-        })
-        const { state } = createTest({}, parent)
-
-        const animate = mockAnimate(state)
-        state.setProps({
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).not.toBeCalled()
-    })
-
-    test("Initial animation with initial=false", () => {
-        const { state } = createTest()
-
-        const animate = mockAnimate(state)
-        state.setProps({
-            initial: false,
-            animate: { opacity: 1 },
-        })
-
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).not.toBeCalled()
-    })
-
-    test("Initial animation with prop as variant with initial=false", () => {
-        const { state } = createTest()
-
-        const animate = mockAnimate(state)
-        state.setProps({
-            initial: false,
-            animate: "test",
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).not.toBeCalled()
-    })
-
-    test("Initial animation with prop as variant list with initial=false", () => {
-        const { state } = createTest()
-
-        const animate = mockAnimate(state)
-        state.setProps({
-            initial: false,
-            animate: ["test", "heyoo"],
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(animate).not.toBeCalled()
-    })
-})
-
-describe("Animation state - Setting props", () => {
-    test("No change, target", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: 1 },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: { opacity: 1 },
-        })
-
-        expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-            opacity: true,
-        })
-    })
-    test("No change, target keyframes", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: [0, 1] },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: { opacity: [0, 1] },
-        })
-
-        expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-            opacity: true,
-        })
-    })
-
-    test("No change, variant", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: "test",
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: "test",
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-            opacity: true,
-        })
-    })
-
-    test("No change, variant list", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: ["test", "test2"],
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: ["test", "test2"],
-            variants: {
-                test: { opacity: 1 },
-            },
-        })
-
-        expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-            opacity: true,
-        })
-    })
-
-    test("Change single value, target", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: 1 },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: { opacity: 0 },
-        })
-
-        expect(animate).toBeCalledWith([{ opacity: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    test("Change single value, keyframes", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: [0, 1] },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: { opacity: [0.5, 1] },
-        })
-
-        expect(animate).toBeCalledWith([{ opacity: [0.5, 1] }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    test("Change single value, variant", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: "a",
-            variants: {
-                a: { opacity: 0 },
-                b: { opacity: 1 },
-            },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: "b",
-            variants: {
-                a: { opacity: 0 },
-                b: { opacity: 1 },
-            },
-        })
-
-        expect(animate).toBeCalledWith(["b"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    test("Change single value, variant list", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: ["a"],
-            variants: {
-                a: { opacity: 0 },
-                b: { opacity: 1 },
-            },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
-            animate: ["b"],
-            variants: {
-                a: { opacity: 0 },
-                b: { opacity: 1 },
-            },
-        })
-
-        expect(animate).toBeCalledWith(["b"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    test("Swap between value in target and transitionEnd, target", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            style: { opacity: 0.1 },
-            animate: { opacity: 0.2 },
-        })
-
-        let animate = mockAnimate(state)
-
-        state.setProps({
-            style: { opacity: 0.1 },
-            animate: { transitionEnd: { opacity: 0.3 } },
-        })
-
-        expect(animate).toBeCalledWith([{ transitionEnd: { opacity: 0.3 } }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-
-        animate = mockAnimate(state)
-
-        state.setProps({
-            style: { opacity: 0.1 },
-            animate: { opacity: 0.2 },
-        })
-        expect(animate).toBeCalledWith([{ opacity: 0.2 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    test("Change single value, target, with unchanging values", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: 1, x: 0 },
-        })
-
-        let animate = mockAnimate(state)
-
-        state.setProps({
-            animate: { opacity: 0, x: 0 },
-        })
-
-        expect(animate).toBeCalledWith([{ opacity: 0, x: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-            x: true,
-        })
-
-        animate = mockAnimate(state)
-
-        state.setProps({
-            animate: { opacity: 0, x: 100 },
-        })
-
-        expect(animate).toBeCalledWith([{ opacity: 0, x: 100 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-            opacity: true,
-        })
-    })
-
-    test("Removing values, target changed", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: 1 },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
+    childState.setProps(
+        {
             style: { opacity: 0 },
-            animate: {},
-        })
+            variants: {
+                a: { opacity: 0.1 },
+                b: { opacity: 0.9 },
+            },
+        },
+        undefined,
+        undefined,
+        false
+    )
 
-        expect(animate).toBeCalledWith([{ opacity: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
+    let parentAnimate = mockAnimate(parentState)
+    let childAnimate = mockAnimate(childState)
 
-    test("Removing values, target undefined", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: { opacity: 1 },
-        })
-
-        const animate = mockAnimate(state)
-
-        state.setProps({
+    childState.setProps(
+        {
             style: { opacity: 0 },
-            animate: undefined,
-        })
-
-        expect(animate).toBeCalledWith([{ opacity: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    /**
-     * TODO: Un-skip these and validate before merge
-     */
-    test.skip("Removing values, variant changed", () => {
-        const { state } = createTest()
-
-        state.setProps({
-            animate: "a",
             variants: {
-                a: { opacity: 0 },
-                b: { x: 1 },
+                a: { opacity: 0.1 },
+                b: { opacity: 0.9 },
             },
-        })
+        },
+        undefined,
+        undefined,
+        false
+    )
+    parentState.setProps({ animate: "a" }, undefined, undefined, false)
 
-        const animate = mockAnimate(state)
+    child.animationState!.animateChanges()
+    parent.animationState!.animateChanges()
 
-        state.setProps({
-            style: { opacity: 1 },
-            animate: "b",
-            variants: {
-                a: { opacity: 0 },
-                b: { x: 1 },
-            },
-        })
+    expect(parentAnimate).toBeCalledWith(["a"])
+    expect(childAnimate).not.toBeCalled()
+    expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
+        {}
+    )
 
-        expect(animate).toBeCalledWith(["b", { opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
+    parentAnimate = mockAnimate(parentState)
+    childAnimate = mockAnimate(childState)
 
-    test.skip("Removing values, inherited variant changed", () => {
-        const { element: parent } = createTest({ animate: "a" })
-        const { state } = createTest({}, parent)
-
-        state.setProps({
-            variants: {
-                a: { opacity: 0 },
-                b: { x: 1 },
-            },
-        })
-
-        const animate = mockAnimate(state)
-        parent.setProps({ animate: "b" })
-        state.setProps({
-            style: { opacity: 1 },
-            variants: {
-                a: { opacity: 0 },
-                b: { x: 1 },
-            },
-        })
-
-        expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-})
-
-describe("Animation state - Set active", () => {
-    test("Change active state while props are the same", () => {
-        const { state } = createTest()
-
-        state.setProps({
+    childState.setProps(
+        {
             style: { opacity: 0 },
-            animate: { opacity: 1 },
-            whileHover: { opacity: 0.5 },
-            whileTap: { opacity: 0.8 },
-        })
+            variants: {
+                a: { opacity: 0.1 },
+                b: { opacity: 0.9 },
+            },
+        },
+        undefined,
+        undefined,
+        false
+    )
+    parentState.setProps({ animate: "b" }, undefined, undefined, false)
 
-        // Set hover to true
-        let animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
-        expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+    child.animationState!.animateChanges()
+    parent.animationState!.animateChanges()
+    expect(parentAnimate).toBeCalledWith(["b"])
+    expect(childAnimate).not.toBeCalled()
+    expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
+        {}
+    )
 
-        // Set hover to false
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
-        expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+    parentAnimate = mockAnimate(parentState)
+    childAnimate = mockAnimate(childState)
 
-        // Set hover to true
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
-        expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+    childState.setProps(
+        {
+            style: { opacity: 0 },
+            variants: {
+                a: { opacity: 0.1 },
+                b: { opacity: 0.9 },
+            },
+        },
+        undefined,
+        undefined,
+        false
+    )
+    parentState.setProps({ animate: undefined }, undefined, undefined, false)
 
-        // Set hover to false
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
-        expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
-
-        // Set hover to true
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
-        expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
-
-        // Set press to true
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Tap, true)
-        expect(animate).toBeCalledWith([{ opacity: 0.8 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(
-            state.getState()[AnimationType.Hover].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Tap].protectedKeys).toEqual({})
-
-        // Set hover to false
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(
-            state.getState()[AnimationType.Tap].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(animate).not.toBeCalled()
-
-        // Set press to false
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Tap, false)
-        expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-    })
-
-    test("Change active variant where no variants are defined", () => {
-        /**
-         * We should still animate back to lower-priority variants in case children need animating to
-         */
-        const { state } = createTest()
-
-        state.setProps({
-            animate: "a",
-            whileHover: "b",
-        })
-
-        // Set hover to true
-        let animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
-        expect(animate).toBeCalledWith(["b"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
-
-        // Set hover to false
-        animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
-        expect(animate).toBeCalledWith(["a"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
-    })
+    child.animationState!.animateChanges()
+    parent.animationState!.animateChanges()
+    expect(parentAnimate).not.toBeCalled()
+    expect(childAnimate).toBeCalledWith([{ opacity: 0 }])
+    expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
+        {}
+    )
 })
+// })
+
+// describe("Animation state - Set active", () => {
+//     test("Change active state while props are the same", () => {
+//         const { state } = createTest()
+
+//         state.setProps({
+//             style: { opacity: 0 },
+//             animate: { opacity: 1 },
+//             whileHover: { opacity: 0.5 },
+//             whileTap: { opacity: 0.8 },
+//         })
+
+//         // Set hover to true
+//         let animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, true)
+//         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
+//         expect(
+//             state.getState()[AnimationType.Animate].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+//         // Set hover to false
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, false)
+//         expect(animate).toBeCalledWith([{ opacity: 1 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+//         // Set hover to true
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, true)
+//         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
+//         expect(
+//             state.getState()[AnimationType.Animate].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+//         // Set hover to false
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, false)
+//         expect(animate).toBeCalledWith([{ opacity: 1 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+//         // Set hover to true
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, true)
+//         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
+//         expect(
+//             state.getState()[AnimationType.Animate].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+//         // Set press to true
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Tap, true)
+//         expect(animate).toBeCalledWith([{ opacity: 0.8 }])
+//         expect(
+//             state.getState()[AnimationType.Animate].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(
+//             state.getState()[AnimationType.Hover].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(state.getState()[AnimationType.Tap].protectedKeys).toEqual({})
+
+//         // Set hover to false
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, false)
+//         expect(
+//             state.getState()[AnimationType.Animate].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(
+//             state.getState()[AnimationType.Tap].protectedKeys
+//         ).toHaveProperty("opacity")
+//         expect(animate).not.toBeCalled()
+
+//         // Set press to false
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Tap, false)
+//         expect(animate).toBeCalledWith([{ opacity: 1 }])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//     })
+
+//     test("Change active variant where no variants are defined", () => {
+//         /**
+//          * We should still animate back to lower-priority variants in case children need animating to
+//          */
+//         const { state } = createTest()
+
+//         state.setProps({
+//             animate: "a",
+//             whileHover: "b",
+//         })
+
+//         // Set hover to true
+//         let animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, true)
+//         expect(animate).toBeCalledWith(["b"])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+//         // Set hover to false
+//         animate = mockAnimate(state)
+//         state.setActive(AnimationType.Hover, false)
+//         expect(animate).toBeCalledWith(["a"])
+//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+//             {}
+//         )
+//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+//     })
+// })

--- a/src/render/utils/__tests__/animation-state.test.ts
+++ b/src/render/utils/__tests__/animation-state.test.ts
@@ -581,7 +581,7 @@ test("Removing values, inherited variant changed from starting at undefined", ()
     parent.animationState!.animateChanges()
 
     expect(parentAnimate).toBeCalledWith(["a"])
-    expect(childAnimate).not.toBeCalled()
+    expect(childAnimate).toBeCalledWith(["a"])
     expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
         {}
     )
@@ -606,7 +606,7 @@ test("Removing values, inherited variant changed from starting at undefined", ()
     child.animationState!.animateChanges()
     parent.animationState!.animateChanges()
     expect(parentAnimate).toBeCalledWith(["b"])
-    expect(childAnimate).not.toBeCalled()
+    expect(childAnimate).toBeCalledWith(["b"])
     expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
         {}
     )

--- a/src/render/utils/__tests__/animation-state.test.ts
+++ b/src/render/utils/__tests__/animation-state.test.ts
@@ -87,672 +87,680 @@ function mockAnimate(state: AnimationState) {
     return mocked
 }
 
-// describe("Animation state - Initiating props", () => {
-//     test("Initial animation", () => {
-//         const { state } = createTest()
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             animate: { opacity: 1 },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).toBeCalledWith([{ opacity: 1 }])
-//     })
-
-//     test("Initial animation with prop as variant", () => {
-//         const { state } = createTest()
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             animate: "test",
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).toBeCalledWith(["test"])
-//     })
-
-//     test("Initial animation with prop as variant list", () => {
-//         const { state } = createTest()
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             animate: ["test", "heyoo"],
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).toBeCalledWith(["test", "heyoo"])
-//     })
-
-//     test("Initial animation with prop as inherited variant", () => {
-//         const { element: parent } = createTest({
-//             animate: "test",
-//         })
-//         const { state } = createTest({}, parent)
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).not.toBeCalled()
-//     })
-
-//     test("Initial animation with initial=false", () => {
-//         const { state } = createTest()
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             initial: false,
-//             animate: { opacity: 1 },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).not.toBeCalled()
-//     })
-
-//     test("Initial animation with prop as variant with initial=false", () => {
-//         const { state } = createTest()
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             initial: false,
-//             animate: "test",
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).not.toBeCalled()
-//     })
-
-//     test("Initial animation with prop as variant list with initial=false", () => {
-//         const { state } = createTest()
-
-//         const animate = mockAnimate(state)
-//         state.setProps({
-//             initial: false,
-//             animate: ["test", "heyoo"],
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(animate).not.toBeCalled()
-//     })
-// })
-
-// describe("Animation state - Setting props", () => {
-//     test("No change, target", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: 1 },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: { opacity: 1 },
-//         })
-
-//         expect(animate).not.toBeCalled()
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-//             opacity: true,
-//         })
-//     })
-//     test("No change, target keyframes", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: [0, 1] },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: { opacity: [0, 1] },
-//         })
-
-//         expect(animate).not.toBeCalled()
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-//             opacity: true,
-//         })
-//     })
-
-//     test("No change, variant", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: "test",
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: "test",
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(animate).not.toBeCalled()
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-//             opacity: true,
-//         })
-//     })
-
-//     test("No change, variant list", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: ["test", "test2"],
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: ["test", "test2"],
-//             variants: {
-//                 test: { opacity: 1 },
-//             },
-//         })
-
-//         expect(animate).not.toBeCalled()
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-//             opacity: true,
-//         })
-//     })
-
-//     test("Change single value, target", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: 1 },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: { opacity: 0 },
-//         })
-
-//         expect(animate).toBeCalledWith([{ opacity: 0 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-//     test("Change single value, keyframes", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: [0, 1] },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: { opacity: [0.5, 1] },
-//         })
-
-//         expect(animate).toBeCalledWith([{ opacity: [0.5, 1] }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-//     test("Change single value, variant", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: "a",
-//             variants: {
-//                 a: { opacity: 0 },
-//                 b: { opacity: 1 },
-//             },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: "b",
-//             variants: {
-//                 a: { opacity: 0 },
-//                 b: { opacity: 1 },
-//             },
-//         })
-
-//         expect(animate).toBeCalledWith(["b"])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-//     test("Change single value, variant list", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: ["a"],
-//             variants: {
-//                 a: { opacity: 0 },
-//                 b: { opacity: 1 },
-//             },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: ["b"],
-//             variants: {
-//                 a: { opacity: 0 },
-//                 b: { opacity: 1 },
-//             },
-//         })
-
-//         expect(animate).toBeCalledWith(["b"])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-//     test("Swap between value in target and transitionEnd, target", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             style: { opacity: 0.1 },
-//             animate: { opacity: 0.2 },
-//         })
-
-//         let animate = mockAnimate(state)
-
-//         state.setProps({
-//             style: { opacity: 0.1 },
-//             animate: { transitionEnd: { opacity: 0.3 } },
-//         })
-
-//         expect(animate).toBeCalledWith([{ transitionEnd: { opacity: 0.3 } }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-
-//         animate = mockAnimate(state)
-
-//         state.setProps({
-//             style: { opacity: 0.1 },
-//             animate: { opacity: 0.2 },
-//         })
-//         expect(animate).toBeCalledWith([{ opacity: 0.2 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-//     test("Change single value, target, with unchanging values", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: 1, x: 0 },
-//         })
-
-//         let animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: { opacity: 0, x: 0 },
-//         })
-
-//         expect(animate).toBeCalledWith([{ opacity: 0, x: 0 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-//             x: true,
-//         })
-
-//         animate = mockAnimate(state)
-
-//         state.setProps({
-//             animate: { opacity: 0, x: 100 },
-//         })
-
-//         expect(animate).toBeCalledWith([{ opacity: 0, x: 100 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
-//             opacity: true,
-//         })
-//     })
-
-//     test("Removing values, target changed", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: 1 },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             style: { opacity: 0 },
-//             animate: {},
-//         })
-
-//         expect(animate).toBeCalledWith([{ opacity: 0 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-//     test("Removing values, target undefined", () => {
-//         const { state } = createTest()
-
-//         state.setProps({
-//             animate: { opacity: 1 },
-//         })
-
-//         const animate = mockAnimate(state)
-
-//         state.setProps({
-//             style: { opacity: 0 },
-//             animate: undefined,
-//         })
-
-//         expect(animate).toBeCalledWith([{ opacity: 0 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
-
-// test("Removing values, variant changed", () => {
-//     const { state } = createTest()
-
-//     state.setProps({
-//         animate: "a",
-//         variants: {
-//             a: { opacity: 0 },
-//             b: { x: 1 },
-//         },
-//     })
-
-//     const animate = mockAnimate(state)
-
-//     state.setProps({
-//         style: { opacity: 1 },
-//         animate: "b",
-//         variants: {
-//             a: { opacity: 0 },
-//             b: { x: 1 },
-//         },
-//     })
-
-//     expect(animate).toBeCalledWith(["b", { opacity: 1 }])
-//     expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({})
-// })
-
-// test("Removing values, inherited variant changed", () => {
-//     const { element: parent } = createTest({ animate: "a" })
-//     const { state } = createTest({}, parent)
-
-//     state.setProps({
-//         variants: {
-//             a: { opacity: 0 },
-//             b: { x: 1 },
-//         },
-//     })
-
-//     const animate = mockAnimate(state)
-//     parent.setProps({ animate: "b" })
-//     state.setProps({
-//         style: { opacity: 1 },
-//         variants: {
-//             a: { opacity: 0 },
-//             b: { x: 1 },
-//         },
-//     })
-
-//     expect(animate).toBeCalledWith([{ opacity: 1 }])
-//     expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({})
-// })
-
-test("Removing values, inherited variant changed from starting at undefined", () => {
-    console.log("++++ Test 3 ++++")
-    const { element: parent, state: parentState } = createTest({
-        animate: "",
+describe("Animation state - Initiating props", () => {
+    test("Initial animation", () => {
+        const { state } = createTest()
+
+        const animate = mockAnimate(state)
+        state.setProps({
+            animate: { opacity: 1 },
+        })
+
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).toBeCalledWith([{ opacity: 1 }])
     })
-    const { element: child, state: childState } = createTest({}, parent)
 
-    childState.setProps(
-        {
-            style: { opacity: 0 },
+    test("Initial animation with prop as variant", () => {
+        const { state } = createTest()
+
+        const animate = mockAnimate(state)
+        state.setProps({
+            animate: "test",
             variants: {
-                a: { opacity: 0.1 },
-                b: { opacity: 0.9 },
+                test: { opacity: 1 },
             },
-        },
-        undefined,
-        undefined,
-        false
-    )
+        })
 
-    let parentAnimate = mockAnimate(parentState)
-    let childAnimate = mockAnimate(childState)
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).toBeCalledWith(["test"])
+    })
 
-    childState.setProps(
-        {
-            style: { opacity: 0 },
+    test("Initial animation with prop as variant list", () => {
+        const { state } = createTest()
+
+        const animate = mockAnimate(state)
+        state.setProps({
+            animate: ["test", "heyoo"],
             variants: {
-                a: { opacity: 0.1 },
-                b: { opacity: 0.9 },
+                test: { opacity: 1 },
             },
-        },
-        undefined,
-        undefined,
-        false
-    )
-    parentState.setProps({ animate: "a" }, undefined, undefined, false)
+        })
 
-    child.animationState!.animateChanges()
-    parent.animationState!.animateChanges()
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).toBeCalledWith(["test", "heyoo"])
+    })
 
-    expect(parentAnimate).toBeCalledWith(["a"])
-    expect(childAnimate).toBeCalledWith(["a"])
-    expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
-        {}
-    )
+    test("Initial animation with prop as inherited variant", () => {
+        const { element: parent } = createTest({
+            animate: "test",
+        })
+        const { state } = createTest({}, parent)
 
-    parentAnimate = mockAnimate(parentState)
-    childAnimate = mockAnimate(childState)
-
-    childState.setProps(
-        {
-            style: { opacity: 0 },
+        const animate = mockAnimate(state)
+        state.setProps({
             variants: {
-                a: { opacity: 0.1 },
-                b: { opacity: 0.9 },
+                test: { opacity: 1 },
             },
-        },
-        undefined,
-        undefined,
-        false
-    )
-    parentState.setProps({ animate: "b" }, undefined, undefined, false)
+        })
 
-    child.animationState!.animateChanges()
-    parent.animationState!.animateChanges()
-    expect(parentAnimate).toBeCalledWith(["b"])
-    expect(childAnimate).toBeCalledWith(["b"])
-    expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
-        {}
-    )
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).not.toBeCalled()
+    })
 
-    parentAnimate = mockAnimate(parentState)
-    childAnimate = mockAnimate(childState)
+    test("Initial animation with initial=false", () => {
+        const { state } = createTest()
 
-    childState.setProps(
-        {
-            style: { opacity: 0 },
+        const animate = mockAnimate(state)
+        state.setProps({
+            initial: false,
+            animate: { opacity: 1 },
+        })
+
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).not.toBeCalled()
+    })
+
+    test("Initial animation with prop as variant with initial=false", () => {
+        const { state } = createTest()
+
+        const animate = mockAnimate(state)
+        state.setProps({
+            initial: false,
+            animate: "test",
             variants: {
-                a: { opacity: 0.1 },
-                b: { opacity: 0.9 },
+                test: { opacity: 1 },
             },
-        },
-        undefined,
-        undefined,
-        false
-    )
-    parentState.setProps({ animate: undefined }, undefined, undefined, false)
+        })
 
-    child.animationState!.animateChanges()
-    parent.animationState!.animateChanges()
-    expect(parentAnimate).not.toBeCalled()
-    expect(childAnimate).toBeCalledWith([{ opacity: 0 }])
-    expect(childState.getState()[AnimationType.Animate].protectedKeys).toEqual(
-        {}
-    )
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).not.toBeCalled()
+    })
+
+    test("Initial animation with prop as variant list with initial=false", () => {
+        const { state } = createTest()
+
+        const animate = mockAnimate(state)
+        state.setProps({
+            initial: false,
+            animate: ["test", "heyoo"],
+            variants: {
+                test: { opacity: 1 },
+            },
+        })
+
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(animate).not.toBeCalled()
+    })
 })
-// })
 
-// describe("Animation state - Set active", () => {
-//     test("Change active state while props are the same", () => {
-//         const { state } = createTest()
+describe("Animation state - Setting props", () => {
+    test("No change, target", () => {
+        const { state } = createTest()
 
-//         state.setProps({
-//             style: { opacity: 0 },
-//             animate: { opacity: 1 },
-//             whileHover: { opacity: 0.5 },
-//             whileTap: { opacity: 0.8 },
-//         })
+        state.setProps({
+            animate: { opacity: 1 },
+        })
 
-//         // Set hover to true
-//         let animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, true)
-//         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-//         expect(
-//             state.getState()[AnimationType.Animate].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        const animate = mockAnimate(state)
 
-//         // Set hover to false
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, false)
-//         expect(animate).toBeCalledWith([{ opacity: 1 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        state.setProps({
+            animate: { opacity: 1 },
+        })
 
-//         // Set hover to true
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, true)
-//         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-//         expect(
-//             state.getState()[AnimationType.Animate].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        expect(animate).not.toBeCalled()
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+            opacity: true,
+        })
+    })
+    test("No change, target keyframes", () => {
+        const { state } = createTest()
 
-//         // Set hover to false
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, false)
-//         expect(animate).toBeCalledWith([{ opacity: 1 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        state.setProps({
+            animate: { opacity: [0, 1] },
+        })
 
-//         // Set hover to true
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, true)
-//         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-//         expect(
-//             state.getState()[AnimationType.Animate].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        const animate = mockAnimate(state)
 
-//         // Set press to true
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Tap, true)
-//         expect(animate).toBeCalledWith([{ opacity: 0.8 }])
-//         expect(
-//             state.getState()[AnimationType.Animate].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(
-//             state.getState()[AnimationType.Hover].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(state.getState()[AnimationType.Tap].protectedKeys).toEqual({})
+        state.setProps({
+            animate: { opacity: [0, 1] },
+        })
 
-//         // Set hover to false
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, false)
-//         expect(
-//             state.getState()[AnimationType.Animate].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(
-//             state.getState()[AnimationType.Tap].protectedKeys
-//         ).toHaveProperty("opacity")
-//         expect(animate).not.toBeCalled()
+        expect(animate).not.toBeCalled()
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+            opacity: true,
+        })
+    })
 
-//         // Set press to false
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Tap, false)
-//         expect(animate).toBeCalledWith([{ opacity: 1 }])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//     })
+    test("No change, variant", () => {
+        const { state } = createTest()
 
-//     test("Change active variant where no variants are defined", () => {
-//         /**
-//          * We should still animate back to lower-priority variants in case children need animating to
-//          */
-//         const { state } = createTest()
+        state.setProps({
+            animate: "test",
+            variants: {
+                test: { opacity: 1 },
+            },
+        })
 
-//         state.setProps({
-//             animate: "a",
-//             whileHover: "b",
-//         })
+        const animate = mockAnimate(state)
 
-//         // Set hover to true
-//         let animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, true)
-//         expect(animate).toBeCalledWith(["b"])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        state.setProps({
+            animate: "test",
+            variants: {
+                test: { opacity: 1 },
+            },
+        })
 
-//         // Set hover to false
-//         animate = mockAnimate(state)
-//         state.setActive(AnimationType.Hover, false)
-//         expect(animate).toBeCalledWith(["a"])
-//         expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-//             {}
-//         )
-//         expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
-//     })
-// })
+        expect(animate).not.toBeCalled()
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+            opacity: true,
+        })
+    })
+
+    test("No change, variant list", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: ["test", "test2"],
+            variants: {
+                test: { opacity: 1 },
+            },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            animate: ["test", "test2"],
+            variants: {
+                test: { opacity: 1 },
+            },
+        })
+
+        expect(animate).not.toBeCalled()
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+            opacity: true,
+        })
+    })
+
+    test("Change single value, target", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: { opacity: 1 },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            animate: { opacity: 0 },
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: 0 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Change single value, keyframes", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: { opacity: [0, 1] },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            animate: { opacity: [0.5, 1] },
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: [0.5, 1] }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Change single value, variant", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: "a",
+            variants: {
+                a: { opacity: 0 },
+                b: { opacity: 1 },
+            },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            animate: "b",
+            variants: {
+                a: { opacity: 0 },
+                b: { opacity: 1 },
+            },
+        })
+
+        expect(animate).toBeCalledWith(["b"])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Change single value, variant list", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: ["a"],
+            variants: {
+                a: { opacity: 0 },
+                b: { opacity: 1 },
+            },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            animate: ["b"],
+            variants: {
+                a: { opacity: 0 },
+                b: { opacity: 1 },
+            },
+        })
+
+        expect(animate).toBeCalledWith(["b"])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Swap between value in target and transitionEnd, target", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            style: { opacity: 0.1 },
+            animate: { opacity: 0.2 },
+        })
+
+        let animate = mockAnimate(state)
+
+        state.setProps({
+            style: { opacity: 0.1 },
+            animate: { transitionEnd: { opacity: 0.3 } },
+        })
+
+        expect(animate).toBeCalledWith([{ transitionEnd: { opacity: 0.3 } }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+
+        animate = mockAnimate(state)
+
+        state.setProps({
+            style: { opacity: 0.1 },
+            animate: { opacity: 0.2 },
+        })
+        expect(animate).toBeCalledWith([{ opacity: 0.2 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Change single value, target, with unchanging values", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: { opacity: 1, x: 0 },
+        })
+
+        let animate = mockAnimate(state)
+
+        state.setProps({
+            animate: { opacity: 0, x: 0 },
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: 0, x: 0 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+            x: true,
+        })
+
+        animate = mockAnimate(state)
+
+        state.setProps({
+            animate: { opacity: 0, x: 100 },
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: 0, x: 100 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+            opacity: true,
+        })
+    })
+
+    test("Removing values, target changed", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: { opacity: 1 },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            style: { opacity: 0 },
+            animate: {},
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: 0 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Removing values, target undefined", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: { opacity: 1 },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            style: { opacity: 0 },
+            animate: undefined,
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: 0 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Removing values, variant changed", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            animate: "a",
+            variants: {
+                a: { opacity: 0 },
+                b: { x: 1 },
+            },
+        })
+
+        const animate = mockAnimate(state)
+
+        state.setProps({
+            style: { opacity: 1 },
+            animate: "b",
+            variants: {
+                a: { opacity: 0 },
+                b: { x: 1 },
+            },
+        })
+
+        expect(animate).toBeCalledWith(["b", { opacity: 1 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Removing values, inherited variant changed", () => {
+        const { element: parent } = createTest({ animate: "a" })
+        const { state } = createTest({}, parent)
+
+        state.setProps({
+            variants: {
+                a: { opacity: 0 },
+                b: { x: 1 },
+            },
+        })
+
+        const animate = mockAnimate(state)
+        parent.setProps({ animate: "b" })
+        state.setProps({
+            style: { opacity: 1 },
+            variants: {
+                a: { opacity: 0 },
+                b: { x: 1 },
+            },
+        })
+
+        expect(animate).toBeCalledWith([{ opacity: 1 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Removing values, inherited variant changed from starting at undefined", () => {
+        console.log("++++ Test 3 ++++")
+        const { element: parent, state: parentState } = createTest({
+            animate: "",
+        })
+        const { element: child, state: childState } = createTest({}, parent)
+        child.manuallyAnimateOnMount = false
+        childState.setProps(
+            {
+                style: { opacity: 0 },
+                variants: {
+                    a: { opacity: 0.1 },
+                    b: { opacity: 0.9 },
+                },
+            },
+            undefined,
+            undefined,
+            false
+        )
+
+        let parentAnimate = mockAnimate(parentState)
+        let childAnimate = mockAnimate(childState)
+
+        childState.setProps(
+            {
+                style: { opacity: 0 },
+                variants: {
+                    a: { opacity: 0.1 },
+                    b: { opacity: 0.9 },
+                },
+            },
+            undefined,
+            undefined,
+            false
+        )
+        parentState.setProps({ animate: "a" }, undefined, undefined, false)
+        child.animationState!.animateChanges()
+        parent.animationState!.animateChanges()
+
+        expect(parentAnimate).toBeCalledWith(["a"])
+        expect(childAnimate).not.toBeCalled()
+        expect(
+            childState.getState()[AnimationType.Animate].protectedKeys
+        ).toEqual({})
+
+        parentAnimate = mockAnimate(parentState)
+        childAnimate = mockAnimate(childState)
+
+        childState.setProps(
+            {
+                style: { opacity: 0 },
+                variants: {
+                    a: { opacity: 0.1 },
+                    b: { opacity: 0.9 },
+                },
+            },
+            undefined,
+            undefined,
+            false
+        )
+        parentState.setProps({ animate: "b" }, undefined, undefined, false)
+
+        child.animationState!.animateChanges()
+        parent.animationState!.animateChanges()
+        expect(parentAnimate).toBeCalledWith(["b"])
+        expect(childAnimate).not.toBeCalled()
+        expect(
+            childState.getState()[AnimationType.Animate].protectedKeys
+        ).toEqual({})
+
+        parentAnimate = mockAnimate(parentState)
+        childAnimate = mockAnimate(childState)
+
+        childState.setProps(
+            {
+                style: { opacity: 0 },
+                variants: {
+                    a: { opacity: 0.1 },
+                    b: { opacity: 0.9 },
+                },
+            },
+            undefined,
+            undefined,
+            false
+        )
+        parentState.setProps(
+            { animate: undefined },
+            undefined,
+            undefined,
+            false
+        )
+
+        child.animationState!.animateChanges()
+        parent.animationState!.animateChanges()
+        expect(parentAnimate).not.toBeCalled()
+        expect(childAnimate).toBeCalledWith([{ opacity: 0 }])
+        expect(
+            childState.getState()[AnimationType.Animate].protectedKeys
+        ).toEqual({})
+    })
+})
+
+describe("Animation state - Set active", () => {
+    test("Change active state while props are the same", () => {
+        const { state } = createTest()
+
+        state.setProps({
+            style: { opacity: 0 },
+            animate: { opacity: 1 },
+            whileHover: { opacity: 0.5 },
+            whileTap: { opacity: 0.8 },
+        })
+
+        // Set hover to true
+        let animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, true)
+        expect(animate).toBeCalledWith([{ opacity: 0.5 }])
+        expect(
+            state.getState()[AnimationType.Animate].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+        // Set hover to false
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, false)
+        expect(animate).toBeCalledWith([{ opacity: 1 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+        // Set hover to true
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, true)
+        expect(animate).toBeCalledWith([{ opacity: 0.5 }])
+        expect(
+            state.getState()[AnimationType.Animate].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+        // Set hover to false
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, false)
+        expect(animate).toBeCalledWith([{ opacity: 1 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+        // Set hover to true
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, true)
+        expect(animate).toBeCalledWith([{ opacity: 0.5 }])
+        expect(
+            state.getState()[AnimationType.Animate].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+        // Set press to true
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Tap, true)
+        expect(animate).toBeCalledWith([{ opacity: 0.8 }])
+        expect(
+            state.getState()[AnimationType.Animate].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(
+            state.getState()[AnimationType.Hover].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(state.getState()[AnimationType.Tap].protectedKeys).toEqual({})
+
+        // Set hover to false
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, false)
+        expect(
+            state.getState()[AnimationType.Animate].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(
+            state.getState()[AnimationType.Tap].protectedKeys
+        ).toHaveProperty("opacity")
+        expect(animate).not.toBeCalled()
+
+        // Set press to false
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Tap, false)
+        expect(animate).toBeCalledWith([{ opacity: 1 }])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+    })
+
+    test("Change active variant where no variants are defined", () => {
+        /**
+         * We should still animate back to lower-priority variants in case children need animating to
+         */
+        const { state } = createTest()
+
+        state.setProps({
+            animate: "a",
+            whileHover: "b",
+        })
+
+        // Set hover to true
+        let animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, true)
+        expect(animate).toBeCalledWith(["b"])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+
+        // Set hover to false
+        animate = mockAnimate(state)
+        state.setActive(AnimationType.Hover, false)
+        expect(animate).toBeCalledWith(["a"])
+        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
+            {}
+        )
+        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+    })
+})

--- a/src/render/utils/animation-state.ts
+++ b/src/render/utils/animation-state.ts
@@ -109,6 +109,7 @@ export function createAnimationState(
     ) {
         const props = visualElement.getProps()
         const context = visualElement.getVariantContext(true) || {}
+        console.log("prop", props.animate, context)
 
         /**
          * A list of animations that we'll build into as we iterate through the animation
@@ -181,7 +182,7 @@ export function createAnimationState(
              * be any key that has been animated or otherwise handled by active, higher-priortiy types.
              */
             typeState.protectedKeys = { ...encounteredKeys }
-
+            console.log("trying to animate", type, prop)
             // Check if we can skip analysing this prop early
             if (
                 // If it isn't active and hasn't *just* been set as inactive
@@ -194,7 +195,7 @@ export function createAnimationState(
             ) {
                 continue
             }
-
+            if (AnimationType.Animate) console.log(prop)
             /**
              * As we go look through the values defined on this type, if we detect
              * a changed value or a value that was removed in a higher priority, we set
@@ -210,12 +211,16 @@ export function createAnimationState(
                 // If we removed a higher-priority variant (i is in reverse order)
                 (i > removedVariantIndex && propIsVariant)
 
+            if (AnimationType.Animate)
+                console.log("shouldAnimateType:", shouldAnimateType)
             /**
              * As animations can be set as variant lists, variants or target objects, we
              * coerce everything to an array if it isn't one already
              */
             const definitionList = Array.isArray(prop) ? prop : [prop]
 
+            if (AnimationType.Animate)
+                console.log("definitionList", definitionList)
             /**
              * Build an object of all the resolved values. We'll use this in the subsequent
              * animateChanges calls to determine whether a value has changed.
@@ -339,11 +344,12 @@ export function createAnimationState(
             const fallbackAnimation = {}
             removedKeys.forEach((key) => {
                 const fallbackTarget = visualElement.getBaseTarget(key)
+                console.log(key, fallbackTarget)
                 if (fallbackTarget !== undefined) {
                     fallbackAnimation[key] = fallbackTarget
                 }
             })
-
+            console.log("fallback animation", fallbackAnimation)
             animations.push({ animation: fallbackAnimation })
         }
 

--- a/src/render/utils/animation-state.ts
+++ b/src/render/utils/animation-state.ts
@@ -109,7 +109,6 @@ export function createAnimationState(
     ) {
         const props = visualElement.getProps()
         const context = visualElement.getVariantContext(true) || {}
-        console.log("prop", props.animate, context)
 
         /**
          * A list of animations that we'll build into as we iterate through the animation
@@ -182,7 +181,7 @@ export function createAnimationState(
              * be any key that has been animated or otherwise handled by active, higher-priortiy types.
              */
             typeState.protectedKeys = { ...encounteredKeys }
-            console.log("trying to animate", type, prop)
+
             // Check if we can skip analysing this prop early
             if (
                 // If it isn't active and hasn't *just* been set as inactive
@@ -195,7 +194,7 @@ export function createAnimationState(
             ) {
                 continue
             }
-            if (AnimationType.Animate) console.log(prop)
+
             /**
              * As we go look through the values defined on this type, if we detect
              * a changed value or a value that was removed in a higher priority, we set
@@ -211,16 +210,12 @@ export function createAnimationState(
                 // If we removed a higher-priority variant (i is in reverse order)
                 (i > removedVariantIndex && propIsVariant)
 
-            if (AnimationType.Animate)
-                console.log("shouldAnimateType:", shouldAnimateType)
             /**
              * As animations can be set as variant lists, variants or target objects, we
              * coerce everything to an array if it isn't one already
              */
             const definitionList = Array.isArray(prop) ? prop : [prop]
 
-            if (AnimationType.Animate)
-                console.log("definitionList", definitionList)
             /**
              * Build an object of all the resolved values. We'll use this in the subsequent
              * animateChanges calls to determine whether a value has changed.
@@ -344,12 +339,11 @@ export function createAnimationState(
             const fallbackAnimation = {}
             removedKeys.forEach((key) => {
                 const fallbackTarget = visualElement.getBaseTarget(key)
-                console.log(key, fallbackTarget)
                 if (fallbackTarget !== undefined) {
                     fallbackAnimation[key] = fallbackTarget
                 }
             })
-            console.log("fallback animation", fallbackAnimation)
+
             animations.push({ animation: fallbackAnimation })
         }
 
@@ -364,6 +358,7 @@ export function createAnimationState(
         }
 
         isInitialRender = false
+
         return shouldAnimate ? animate(animations) : Promise.resolve()
     }
 

--- a/src/render/utils/variants.ts
+++ b/src/render/utils/variants.ts
@@ -107,3 +107,7 @@ export function checkIfControllingVariants(props: MotionProps) {
         isVariantLabel(props.exit)
     )
 }
+
+export function checkIfVariantNode(props: MotionProps) {
+    return Boolean(checkIfControllingVariants(props) || props.variants)
+}


### PR DESCRIPTION
Fixes variant inheritence bugs

Note: This doesn't include the fix for the linked sandbox, it's recommended not to change the inferred variant tree. As effects are executed bottom-up there's no easy moment between updating props and firing animations to reestablish the variant tree

https://codesandbox.io/s/motion-bug-forked-4l2t5