### PR TITLE
[DOCUMENTATION] Specify the unit for PanInfo#velocity

### DIFF
--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -117,7 +117,7 @@ export interface PanInfo {
      */
     offset: Point2D
     /**
-     * Contains `x` and `y` values for the current velocity of the pointer.
+     * Contains `x` and `y` values for the current velocity of the pointer, in px/ms.
      *
      * @library
      *


### PR DESCRIPTION
This extends the documentation for the `PanInfo` type to specify that the `velocity` vector is expressed in px per millisecond. That's my understanding from reading the code at least. This came up while trying to convert some gesture code from another library which used px per second.