### PR TITLE
useMotionRef not updating callback

### DIFF
--- a/src/motion/utils/use-motion-ref.ts
+++ b/src/motion/utils/use-motion-ref.ts
@@ -31,6 +31,6 @@ export function useMotionRef<Instance, RenderState>(
                 }
             }
         },
-        [visualElement]
+        [visualElement, visualState, externalRef]
     )
 }


### PR DESCRIPTION
When using a callback as ref the useMotionRef callback is never updated because it isn't in the deps list.

```jsx
const MyComponent = ({ somethingThatChanges }) => {

  const callbackRef = useCallback(() => {
    // This only triggers once, even if `callbackRef` updates.
    console.log(somethingThatChanges);
  }, [somethingThatChanges])

  return <motion.div ref={callbackRef} ... />
}
```