### PR TITLE
Disable hover on drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.1.4] 2021-04-15
+
+### Fixed
+
+-   Disabling hover events when a drag is active.
+
 ## [4.1.3] 2021-04-07
 
 ### Fixed

--- a/src/gestures/use-hover-gesture.ts
+++ b/src/gestures/use-hover-gesture.ts
@@ -4,6 +4,7 @@ import { AnimationType } from "../render/utils/types"
 import { usePointerEvent } from "../events/use-pointer-event"
 import { VisualElement } from "../render/types"
 import { FeatureProps } from "../motion/features/types"
+import { isDragActive } from "./drag/utils/lock"
 
 function createHoverEvent(
     visualElement: VisualElement,
@@ -11,7 +12,14 @@ function createHoverEvent(
     callback?: (event: MouseEvent, info: EventInfo) => void
 ) {
     return (event: MouseEvent, info: EventInfo) => {
-        if (!isMouseEvent(event) || !visualElement.isHoverEventsEnabled) return
+        if (
+            !isMouseEvent(event) ||
+            !visualElement.isHoverEventsEnabled ||
+            isDragActive()
+        ) {
+            return
+        }
+
         callback?.(event, info)
         visualElement.animationState?.setActive(AnimationType.Hover, isActive)
     }


### PR DESCRIPTION
This PR disables hover events while a drag event is active. In Framer this will ensure we don't trigger hover state changes while a drag gesture is active.