### PR TITLE
Adds package.json to exports field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.0.0] Unreleased
+## [4.0.1] 2021-03-22
+
+### Fixed
+
+-   Adding `package.json` to `exports` so it can be imported by Next.js.
+
+## [4.0.0] 2021-03-19
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "4.0.0",
+    "version": "4.0.1-rc.0",
     "description": "A simple and powerful React animation library",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.js",
     "exports": {
+        "package.json": "./package.json",
         "require": "./dist/framer-motion.cjs.js",
         "import": "./dist/es/index.js",
         "default": "./dist/es/index.js"


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/1050

Adding `exports` to `package.json` actually breaks direct imports (ie `import from "framer-motion/package.json"`)

This PR adds a specific export for `package.json`. Seems backwards, but is apparently legit.