### PR TITLE
Relative projection fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.1.5] 2021-04-15
+
+### Fixed
+
+-   Being more conservative with when we perform relative projection.
+
 ## [4.1.4] 2021-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--   Being more conservative with when we perform relative projection.
+-   Layout projection improvements.
 
 ## [4.1.4] 2021-04-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "4.1.4",
+    "version": "4.1.5-rc.0",
     "description": "A simple and powerful React animation library",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.js",

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -153,9 +153,11 @@ class Animate extends React.Component<AnimateProps> {
             }
 
             if (prevParentViewportBox) {
-                isRelative = true
-                origin = calcRelativeOffset(prevParentViewportBox, origin)
-                target = calcRelativeOffset(parentLayout, target)
+                if (prevParent || (!prevParent && !(originBox || targetBox))) {
+                    isRelative = true
+                    origin = calcRelativeOffset(prevParentViewportBox, origin)
+                    target = calcRelativeOffset(parentLayout, target)
+                }
             }
         }
 

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -16,6 +16,7 @@ import { LayoutProps } from "./types"
 import { axisBox } from "../../../utils/geometry"
 import { addScaleCorrection } from "../../../render/dom/projection/scale-correction"
 import { defaultScaleCorrectors } from "../../../render/dom/projection/default-scale-correctors"
+import { VisualElement } from "../../../render/types"
 
 interface AxisLocks {
     x?: () => void
@@ -152,12 +153,17 @@ class Animate extends React.Component<AnimateProps> {
                 }
             }
 
-            if (prevParentViewportBox) {
-                if (prevParent || (!prevParent && !(originBox || targetBox))) {
-                    isRelative = true
-                    origin = calcRelativeOffset(prevParentViewportBox, origin)
-                    target = calcRelativeOffset(parentLayout, target)
-                }
+            if (
+                prevParentViewportBox &&
+                isProvidedCorrectDataForRelativeSharedLayout(
+                    prevParent,
+                    originBox,
+                    targetBox
+                )
+            ) {
+                isRelative = true
+                origin = calcRelativeOffset(prevParentViewportBox, origin)
+                target = calcRelativeOffset(parentLayout, target)
             }
         }
 
@@ -334,4 +340,12 @@ function axisIsEqual(a: Axis, b: Axis) {
 const defaultLayoutTransition = {
     duration: 0.45,
     ease: [0.4, 0, 0.1, 1],
+}
+
+function isProvidedCorrectDataForRelativeSharedLayout(
+    prevParent?: VisualElement,
+    originBox?: AxisBox2D,
+    targetBox?: AxisBox2D
+) {
+    return prevParent || (!prevParent && !(originBox || targetBox))
 }


### PR DESCRIPTION
This PR introduces two fixes to layout projection.

1. It is more defensive about when it performs a layout animation relatively. If either an `originBox` or `targetBox` is explicitly defined **without** reference to a different parent component, we revert to viewport projection. This ensures we don't calculate a relative position to the wrong component.
2. The layout animation batcher in `AnimateSharedLayout` schedules a job to overwrite the `prevViewportBox` snapshot with the live `projection` data. This ensures that any nested `AnimateSharedLayout` components attempting to calculate a relative position aren't doing so against an out-of-date snapshot. 