### PR TITLE
Animate zeros as target/origin value type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.1.0] Unreleased
+## [4.1.1] 2021-04-01
+
+### Fixed
+
+-   Animating from `undefined` to number (including units) now animates from `0`.
+
+## [4.1.0] 2021-03-31
 
 ### Added
 

--- a/dev/examples/Animation-CSS-variables.tsx
+++ b/dev/examples/Animation-CSS-variables.tsx
@@ -10,6 +10,7 @@ const style = {
     width: 100,
     height: 100,
     background: "var(--from)",
+    x: "var(--x)",
 }
 
 export const App = () => {
@@ -36,8 +37,10 @@ export const App = () => {
                 }}
                 animate={{
                     background: `var(--token-666a5765-0e05-4d0e-b396-a6c555d9cdb3, hsl(125, 74%, 43%)) /* {"name":"Goblin Green"} */`,
+                    "--x": "100px",
                 }}
                 transition={transition}
+                onUpdate={(v) => console.log(v)}
                 style={style}
             />
         </div>

--- a/src/animation/utils/__tests__/transitions.test.ts
+++ b/src/animation/utils/__tests__/transitions.test.ts
@@ -232,6 +232,7 @@ describe("isZero", () => {
         expect(isZero(5)).toBe(false)
         expect(isZero("#000")).toBe(false)
         expect(isZero("5%")).toBe(false)
+        expect(isZero("0px 0px")).toBe(false)
     })
 })
 

--- a/src/animation/utils/__tests__/transitions.test.ts
+++ b/src/animation/utils/__tests__/transitions.test.ts
@@ -4,7 +4,8 @@ import {
     getDelayFromTransition,
     hydrateKeyframes,
     getPopmotionAnimationOptions,
-    convertZeroToUnit,
+    getZeroUnit,
+    isZero,
 } from "../transitions"
 import {
     underDampedSpring,
@@ -224,14 +225,20 @@ describe("getPopmotionAnimationOptions", () => {
     })
 })
 
-describe("convertZeroToUnit", () => {
-    test("correctly converts zeroes to the other unit type", () => {
-        expect(convertZeroToUnit(0, "5px")).toBe("0px")
-        expect(convertZeroToUnit(0, "5%")).toBe("0%")
-        expect(convertZeroToUnit(20, "5px")).toBe(20)
-        expect(convertZeroToUnit("20px", 0)).toBe("20px")
-        expect(convertZeroToUnit("20px", 0)).toBe("20px")
-        expect(convertZeroToUnit("0%", "100px")).toBe("0px")
-        expect(convertZeroToUnit("0%", 100)).toBe(0)
+describe("isZero", () => {
+    test("correctly detects zero values", () => {
+        expect(isZero(0)).toBe(true)
+        expect(isZero("0px")).toBe(true)
+        expect(isZero(5)).toBe(false)
+        expect(isZero("#000")).toBe(false)
+        expect(isZero("5%")).toBe(false)
+    })
+})
+
+describe("getZeroUnit", () => {
+    test("correctly converts zeroes to the unit type of provided value", () => {
+        expect(getZeroUnit("5px")).toBe("0px")
+        expect(getZeroUnit("5%")).toBe("0%")
+        expect(getZeroUnit(5)).toBe(0)
     })
 })

--- a/src/animation/utils/__tests__/transitions.test.ts
+++ b/src/animation/utils/__tests__/transitions.test.ts
@@ -4,6 +4,7 @@ import {
     getDelayFromTransition,
     hydrateKeyframes,
     getPopmotionAnimationOptions,
+    convertZeroToUnit,
 } from "../transitions"
 import {
     underDampedSpring,
@@ -220,5 +221,17 @@ describe("getPopmotionAnimationOptions", () => {
             from: 50,
             to: [50, 100],
         })
+    })
+})
+
+describe("convertZeroToUnit", () => {
+    test("correctly converts zeroes to the other unit type", () => {
+        expect(convertZeroToUnit(0, "5px")).toBe("0px")
+        expect(convertZeroToUnit(0, "5%")).toBe("0%")
+        expect(convertZeroToUnit(20, "5px")).toBe(20)
+        expect(convertZeroToUnit("20px", 0)).toBe("20px")
+        expect(convertZeroToUnit("20px", 0)).toBe("20px")
+        expect(convertZeroToUnit("0%", "100px")).toBe("0px")
+        expect(convertZeroToUnit("0%", 100)).toBe(0)
     })
 })

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -168,13 +168,14 @@ function getAnimation(
          * of the target. This could be improved to work both ways.
          */
         origin = getAnimatableNone(key, target)
-    } else if (!Array.isArray(target) && typeof origin !== typeof target) {
-        /**
-         * If there's a type mismatch between origin and target, coerce any 0 values into
-         * the string value type
-         */
-        origin = convertZeroToUnit(origin, target)
-        target = convertZeroToUnit(target, origin)
+    } else if (isZero(origin) && typeof target === "string") {
+        origin = getZeroUnit(target)
+    } else if (
+        !Array.isArray(target) &&
+        isZero(target) &&
+        typeof origin === "string"
+    ) {
+        target = getZeroUnit(origin)
     }
 
     const isOriginAnimatable = isAnimatable(key, origin)
@@ -227,19 +228,14 @@ function getAnimation(
         : start
 }
 
-export function convertZeroToUnit(
-    source: string | number,
+export function isZero(value: string | number) {
+    return value === 0 || (typeof value === "string" && parseFloat(value) === 0)
+}
+
+export function getZeroUnit(
     potentialUnitType: string | number
 ): string | number {
-    const sourceAsNumber =
-        typeof source === "number" ? source : parseFloat(source)
-
-    if (sourceAsNumber !== 0) return source
-
-    return getValueAsType(
-        sourceAsNumber,
-        findDimensionValueType(potentialUnitType)
-    )
+    return getValueAsType(0, findDimensionValueType(potentialUnitType))
 }
 
 export function getValueTransition(transition: Transition, key: string) {

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -175,6 +175,7 @@ function getAnimation(
         isZero(target) &&
         typeof origin === "string"
     ) {
+        console.log("b")
         target = getZeroUnit(origin)
     }
 
@@ -229,7 +230,12 @@ function getAnimation(
 }
 
 export function isZero(value: string | number) {
-    return value === 0 || (typeof value === "string" && parseFloat(value) === 0)
+    return (
+        value === 0 ||
+        (typeof value === "string" &&
+            parseFloat(value) === 0 &&
+            value.indexOf(" ") === -1)
+    )
 }
 
 export function getZeroUnit(

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -175,7 +175,6 @@ function getAnimation(
         isZero(target) &&
         typeof origin === "string"
     ) {
-        console.log("b")
         target = getZeroUnit(origin)
     }
 


### PR DESCRIPTION
This PR will check if we're animating to/from a `0` or `0` equivalent (`"0%"`, `"0px"` etc), from/to a value with a unit type. If so, it will convert the `0` into the target unit type.

This enables patterns like:

```jsx
<motion.div initial={{ x: 0 }} animate={{ x: "100%" }} />
```

It also allows the animation of unencountered styles or CSS variables (which default to `0` when read from the DOM):

```jsx
<motion.div animate={{ "--foo": "100%" }} />
```

