### PR TITLE
Nested drag fixes

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -733,8 +733,6 @@ export interface SyncLayoutLifecycles {
     // (undocumented)
     layoutReady: (child: VisualElement) => void;
     // (undocumented)
-    measureLayout: (child: VisualElement) => void;
-    // (undocumented)
     parent?: VisualElement;
 }
 
@@ -915,6 +913,8 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     build(): RenderState;
     // (undocumented)
+    children: Set<VisualElement>;
+    // (undocumented)
     current: Instance | null;
     // (undocumented)
     depth: number;
@@ -949,9 +949,9 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     getStaticValue(key: string): number | string | undefined;
     // (undocumented)
-    getValue(key: string, defaultValue: string | number): MotionValue;
-    // (undocumented)
     getValue(key: string, defaultValue?: string | number): undefined | MotionValue;
+    // (undocumented)
+    getValue(key: string, defaultValue: string | number): MotionValue;
     // (undocumented)
     getValue(key: string): undefined | MotionValue;
     // (undocumented)
@@ -976,6 +976,8 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     isPresent: boolean;
     // (undocumented)
+    isProjecting: () => boolean;
+    // (undocumented)
     isStatic?: boolean;
     isVisible?: boolean;
     // (undocumented)
@@ -994,6 +996,8 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     mount(instance: Instance): void;
     // (undocumented)
     notifyLayoutReady(config?: SharedLayoutAnimationConfig): void;
+    // (undocumented)
+    parent?: VisualElement;
     // (undocumented)
     path: VisualElement[];
     // (undocumented)
@@ -1023,6 +1027,8 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     resolveRelativeTargetBox(): void;
     // (undocumented)
+    restoreTransform(): void;
+    // (undocumented)
     scheduleRender(): void;
     // (undocumented)
     scheduleUpdateLayoutProjection(): void;
@@ -1039,13 +1045,9 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     setVisibility(visibility: boolean): void;
     // (undocumented)
-    snapshotTimestamp?: number;
-    // (undocumented)
-    snapshotViewportBox(): void;
-    // (undocumented)
     sortNodePosition(element: VisualElement): number;
     // (undocumented)
-    startLayoutAnimation(axis: "x" | "y", transition: Transition): Promise<any>;
+    startLayoutAnimation(axis: "x" | "y", transition: Transition, isRelative: boolean): Promise<any>;
     // (undocumented)
     stopLayoutAnimation(): void;
     // (undocumented)
@@ -1059,15 +1061,11 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     unmount(): void;
     // (undocumented)
-    updateLayoutMeasurement(): void;
-    // (undocumented)
     updateLayoutProjection(): void;
     // (undocumented)
     updateTreeLayoutProjection(): void;
     // (undocumented)
     variantChildren?: Set<VisualElement>;
-    // (undocumented)
-    withoutTransform(callback: () => void): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "VisualElementConfig" needs to be exported by the entry point index.d.ts

--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -951,9 +951,9 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     getValue(key: string, defaultValue: string | number): MotionValue;
     // (undocumented)
-    getValue(key: string): undefined | MotionValue;
-    // (undocumented)
     getValue(key: string, defaultValue?: string | number): undefined | MotionValue;
+    // (undocumented)
+    getValue(key: string): undefined | MotionValue;
     // (undocumented)
     getVariant(name: string): Variant | undefined;
     // (undocumented)
@@ -1038,6 +1038,8 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     setStaticValue(key: string, value: number | string): void;
     // (undocumented)
     setVisibility(visibility: boolean): void;
+    // (undocumented)
+    snapshotTimestamp?: number;
     // (undocumented)
     snapshotViewportBox(): void;
     // (undocumented)

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
     "baseUrl": "http://0.0.0.0:9990",
-    "video": false
+    "video": true
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
     "baseUrl": "http://0.0.0.0:9990",
-    "video": true
+    "video": false
 }

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -357,11 +357,36 @@ function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
             })
         })
         .wait(30)
+        .get("#child")
+        .trigger("pointerup", { force: true })
+        .wait(50)
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 250,
+                left: 250,
+                width: 600,
+                height: 200,
+            })
+        })
+        .get("#parent")
+        .should(([$parent]: any) => {
+            expectBbox($parent, {
+                top: 200,
+                left: 100,
+                width: 300,
+                height: 300,
+            })
+        })
 }
 
-describe.skip("Nested drag with alternate draggable axes", () => {
-    it("Parent: layout, Child: layout", () => testAlternateAxes(true, true))
-    it("Parent: layout", () => testAlternateAxes(true, false))
-    it("Child: layout", () => testAlternateAxes(false, true))
+describe("Nested drag with alternate draggable axes", () => {
+    /**
+     * Skipping for now as there are still issues when either draggable
+     * component is also involved in layout animation
+     */
+    it.skip("Parent: layout, Child: layout", () =>
+        testAlternateAxes(true, true))
+    it.skip("Parent: layout", () => testAlternateAxes(true, false))
+    it.skip("Child: layout", () => testAlternateAxes(false, true))
     it("Neither", () => testAlternateAxes(false, false))
 })

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -29,7 +29,6 @@ function testNestedDrag(parentLayout: boolean, childLayout: boolean) {
                 height: 300,
             })
         })
-
         .get("#child")
         .should(([$child]: any) => {
             expectBbox($child, {
@@ -89,6 +88,7 @@ function testNestedDrag(parentLayout: boolean, childLayout: boolean) {
         })
         .get("#parent")
         .trigger("pointerdown", 5, 5)
+        .wait(20)
         .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
         .wait(50)
         .trigger("pointermove", 50, 50)
@@ -112,29 +112,6 @@ function testNestedDrag(parentLayout: boolean, childLayout: boolean) {
                 height: 200,
             })
         })
-    // .trigger("pointerdown", 5, 5)
-    // .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
-    // .wait(50)
-    // .trigger("pointermove", 100, 100, { force: true })
-    // .wait(50)
-    // .trigger("pointerup", { force: true })
-    // .should(([$parent]: any) => {
-    //     expectBbox($parent, {
-    //         top: 200,
-    //         left: 300,
-    //         width: 300,
-    //         height: 300,
-    //     })
-    // })
-    // .get("#child")
-    // .should(([$child]: any) => {
-    //     expectBbox($child, {
-    //         top: 350,
-    //         left: 450,
-    //         width: 600,
-    //         height: 200,
-    //     })
-    // })
 }
 
 describe("Nested drag", () => {
@@ -143,3 +120,135 @@ describe("Nested drag", () => {
     it("Child: layout", () => testNestedDrag(false, true))
     it("Neither", () => testNestedDrag(false, false))
 })
+
+function testNestedDragConstraints(
+    parentLayout: boolean,
+    childLayout: boolean
+) {
+    let url = `?test=drag-layout-nested&constraints=true`
+    if (parentLayout) url += `&parentLayout=true`
+    if (childLayout) url += `&childLayout=true`
+
+    cy.visit(url)
+        .get("#parent")
+        .trigger("pointerdown", 40, 40)
+        .trigger("pointermove", 35, 35) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 20, 20)
+        .wait(50)
+        .trigger("pointerup")
+        .should(([$parent]: any) => {
+            // Should have only moved 10 px to the top
+            expectBbox($parent, {
+                top: 90,
+                left: 75,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 140,
+                left: 125,
+                width: 600,
+                height: 200,
+            })
+        })
+        .get("#parent")
+        .trigger("pointerdown", 5, 5)
+        .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 200, 100)
+        .wait(50)
+        .trigger("pointerup")
+        .should(([$parent]: any) => {
+            expectBbox($parent, {
+                top: 190,
+                left: 200,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 240,
+                left: 250,
+                width: 600,
+                height: 200,
+            })
+        })
+        .trigger("pointerdown", 5, 5, { force: true })
+        .trigger("pointermove", 10, 10, { force: true }) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 200, 100, { force: true })
+        .wait(50)
+        .trigger("pointerup")
+        .get("#parent")
+        .should(([$parent]: any) => {
+            expectBbox($parent, {
+                top: 190,
+                left: 200,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 340,
+                left: 350,
+                width: 600,
+                height: 200,
+            })
+        })
+        .wait(20)
+        .get("#parent")
+        .trigger("pointerdown", { clientX: 210, clientY: 200, force: true })
+        .trigger("pointermove", { clientX: 205, clientY: 195, force: true }) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", { clientX: 110, clientY: 100, force: true })
+        .wait(50)
+        .trigger("pointerup")
+        .should(([$parent]: any) => {
+            // Should have only moved 10 px to the top
+            expectBbox($parent, {
+                top: 90,
+                left: 100,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 240,
+                left: 250,
+                width: 600,
+                height: 200,
+            })
+        })
+}
+
+describe("Nested drag with constraints", () => {
+    it("Parent: layout, Child: layout", () =>
+        testNestedDragConstraints(true, true))
+    it("Parent: layout", () => testNestedDragConstraints(true, false))
+    it("Child: layout", () => testNestedDragConstraints(false, true))
+    it("Neither", () => testNestedDragConstraints(false, false))
+})
+
+// function testNestedDragConstraints(parentLayout: boolean, childLayout: boolean) {
+//     let url = `?test=drag-layout-nested&constraints=true`
+//     if (parentLayout) url += `&parentLayout=true`
+//     if (childLayout) url += `&childLayout=true`
+//     cy.visit(url)
+// }
+
+// describe("Nested drag with constraints", () => {
+//     it("Parent: layout, Child: layout", () => testNestedDragConstraints(true, true))
+//     it("Parent: layout", () => testNestedDragConstraints(true, false))
+//     it("Child: layout", () => testNestedDragConstraints(false, true))
+//     it("Neither", () => testNestedDragConstraints(false, false))
+// })

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -84,7 +84,7 @@ function testNestedDrag(query: string) {
         })
 }
 
-describe.skip("Nested drag", () => {
+describe("Nested drag", () => {
     it("Parent: layout, Child: layout", () =>
         testNestedDrag("parentLayout=true&childLayout=true"))
     it("Parent: layout", () => testNestedDrag("parentLayout=true"))

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -337,7 +337,7 @@ function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
         .trigger("pointerdown", 5, 5, { force: true })
         .trigger("pointermove", 10, 10, { force: true })
         .wait(50)
-        .trigger("pointermove", 100, 100, { force: true })
+        .trigger("pointermove", 110, 110, { force: true })
         .wait(50)
         .should(([$child]: any) => {
             expectBbox($child, {
@@ -359,7 +359,7 @@ function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
         .wait(30)
 }
 
-describe("Nested drag with alternate draggable axes", () => {
+describe.skip("Nested drag with alternate draggable axes", () => {
     it("Parent: layout, Child: layout", () => testAlternateAxes(true, true))
     it("Parent: layout", () => testAlternateAxes(true, false))
     it("Child: layout", () => testAlternateAxes(false, true))

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -182,7 +182,7 @@ function testNestedDragConstraints(
         .trigger("pointerdown", 5, 5, { force: true })
         .trigger("pointermove", 10, 10, { force: true }) // Gesture will start from first move past threshold
         .wait(50)
-        .trigger("pointermove", 200, 100, { force: true })
+        .trigger("pointermove", 300, 100, { force: true })
         .wait(50)
         .trigger("pointerup")
         .get("#parent")
@@ -203,32 +203,31 @@ function testNestedDragConstraints(
                 height: 200,
             })
         })
-        .wait(20)
-        .get("#parent")
-        .trigger("pointerdown", { clientX: 210, clientY: 200, force: true })
-        .trigger("pointermove", { clientX: 205, clientY: 195, force: true }) // Gesture will start from first move past threshold
-        .wait(50)
-        .trigger("pointermove", { clientX: 110, clientY: 100, force: true })
-        .wait(50)
-        .trigger("pointerup")
-        .should(([$parent]: any) => {
-            // Should have only moved 10 px to the top
-            expectBbox($parent, {
-                top: 90,
-                left: 100,
-                width: 300,
-                height: 300,
-            })
-        })
-        .get("#child")
-        .should(([$child]: any) => {
-            expectBbox($child, {
-                top: 240,
-                left: 250,
-                width: 600,
-                height: 200,
-            })
-        })
+    // .wait(20)
+    // .get("#parent")
+    // .trigger("pointerdown", { clientX: 210, clientY: 200, force: true })
+    // .trigger("pointermove", { clientX: 205, clientY: 195, force: true }) // Gesture will start from first move past threshold
+    // .wait(50)
+    // .trigger("pointermove", { clientX: 110, clientY: 100, force: true })
+    // .wait(50)
+    // .trigger("pointerup")
+    // .should(([$parent]: any) => {
+    //     expectBbox($parent, {
+    //         top: 90,
+    //         left: 100,
+    //         width: 300,
+    //         height: 300,
+    //     })
+    // })
+    // .get("#child")
+    // .should(([$child]: any) => {
+    //     expectBbox($child, {
+    //         top: 240,
+    //         left: 250,
+    //         width: 600,
+    //         height: 200,
+    //     })
+    // })
 }
 
 describe("Nested drag with constraints", () => {
@@ -239,16 +238,91 @@ describe("Nested drag with constraints", () => {
     it("Neither", () => testNestedDragConstraints(false, false))
 })
 
-// function testNestedDragConstraints(parentLayout: boolean, childLayout: boolean) {
-//     let url = `?test=drag-layout-nested&constraints=true`
-//     if (parentLayout) url += `&parentLayout=true`
-//     if (childLayout) url += `&childLayout=true`
-//     cy.visit(url)
-// }
+function testNestedDragConstraintsAndAnimation(
+    parentLayout: boolean,
+    childLayout: boolean
+) {
+    let url = `?test=drag-layout-nested&constraints=true&animation=true`
+    if (parentLayout) url += `&parentLayout=true`
+    if (childLayout) url += `&childLayout=true`
+    cy.visit(url)
+        .get("#parent")
+        .trigger("pointerdown", 5, 10)
+        .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 200, 10, { force: true })
+        .wait(50)
+        .should(([$parent]: any) => {
+            // Should have only moved 10 px to the top
+            expectBbox($parent, {
+                top: 100,
+                left: 250,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 150,
+                left: 300,
+                width: 600,
+                height: 200,
+            })
+        })
+        .get("#parent")
+        .trigger("pointerup")
+        .wait(2000)
+        .should(([$parent]: any) => {
+            // Should have only moved 10 px to the top
+            expectBbox($parent, {
+                top: 100,
+                left: 200,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 150,
+                left: 250,
+                width: 600,
+                height: 200,
+            })
+        })
+        .get("#child")
+        .trigger("pointerdown", 5, 10)
+        .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 200, 10, { force: true })
+        .wait(50)
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 150,
+                left: 400,
+                width: 600,
+                height: 200,
+            })
+        })
+        .trigger("pointerup")
+        .wait(2000)
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 150,
+                left: 350,
+                width: 600,
+                height: 200,
+            })
+        })
+}
 
-// describe("Nested drag with constraints", () => {
-//     it("Parent: layout, Child: layout", () => testNestedDragConstraints(true, true))
-//     it("Parent: layout", () => testNestedDragConstraints(true, false))
-//     it("Child: layout", () => testNestedDragConstraints(false, true))
-//     it("Neither", () => testNestedDragConstraints(false, false))
-// })
+describe("Nested drag with constraints and animation", () => {
+    it("Parent: layout, Child: layout", () =>
+        testNestedDragConstraintsAndAnimation(true, true))
+    it("Parent: layout", () =>
+        testNestedDragConstraintsAndAnimation(true, false))
+    it("Child: layout", () =>
+        testNestedDragConstraintsAndAnimation(false, true))
+    it("Neither", () => testNestedDragConstraintsAndAnimation(false, false))
+})

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -326,3 +326,42 @@ describe("Nested drag with constraints and animation", () => {
         testNestedDragConstraintsAndAnimation(false, true))
     it("Neither", () => testNestedDragConstraintsAndAnimation(false, false))
 })
+
+function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
+    let url = `?test=drag-layout-nested&bothAxes=true`
+    if (parentLayout) url += `&parentLayout=true`
+    if (childLayout) url += `&childLayout=true`
+    cy.visit(url)
+        .wait(50)
+        .get("#child")
+        .trigger("pointerdown", 5, 5, { force: true })
+        .trigger("pointermove", 10, 10, { force: true })
+        .wait(50)
+        .trigger("pointermove", 100, 100, { force: true })
+        .wait(50)
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 250,
+                left: 250,
+                width: 600,
+                height: 200,
+            })
+        })
+        .get("#parent")
+        .should(([$parent]: any) => {
+            expectBbox($parent, {
+                top: 200,
+                left: 100,
+                width: 300,
+                height: 300,
+            })
+        })
+        .wait(30)
+}
+
+describe("Nested drag with alternate draggable axes", () => {
+    it("Parent: layout, Child: layout", () => testAlternateAxes(true, true))
+    it("Parent: layout", () => testAlternateAxes(true, false))
+    it("Child: layout", () => testAlternateAxes(false, true))
+    it("Neither", () => testAlternateAxes(false, false))
+})

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -13,14 +13,18 @@ function expectBbox(element: HTMLElement, expectedBbox: BoundingBox) {
     expect(bbox.height).to.equal(expectedBbox.height)
 }
 
-function testNestedDrag(query: string) {
-    cy.visit(`?test=drag-layout-nested&${query}`)
+function testNestedDrag(parentLayout: boolean, childLayout: boolean) {
+    let url = `?test=drag-layout-nested`
+    if (parentLayout) url += `&parentLayout=true`
+    if (childLayout) url += `&childLayout=true`
+
+    cy.visit(url)
         .wait(50)
         .get("#parent")
         .should(([$parent]: any) => {
             expectBbox($parent, {
                 top: 100,
-                left: 200,
+                left: 100,
                 width: 300,
                 height: 300,
             })
@@ -30,6 +34,54 @@ function testNestedDrag(query: string) {
         .should(([$child]: any) => {
             expectBbox($child, {
                 top: 150,
+                left: 150,
+                width: 600,
+                height: 200,
+            })
+        })
+        .get("#parent")
+        .trigger("pointerdown", 5, 5)
+        .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 50, 50)
+        .wait(50)
+        .trigger("pointerup")
+        .should(([$parent]: any) => {
+            expectBbox($parent, {
+                top: 150,
+                left: 150,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 200,
+                left: 200,
+                width: 600,
+                height: 200,
+            })
+        })
+        .trigger("pointerdown", 5, 5)
+        .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+        .wait(50)
+        .trigger("pointermove", 50, 50)
+        .wait(50)
+        .trigger("pointerup")
+        .get("#parent")
+        .should(([$parent]: any) => {
+            expectBbox($parent, {
+                top: 150,
+                left: 150,
+                width: 300,
+                height: 300,
+            })
+        })
+        .get("#child")
+        .should(([$child]: any) => {
+            expectBbox($child, {
+                top: 250,
                 left: 250,
                 width: 600,
                 height: 200,
@@ -39,13 +91,14 @@ function testNestedDrag(query: string) {
         .trigger("pointerdown", 5, 5)
         .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
         .wait(50)
-        .trigger("pointermove", 100, 100, { force: true })
+        .trigger("pointermove", 50, 50)
         .wait(50)
-        .trigger("pointerup", { force: true })
+        .trigger("pointerup")
+        .get("#parent")
         .should(([$parent]: any) => {
             expectBbox($parent, {
                 top: 200,
-                left: 300,
+                left: 200,
                 width: 300,
                 height: 300,
             })
@@ -53,41 +106,40 @@ function testNestedDrag(query: string) {
         .get("#child")
         .should(([$child]: any) => {
             expectBbox($child, {
-                top: 250,
-                left: 350,
-                width: 600,
-                height: 200,
-            })
-        })
-        .trigger("pointerdown", 5, 5)
-        .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
-        .wait(50)
-        .trigger("pointermove", 100, 100, { force: true })
-        .wait(50)
-        .trigger("pointerup", { force: true })
-        .should(([$parent]: any) => {
-            expectBbox($parent, {
-                top: 200,
+                top: 300,
                 left: 300,
-                width: 300,
-                height: 300,
-            })
-        })
-        .get("#child")
-        .should(([$child]: any) => {
-            expectBbox($child, {
-                top: 350,
-                left: 450,
                 width: 600,
                 height: 200,
             })
         })
+    // .trigger("pointerdown", 5, 5)
+    // .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+    // .wait(50)
+    // .trigger("pointermove", 100, 100, { force: true })
+    // .wait(50)
+    // .trigger("pointerup", { force: true })
+    // .should(([$parent]: any) => {
+    //     expectBbox($parent, {
+    //         top: 200,
+    //         left: 300,
+    //         width: 300,
+    //         height: 300,
+    //     })
+    // })
+    // .get("#child")
+    // .should(([$child]: any) => {
+    //     expectBbox($child, {
+    //         top: 350,
+    //         left: 450,
+    //         width: 600,
+    //         height: 200,
+    //     })
+    // })
 }
 
 describe("Nested drag", () => {
-    it("Parent: layout, Child: layout", () =>
-        testNestedDrag("parentLayout=true&childLayout=true"))
-    it("Parent: layout", () => testNestedDrag("parentLayout=true"))
-    it("Child: layout", () => testNestedDrag("childLayout=true"))
-    it("Neither", () => testNestedDrag(""))
+    it("Parent: layout, Child: layout", () => testNestedDrag(true, true))
+    it("Parent: layout", () => testNestedDrag(true, false))
+    it("Child: layout", () => testNestedDrag(false, true))
+    it("Neither", () => testNestedDrag(false, false))
 })

--- a/cypress/integration/drag-nested.ts
+++ b/cypress/integration/drag-nested.ts
@@ -317,31 +317,22 @@ function testNestedDragConstraintsAndAnimation(
         })
 }
 
-describe("Nested drag with constraints and animation", () => {
-    it("Parent: layout, Child: layout", () =>
-        testNestedDragConstraintsAndAnimation(true, true))
-    it("Parent: layout", () =>
-        testNestedDragConstraintsAndAnimation(true, false))
-    it("Child: layout", () =>
-        testNestedDragConstraintsAndAnimation(false, true))
-    it("Neither", () => testNestedDragConstraintsAndAnimation(false, false))
-})
-
 function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
     let url = `?test=drag-layout-nested&bothAxes=true`
     if (parentLayout) url += `&parentLayout=true`
     if (childLayout) url += `&childLayout=true`
-    cy.visit(url)
+    return cy
+        .visit(url)
         .wait(50)
         .get("#child")
         .trigger("pointerdown", 5, 5, { force: true })
         .trigger("pointermove", 10, 10, { force: true })
         .wait(50)
-        .trigger("pointermove", 110, 110, { force: true })
+        .trigger("pointermove", 100, 100, { force: true })
         .wait(50)
         .should(([$child]: any) => {
             expectBbox($child, {
-                top: 250,
+                top: 240,
                 left: 250,
                 width: 600,
                 height: 200,
@@ -350,7 +341,7 @@ function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
         .get("#parent")
         .should(([$parent]: any) => {
             expectBbox($parent, {
-                top: 200,
+                top: 195,
                 left: 100,
                 width: 300,
                 height: 300,
@@ -362,7 +353,7 @@ function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
         .wait(50)
         .should(([$child]: any) => {
             expectBbox($child, {
-                top: 250,
+                top: 245,
                 left: 250,
                 width: 600,
                 height: 200,
@@ -371,7 +362,7 @@ function testAlternateAxes(parentLayout: boolean, childLayout: boolean) {
         .get("#parent")
         .should(([$parent]: any) => {
             expectBbox($parent, {
-                top: 200,
+                top: 195,
                 left: 100,
                 width: 300,
                 height: 300,
@@ -389,4 +380,14 @@ describe("Nested drag with alternate draggable axes", () => {
     it.skip("Parent: layout", () => testAlternateAxes(true, false))
     it.skip("Child: layout", () => testAlternateAxes(false, true))
     it("Neither", () => testAlternateAxes(false, false))
+})
+
+describe("Nested drag with constraints and animation", () => {
+    it("Parent: layout, Child: layout", () =>
+        testNestedDragConstraintsAndAnimation(true, true))
+    it("Parent: layout", () =>
+        testNestedDragConstraintsAndAnimation(true, false))
+    it("Child: layout", () =>
+        testNestedDragConstraintsAndAnimation(false, true))
+    it("Neither", () => testNestedDragConstraintsAndAnimation(false, false))
 })

--- a/cypress/integration/drag-to-reorder.ts
+++ b/cypress/integration/drag-to-reorder.ts
@@ -1,0 +1,78 @@
+interface BoundingBox {
+    top: number
+    left: number
+    width: number
+    height: number
+}
+
+function expectBbox(element: HTMLElement, expectedBbox: BoundingBox) {
+    const bbox = element.getBoundingClientRect()
+    expect(bbox.left).to.equal(expectedBbox.left)
+    expect(bbox.top).to.equal(expectedBbox.top)
+    expect(bbox.width).to.equal(expectedBbox.width)
+    expect(bbox.height).to.equal(expectedBbox.height)
+}
+
+describe("Drag to reorder", () => {
+    it("Works correctly with other layout animations", () => {
+        cy.visit("?test=drag-to-reorder")
+            .wait(50)
+            .get("#h60")
+            .should(([$item]: any) => {
+                expectBbox($item, {
+                    top: 0,
+                    left: 0,
+                    width: 300,
+                    height: 60,
+                })
+            })
+            .get("#h40")
+            .should(([$item]: any) => {
+                expectBbox($item, {
+                    top: 160,
+                    left: 0,
+                    width: 300,
+                    height: 40,
+                })
+            })
+            .trigger("pointerdown", 300, 300, { force: true })
+            .wait(50)
+            .trigger("pointermove", 295, 295, { force: true })
+            .wait(50)
+            .trigger("pointermove", 200, 200, { force: true })
+            .wait(50)
+            .should(([$item]: any) => {
+                expectBbox($item, {
+                    top: 55,
+                    left: 0,
+                    width: 300,
+                    height: 40,
+                })
+            })
+            .get("#h60")
+            .should(([$item]: any) => {
+                expectBbox($item, {
+                    top: 0,
+                    left: 0,
+                    width: 300,
+                    height: 60,
+                })
+            })
+
+        // .get("#parent")
+        // .trigger("pointerdown", 5, 5)
+        // .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
+        // .wait(50)
+        // .trigger("pointermove", 50, 50)
+        // .wait(50)
+        // .trigger("pointerup")
+        // .should(([$parent]: any) => {
+        //     expectBbox($parent, {
+        //         top: 150,
+        //         left: 150,
+        //         width: 300,
+        //         height: 300,
+        //     })
+        // })
+    })
+})

--- a/cypress/integration/drag-to-reorder.ts
+++ b/cypress/integration/drag-to-reorder.ts
@@ -58,21 +58,5 @@ describe("Drag to reorder", () => {
                     height: 60,
                 })
             })
-
-        // .get("#parent")
-        // .trigger("pointerdown", 5, 5)
-        // .trigger("pointermove", 10, 10) // Gesture will start from first move past threshold
-        // .wait(50)
-        // .trigger("pointermove", 50, 50)
-        // .wait(50)
-        // .trigger("pointerup")
-        // .should(([$parent]: any) => {
-        //     expectBbox($parent, {
-        //         top: 150,
-        //         left: 150,
-        //         width: 300,
-        //         height: 300,
-        //     })
-        // })
     })
 })

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -15,21 +15,25 @@ export const App = () => {
     }, [])
 
     return (
-        <motion.div
-            id="parent"
-            drag={parentDrag}
-            dragMomentum={false}
-            layout={parentLayout}
-            style={b}
-        >
+        <div style={{ height: 3000 }}>
             <motion.div
-                id="child"
-                drag={childDrag}
+                id="parent"
+                drag={parentDrag}
                 dragMomentum={false}
-                layout={childLayout}
-                style={a}
-            />
-        </motion.div>
+                layout={parentLayout}
+                style={b}
+            >
+                <motion.div
+                    id="child"
+                    drag={childDrag}
+                    dragMomentum={false}
+                    dragElastic={false}
+                    dragConstraints={{ left: 0, right: 500 }}
+                    layout={childLayout}
+                    style={a}
+                />
+            </motion.div>
+        </div>
     )
 }
 

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -8,6 +8,7 @@ export const App = () => {
     const childDrag = params.get("childDrag") || true
     const parentLayout = params.get("parentLayout") ? true : undefined
     const childLayout = params.get("childLayout") ? true : undefined
+    const constraints = Boolean(params.get("constraints"))
 
     // Trigger layout projection in the child
     React.useEffect(() => {
@@ -20,6 +21,8 @@ export const App = () => {
                 id="parent"
                 drag={parentDrag}
                 dragMomentum={false}
+                dragElastic={false}
+                dragConstraints={constraints && { top: -10, right: 100 }}
                 layout={parentLayout}
                 style={b}
             >
@@ -28,7 +31,9 @@ export const App = () => {
                     drag={childDrag}
                     dragMomentum={false}
                     dragElastic={false}
-                    dragConstraints={{ left: 0, right: 500 }}
+                    dragConstraints={
+                        constraints && { top: 0, left: -100, right: 100 }
+                    }
                     layout={childLayout}
                     style={a}
                 />

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -4,12 +4,20 @@ import * as React from "react"
 export const App = () => {
     const [count, setCount] = React.useState(0)
     const params = new URLSearchParams(window.location.search)
-    const parentDrag = params.get("parentDrag") || true
-    const childDrag = params.get("childDrag") || true
+    let parentDrag: boolean | string | undefined =
+        params.get("parentDrag") || true
+    let childDrag: boolean | string | undefined =
+        params.get("childDrag") || true
     const parentLayout = params.get("parentLayout") ? true : undefined
     const childLayout = params.get("childLayout") ? true : undefined
     const constraints = Boolean(params.get("constraints"))
     const animation = Boolean(params.get("animation"))
+    const bothAxes = Boolean(params.get("bothAxes"))
+
+    if (bothAxes) {
+        parentDrag = "y"
+        childDrag = "x"
+    }
 
     // Trigger layout projection in the child
     React.useEffect(() => {
@@ -17,7 +25,7 @@ export const App = () => {
     }, [])
 
     return (
-        <div style={{ height: 2000 }}>
+        <div>
             <motion.div
                 id="parent"
                 drag={parentDrag}

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -15,7 +15,7 @@ export const App = () => {
     }, [])
 
     return (
-        <div style={{ height: 3000 }}>
+        <div>
             <motion.div
                 id="parent"
                 drag={parentDrag}
@@ -41,15 +41,16 @@ const box = {
     position: "absolute",
     top: 0,
     left: 0,
-    background: "red",
+    background: "#ff0055",
 }
 
 const b = {
     ...box,
     top: 100,
-    left: 200,
+    left: 100,
     width: 300,
     height: 300,
+    borderRadius: 10,
 }
 
 const a = {
@@ -58,5 +59,6 @@ const a = {
     left: 50,
     width: 600,
     height: 200,
-    background: "blue",
+    background: "#ffcc00",
+    borderRadius: 10,
 }

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -9,6 +9,7 @@ export const App = () => {
     const parentLayout = params.get("parentLayout") ? true : undefined
     const childLayout = params.get("childLayout") ? true : undefined
     const constraints = Boolean(params.get("constraints"))
+    const animation = Boolean(params.get("animation"))
 
     // Trigger layout projection in the child
     React.useEffect(() => {
@@ -16,12 +17,12 @@ export const App = () => {
     }, [])
 
     return (
-        <div>
+        <div style={{ height: 2000 }}>
             <motion.div
                 id="parent"
                 drag={parentDrag}
-                dragMomentum={false}
-                dragElastic={false}
+                dragMomentum={animation}
+                dragElastic={constraints && animation ? 0.5 : false}
                 dragConstraints={constraints && { top: -10, right: 100 }}
                 layout={parentLayout}
                 style={b}
@@ -29,8 +30,8 @@ export const App = () => {
                 <motion.div
                     id="child"
                     drag={childDrag}
-                    dragMomentum={false}
-                    dragElastic={false}
+                    dragMomentum={animation}
+                    dragElastic={constraints && animation ? 0.5 : false}
                     dragConstraints={
                         constraints && { top: 0, left: -100, right: 100 }
                     }

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -4,10 +4,8 @@ import * as React from "react"
 export const App = () => {
     const [count, setCount] = React.useState(0)
     const params = new URLSearchParams(window.location.search)
-    let parentDrag: boolean | string | undefined =
-        params.get("parentDrag") || true
-    let childDrag: boolean | string | undefined =
-        params.get("childDrag") || true
+    let parentDrag: boolean | string = params.get("parentDrag") || true
+    let childDrag: boolean | string = params.get("childDrag") || true
     const parentLayout = params.get("parentLayout") ? true : undefined
     const childLayout = params.get("childLayout") ? true : undefined
     const constraints = Boolean(params.get("constraints"))

--- a/dev/tests/drag-to-reorder.tsx
+++ b/dev/tests/drag-to-reorder.tsx
@@ -1,0 +1,218 @@
+import * as React from "react"
+import { useState, useRef, useEffect } from "react"
+import { motion } from "@framer"
+import { clamp, distance } from "popmotion"
+import move from "array-move"
+
+/**
+ * This demonstrates drag working with automatic animations.
+ * When the element moves in the underlying layout, it visually
+ * stays stuck to the user's pointer.
+ */
+
+const Item = ({ color, setPosition, moveItem, i }) => {
+    const [isDragging, setDragging] = useState(false)
+
+    // We'll use a `ref` to access the DOM element that the `motion.li` produces.
+    // This will allow us to measure its height and position, which will be useful to
+    // decide when a dragging element should switch places with its siblings.
+    const ref = useRef(null)
+
+    // Update the measured position of the item so we can calculate when we should rearrange.
+    useEffect(() => {
+        setPosition(i, {
+            height: ref.current.offsetHeight,
+            top: ref.current.offsetTop,
+        })
+    })
+
+    return (
+        <li
+            style={{
+                padding: 0,
+                height: heights[color],
+                zIndex: isDragging ? 3 : 1,
+            }}
+        >
+            <motion.div
+                ref={ref}
+                initial={false}
+                id={`h${heights[color]}`}
+                layout
+                // If we're dragging, we want to set the zIndex of that item to be on top of the other items.
+                style={{
+                    background: color,
+                    height: heights[color],
+                    borderRadius: 5,
+                }}
+                whileHover={{
+                    boxShadow: "0px 3px 3px rgba(0,0,0,0.15)",
+                }}
+                whileTap={{
+                    boxShadow: "0px 5px 5px rgba(0,0,0,0.1)",
+                }}
+                drag="y"
+                onDragStart={() => setDragging(true)}
+                onDragEnd={() => setDragging(false)}
+                onViewportBoxUpdate={(_viewportBox, delta) => {
+                    // color === "#FF008C" && console.log(_viewportBox.y.min)
+                    isDragging && moveItem(i, delta.y.translate)
+                }}
+            />
+        </li>
+    )
+}
+
+export const App = () => {
+    const [colors, setColors] = useState(initialColors)
+
+    // We need to collect an array of height and position data for all of this component's
+    // `Item` children, so we can later us that in calculations to decide when a dragging
+    // `Item` should swap places with its siblings.
+    const positions = useRef<Position[]>([]).current
+    const setPosition = (i: number, offset: Position) => (positions[i] = offset)
+
+    // Find the ideal index for a dragging item based on its position in the array, and its
+    // current drag offset. If it's different to its current index, we swap this item with that
+    // sibling.
+    const moveItem = (i: number, dragOffset: number) => {
+        const targetIndex = findIndex(i, dragOffset, positions)
+        if (targetIndex !== i) setColors(move(colors, i, targetIndex))
+    }
+
+    return (
+        <ul>
+            {colors.map((color, i) => (
+                <Item
+                    key={color}
+                    i={i}
+                    color={color}
+                    setPosition={setPosition}
+                    moveItem={moveItem}
+                />
+            ))}
+            <style>{styles}</style>
+        </ul>
+    )
+}
+
+// Spring configs
+const onTop = { zIndex: 1 }
+const flat = {
+    zIndex: 0,
+    //transition: { delay: 0.3 },
+}
+
+const initialColors = ["#FF008C", "#D309E1", "#9C1AFF"] //, "#7700FF"]
+const heights = {
+    "#FF008C": 60,
+    "#D309E1": 80,
+    "#9C1AFF": 40,
+    "#7700FF": 100,
+}
+
+export interface Position {
+    top: number
+    height: number
+}
+
+// Prevent rapid reverse swapping
+const buffer = 5
+
+export const findIndex = (
+    i: number,
+    yOffset: number,
+    positions: Position[]
+) => {
+    let target = i
+    const { top, height } = positions[i]
+    const bottom = top + height
+
+    // If moving down
+    if (yOffset > 0) {
+        const nextItem = positions[i + 1]
+        if (nextItem === undefined) return i
+
+        const swapOffset =
+            distance(bottom, nextItem.top + nextItem.height / 2) + buffer
+        if (yOffset > swapOffset) target = i + 1
+
+        // If moving up
+    } else if (yOffset < 0) {
+        const prevItem = positions[i - 1]
+        if (prevItem === undefined) return i
+
+        const prevBottom = prevItem.top + prevItem.height
+        const swapOffset =
+            distance(top, prevBottom - prevItem.height / 2) + buffer
+        if (yOffset < -swapOffset) target = i - 1
+    }
+
+    return clamp(0, positions.length, target)
+}
+
+const styles = `body {
+  width: 100vw;
+  height: 100vh;
+  background: white;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+nav {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 300px;
+}
+
+ul,
+li {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+ul {
+  position: relative;
+  width: 300px;
+}
+
+li {
+  border-radius: 10px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  width: 100%;
+  height: 80px;
+  position: relative;
+}
+
+.background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 300px;
+  background: #fff;
+}
+
+.refresh {
+  padding: 10px;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 10px;
+  width: 20px;
+  height: 20px;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+}
+`

--- a/dev/tests/layout-shared-crossfade-nested.tsx
+++ b/dev/tests/layout-shared-crossfade-nested.tsx
@@ -1,0 +1,78 @@
+import { motion, AnimateSharedLayout, AnimatePresence } from "@framer"
+import * as React from "react"
+
+export const App = () => {
+    const params = new URLSearchParams(window.location.search)
+    const type = params.get("type") || true
+    const [state, setState] = React.useState(true)
+
+    return (
+        <AnimateSharedLayout type="crossfade">
+            <AnimatePresence>
+                <motion.div
+                    key={state ? "a" : "b"}
+                    style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        width: 500,
+                        height: 400,
+                    }}
+                >
+                    <motion.div
+                        id={state ? "a" : "b"}
+                        data-testid="box"
+                        layoutId="box"
+                        layout={type}
+                        style={{
+                            ...(state ? a : b),
+                            backgroundColor: state ? "#f00" : "#0f0",
+                            borderRadius: state ? 0 : 20,
+                        }}
+                        onClick={() => setState(!state)}
+                    >
+                        <motion.div
+                            layoutId="child"
+                            style={state ? childA : childB}
+                        />
+                    </motion.div>
+                </motion.div>
+            </AnimatePresence>
+        </AnimateSharedLayout>
+    )
+}
+
+const box = {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    background: "red",
+}
+
+const a = {
+    ...box,
+    width: 100,
+    height: 200,
+    top: 100,
+    left: 200,
+}
+
+const b = {
+    ...box,
+    top: 300,
+    left: 200,
+    width: 300,
+    height: 300,
+}
+
+const childA = {
+    width: 100,
+    height: 100,
+    background: "blue",
+}
+
+const childB = {
+    width: 100,
+    height: 100,
+    background: "blue",
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "test-client": "jest --coverage --config jest.config.json --maxWorkers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-e2e": "start-server-and-test start-dev-server http://localhost:9990 'cypress run'",
-        "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --spec \"cypress/integration/layout-shared-lightbox-crossfade-repeated.ts\"'",
+        "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --spec \"cypress/integration/drag-nested.ts\"'",
         "test-e2e-ci": "start-server-and-test start-dev-server http://localhost:9990 'cypress run'",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov  --config jest.config.json",
         "prettier": "prettier ./src/* --write",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "test-client": "jest --coverage --config jest.config.json --maxWorkers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-e2e": "start-server-and-test start-dev-server http://localhost:9990 'cypress run'",
-        "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --spec \"cypress/integration/drag-to-reorder.ts\"'",
+        "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --spec \"cypress/integration/drag-nested.ts\"'",
         "test-e2e-ci": "start-server-and-test start-dev-server http://localhost:9990 'cypress run'",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov  --config jest.config.json",
         "prettier": "prettier ./src/* --write",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "test-client": "jest --coverage --config jest.config.json --maxWorkers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-e2e": "start-server-and-test start-dev-server http://localhost:9990 'cypress run'",
-        "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --spec \"cypress/integration/drag-nested.ts\"'",
+        "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --spec \"cypress/integration/drag-to-reorder.ts\"'",
         "test-e2e-ci": "start-server-and-test start-dev-server http://localhost:9990 'cypress run'",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov  --config jest.config.json",
         "prettier": "prettier ./src/* --write",

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -11,6 +11,7 @@ import { MotionContext, MotionContextProps } from "../../context/MotionContext"
 import { resetRotate } from "./utils/rotate"
 import { VisualElement } from "../../render/types"
 import { createBatcher } from "./utils/batcher"
+import { snapshotViewportBox } from "../../render/dom/projection/utils"
 
 /**
  * @public
@@ -109,7 +110,6 @@ export class AnimateSharedLayout extends React.Component<
          * Create a handler which we can use to flush the children animations
          */
         const handler: SyncLayoutLifecycles = {
-            measureLayout: (child) => child.updateLayoutMeasurement(),
             layoutReady: (child) => {
                 if (child.getLayoutId() !== undefined) {
                     const stack = this.getStack(child)!
@@ -157,7 +157,7 @@ export class AnimateSharedLayout extends React.Component<
         /**
          * Read: Snapshot children
          */
-        this.children.forEach((child) => child.snapshotViewportBox())
+        this.children.forEach(snapshotViewportBox)
 
         /**
          * Every child keeps a local snapshot, but we also want to record

--- a/src/components/AnimateSharedLayout/types.ts
+++ b/src/components/AnimateSharedLayout/types.ts
@@ -64,7 +64,6 @@ export interface SharedLayoutAnimationConfig {
  * @public
  */
 export interface SyncLayoutLifecycles {
-    measureLayout: (child: VisualElement) => void
     layoutReady: (child: VisualElement) => void
     parent?: VisualElement
 }

--- a/src/components/AnimateSharedLayout/utils/batcher.ts
+++ b/src/components/AnimateSharedLayout/utils/batcher.ts
@@ -1,4 +1,8 @@
 import sync, { flushSync } from "framesync"
+import {
+    batchResetAndMeasure,
+    withoutTreeTransform,
+} from "../../../render/dom/projection/utils"
 import { VisualElement } from "../../../render/types"
 import { compareByDepth } from "../../../render/utils/compare-by-depth"
 import { Presence, SyncLayoutBatcher, SyncLayoutLifecycles } from "../types"
@@ -7,7 +11,6 @@ import { Presence, SyncLayoutBatcher, SyncLayoutLifecycles } from "../types"
  * Default handlers for batching VisualElements
  */
 const defaultHandler: SyncLayoutLifecycles = {
-    measureLayout: (child) => child.updateLayoutMeasurement(),
     layoutReady: (child) => child.notifyLayoutReady(),
 }
 
@@ -19,24 +22,14 @@ export function createBatcher(): SyncLayoutBatcher {
 
     return {
         add: (child) => queue.add(child),
-        flush: ({ measureLayout, layoutReady, parent } = defaultHandler) => {
+        flush: ({ layoutReady, parent } = defaultHandler) => {
             const order = Array.from(queue).sort(compareByDepth)
 
-            const resetAndMeasure = () => {
-                /**
-                 * Write: Reset any transforms on children elements so we can read their actual layout
-                 */
-                order.forEach((child) => child.resetTransform())
-
-                /**
-                 * Read: Measure the actual layout
-                 */
-                order.forEach(measureLayout)
-            }
-
             parent
-                ? parent.withoutTransform(resetAndMeasure)
-                : resetAndMeasure()
+                ? withoutTreeTransform(parent, () => {
+                      batchResetAndMeasure(order)
+                  })
+                : batchResetAndMeasure(order)
 
             /**
              * Write: Notify the VisualElements they're ready for further write operations.

--- a/src/components/AnimateSharedLayout/utils/batcher.ts
+++ b/src/components/AnimateSharedLayout/utils/batcher.ts
@@ -25,11 +25,13 @@ export function createBatcher(): SyncLayoutBatcher {
         flush: ({ layoutReady, parent } = defaultHandler) => {
             const order = Array.from(queue).sort(compareByDepth)
 
-            parent
-                ? withoutTreeTransform(parent, () => {
-                      batchResetAndMeasure(order)
-                  })
-                : batchResetAndMeasure(order)
+            if (parent) {
+                withoutTreeTransform(parent, () => {
+                    batchResetAndMeasure(order)
+                })
+            } else {
+                batchResetAndMeasure(order)
+            }
 
             /**
              * Write: Notify the VisualElements they're ready for further write operations.

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -288,7 +288,7 @@ export class VisualElementDragControls {
         const { dragConstraints, dragElastic } = this.props
         this.visualElement.updateLayoutProjection()
         const { layoutCorrected: layout } = this.visualElement.getLayoutState()
-        console.log(layout.x)
+
         if (dragConstraints) {
             this.constraints = isRefObject(dragConstraints)
                 ? this.resolveRefConstraints(layout, dragConstraints)

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -504,16 +504,23 @@ export class VisualElementDragControls {
         }
     }
 
+    private isLayoutDrag() {
+        return !this.getAxisMotionValue("x")
+    }
+
     private animateDragEnd(velocity: Point2D) {
         const { drag, dragMomentum, dragElastic, dragTransition } = this.props
 
-        const isRelative = convertToRelativeProjection(this.visualElement)
+        const isRelative = convertToRelativeProjection(
+            this.visualElement,
+            this.isLayoutDrag()
+        )
 
         const constraints = this.constraints || {}
         if (
             isRelative &&
             Object.keys(constraints).length &&
-            !this.getAxisMotionValue("x")
+            this.isLayoutDrag()
         ) {
             const projectionParent = this.visualElement.getProjectionParent()
 

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -165,7 +165,7 @@ export class VisualElementDragControls {
              * Ensure that this element's layout measurements are updated.
              * We'll need these to accurately project the element and figure out its constraints.
              */
-            updateTreeLayoutMeasurements(this.visualElement)
+            this.updateLayoutMeasurements()
 
             /**
              * If this drag session has been manually triggered by the user, it might be from an event
@@ -283,6 +283,10 @@ export class VisualElementDragControls {
             },
             { transformPagePoint }
         )
+    }
+
+    updateLayoutMeasurements() {
+        updateTreeLayoutMeasurements(this.visualElement)
     }
 
     resolveDragConstraints() {
@@ -511,11 +515,19 @@ export class VisualElementDragControls {
     private animateDragEnd(velocity: Point2D) {
         const { drag, dragMomentum, dragElastic, dragTransition } = this.props
 
+        /**
+         * Everything beyond the drag gesture should be performed with
+         * relative projection so children stay in sync with their parent element.
+         */
         const isRelative = convertToRelativeProjection(
             this.visualElement,
             this.isLayoutDrag()
         )
 
+        /**
+         * If we had previously resolved constraints relative to the viewport,
+         * we need to also convert those to a relative coordinate space for the animation
+         */
         const constraints = this.constraints || {}
         if (
             isRelative &&
@@ -628,7 +640,7 @@ export class VisualElementDragControls {
          * Then, using the latest layout and constraints measurements, reposition the new layout axis
          * proportionally within the constraints.
          */
-        updateTreeLayoutMeasurements(this.visualElement)
+        this.updateLayoutMeasurements()
         this.resolveDragConstraints()
 
         eachAxis((axis) => {

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -220,14 +220,12 @@ export class VisualElementDragControls {
                 if (!this.openGlobalLock) return
             }
 
-            // ===========
-
             /**
              * Resolve the drag constraints. These are either set as top/right/bottom/left constraints
              * relative to the element's layout, or a ref to another element. Both need converting to
              * viewport coordinates.
              */
-            // this.resolveDragConstraints()
+            this.resolveDragConstraints()
 
             // // Set current drag status
             this.isDragging = true
@@ -286,35 +284,15 @@ export class VisualElementDragControls {
         )
     }
 
-    /**
-     * Ensure the component's layout and target bounding boxes are up-to-date.
-     */
-    // prepareBoundingBox() {
-    //     const { visualElement } = this
-
-    //     visualElement.withoutTransform(() => {
-    //         visualElement.updateLayoutMeasurement()
-    //     })
-
-    //     visualElement.rebaseProjectionTarget(
-    //         true,
-    //         visualElement.measureViewportBox(false)
-    //     )
-    // }
-
     resolveDragConstraints() {
         const { dragConstraints, dragElastic } = this.props
-
+        this.visualElement.updateLayoutProjection()
+        const { layoutCorrected: layout } = this.visualElement.getLayoutState()
+        console.log(layout.x)
         if (dragConstraints) {
             this.constraints = isRefObject(dragConstraints)
-                ? this.resolveRefConstraints(
-                      this.visualElement.getLayoutState().layout,
-                      dragConstraints
-                  )
-                : calcRelativeConstraints(
-                      this.visualElement.getLayoutState().layout,
-                      dragConstraints
-                  )
+                ? this.resolveRefConstraints(layout, dragConstraints)
+                : calcRelativeConstraints(layout, dragConstraints)
         } else {
             this.constraints = false
         }
@@ -329,7 +307,7 @@ export class VisualElementDragControls {
             eachAxis((axis) => {
                 if (this.getAxisMotionValue(axis)) {
                     this.constraints[axis] = rebaseAxisConstraints(
-                        this.visualElement.getLayoutState().layout[axis],
+                        layout[axis],
                         this.constraints[axis]
                     )
                 }

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -156,13 +156,6 @@ export class VisualElementDragControls {
         originEvent: AnyPointerEvent,
         { snapToCursor = false, cursorProgress }: DragControlOptions = {}
     ) {
-        /**
-         * If this drag session has been manually triggered by the user, it might be from an event
-         * outside the draggable element. If snapToCursor is set to true, we need to measure the position
-         * of the element and snap it to the cursor.
-         */
-        snapToCursor && this.snapToCursor(originEvent)
-
         const onSessionStart = (event: AnyPointerEvent) => {
             // Stop any animations on both axis values immediately. This allows the user to throw and catch
             // the component.
@@ -173,6 +166,13 @@ export class VisualElementDragControls {
              * We'll need these to accurately project the element and figure out its constraints.
              */
             updateTreeLayoutMeasurements(this.visualElement)
+
+            /**
+             * If this drag session has been manually triggered by the user, it might be from an event
+             * outside the draggable element. If snapToCursor is set to true, we need to measure the position
+             * of the element and snap it to the cursor.
+             */
+            snapToCursor && this.snapToCursor(originEvent)
 
             /**
              * Apply a simple lock to the projection target. This ensures no animations
@@ -228,7 +228,7 @@ export class VisualElementDragControls {
              */
             this.resolveDragConstraints()
 
-            // // Set current drag status
+            // Set current drag status
             this.isDragging = true
             this.currentDirection = null
 
@@ -387,26 +387,26 @@ export class VisualElementDragControls {
         this.props.onDragEnd?.(event, info)
     }
 
-    snapToCursor(_event: AnyPointerEvent) {
-        // this.prepareBoundingBox()
-        // eachAxis((axis) => {
-        //     const { drag } = this.props
-        //     // If we're not dragging this axis, do an early return.
-        //     if (!shouldDrag(axis, drag, this.currentDirection)) return
-        //     const axisValue = this.getAxisMotionValue(axis)
-        //     if (axisValue) {
-        //         const { point } = getViewportPointFromEvent(event)
-        //         const box = this.visualElement.getLayoutState().layout
-        //         const length = box[axis].max - box[axis].min
-        //         const center = box[axis].min + length / 2
-        //         const offset = point[axis] - center
-        //         this.originPoint[axis] = point[axis]
-        //         axisValue.set(offset)
-        //     } else {
-        //         this.cursorProgress[axis] = 0.5
-        //         this.updateVisualElementAxis(axis, event)
-        //     }
-        // })
+    snapToCursor(event: AnyPointerEvent) {
+        eachAxis((axis) => {
+            const { drag } = this.props
+            // If we're not dragging this axis, do an early return.
+            if (!shouldDrag(axis, drag, this.currentDirection)) return
+
+            const axisValue = this.getAxisMotionValue(axis)
+            if (axisValue) {
+                const { point } = getViewportPointFromEvent(event)
+                const box = this.visualElement.getLayoutState().layout
+                const length = box[axis].max - box[axis].min
+                const center = box[axis].min + length / 2
+                const offset = point[axis] - center
+                this.originPoint[axis] = point[axis]
+                axisValue.set(offset)
+            } else {
+                this.cursorProgress[axis] = 0.5
+                this.updateVisualElementAxis(axis, event)
+            }
+        })
     }
 
     /**
@@ -621,8 +621,8 @@ export class VisualElementDragControls {
          * Then, using the latest layout and constraints measurements, reposition the new layout axis
          * proportionally within the constraints.
          */
-        // this.prepareBoundingBox()
-        // this.resolveDragConstraints()
+        updateTreeLayoutMeasurements(this.visualElement)
+        this.resolveDragConstraints()
 
         eachAxis((axis) => {
             if (!shouldDrag(axis, drag, null)) return

--- a/src/gestures/drag/use-drag-controls.ts
+++ b/src/gestures/drag/use-drag-controls.ts
@@ -91,9 +91,9 @@ export class DragControls {
     }
 
     updateConstraints() {
-        this.componentControls.forEach((_controls) => {
-            // controls.prepareBoundingBox()
-            // controls.resolveDragConstraints()
+        this.componentControls.forEach((controls) => {
+            controls.updateLayoutMeasurements()
+            controls.resolveDragConstraints()
         })
     }
 }

--- a/src/gestures/drag/use-drag-controls.ts
+++ b/src/gestures/drag/use-drag-controls.ts
@@ -91,9 +91,9 @@ export class DragControls {
     }
 
     updateConstraints() {
-        this.componentControls.forEach((controls) => {
-            controls.prepareBoundingBox()
-            controls.resolveDragConstraints()
+        this.componentControls.forEach((_controls) => {
+            // controls.prepareBoundingBox()
+            // controls.resolveDragConstraints()
         })
     }
 }

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -193,6 +193,8 @@ class Animate extends React.Component<AnimateProps> {
                     isRelative,
                 })
             } else {
+                this.stopAxisAnimation[axis]?.()
+
                 // If the box has remained in the same place, immediately set the axis target
                 // to the final desired state
                 return visualElement.setProjectionTargetAxis(

--- a/src/motion/features/layout/Measure.tsx
+++ b/src/motion/features/layout/Measure.tsx
@@ -9,6 +9,8 @@ import {
     SharedLayoutSyncMethods,
     SyncLayoutBatcher,
 } from "../../../components/AnimateSharedLayout/types"
+import { setCurrentViewportBox } from "../../../render/dom/projection/relative-set"
+import { snapshotViewportBox } from "../../../render/dom/projection/utils"
 
 interface SyncProps extends FeatureProps {
     syncLayout: SharedLayoutSyncMethods | SyncLayoutBatcher
@@ -51,7 +53,7 @@ class Measure extends React.Component<SyncProps> {
         if (isSharedLayout(syncLayout)) {
             syncLayout.syncUpdate()
         } else {
-            visualElement.snapshotViewportBox()
+            snapshotViewportBox(visualElement)
             syncLayout.add(visualElement)
         }
 
@@ -63,11 +65,7 @@ class Measure extends React.Component<SyncProps> {
 
         if (!isSharedLayout(syncLayout)) syncLayout.flush()
 
-        /**
-         * If this axis isn't animating as a result of this render we want to reset the targetBox
-         * to the measured box
-         */
-        visualElement.rebaseProjectionTarget()
+        setCurrentViewportBox(visualElement)
     }
 
     render() {

--- a/src/motion/features/layout/utils.ts
+++ b/src/motion/features/layout/utils.ts
@@ -13,7 +13,10 @@ export function calcRelativeOffsetAxis(parent: Axis, child: Axis) {
     }
 }
 
-export function calcRelativeOffset(parent: AxisBox2D, child: AxisBox2D) {
+export function calcRelativeOffset(
+    parent: AxisBox2D,
+    child: AxisBox2D
+): AxisBox2D {
     return {
         x: calcRelativeOffsetAxis(parent.x, child.x),
         y: calcRelativeOffsetAxis(parent.y, child.y),

--- a/src/render/dom/projection/convert-to-relative.ts
+++ b/src/render/dom/projection/convert-to-relative.ts
@@ -4,6 +4,10 @@ import { eachAxis } from "../../../utils/each-axis"
 import { removeBoxTransforms } from "../../../utils/geometry/delta-apply"
 import { VisualElement } from "../../types"
 
+/**
+ * Returns a boolean stating whether or not we converted the projection
+ * to relative projection.
+ */
 export function convertToRelativeProjection(
     visualElement: VisualElement,
     isLayoutDrag: boolean = true

--- a/src/render/dom/projection/convert-to-relative.ts
+++ b/src/render/dom/projection/convert-to-relative.ts
@@ -1,0 +1,25 @@
+import { calcRelativeOffset } from "../../../motion/features/layout/utils"
+import { eachAxis } from "../../../utils/each-axis"
+import { VisualElement } from "../../types"
+
+export function convertToRelativeProjection(visualElement: VisualElement) {
+    const projectionParent = visualElement.getProjectionParent()
+
+    if (!projectionParent) return false
+
+    const offset = calcRelativeOffset(
+        projectionParent.projection.target,
+        visualElement.projection.target
+    )
+
+    eachAxis((axis) =>
+        visualElement.setProjectionTargetAxis(
+            axis,
+            offset[axis].min,
+            offset[axis].max,
+            true
+        )
+    )
+
+    return true
+}

--- a/src/render/dom/projection/convert-to-relative.ts
+++ b/src/render/dom/projection/convert-to-relative.ts
@@ -1,5 +1,6 @@
 import { calcRelativeOffset } from "../../../motion/features/layout/utils"
 import { eachAxis } from "../../../utils/each-axis"
+import { removeBoxTransforms } from "../../../utils/geometry/delta-apply"
 import { VisualElement } from "../../types"
 
 export function convertToRelativeProjection(visualElement: VisualElement) {
@@ -11,6 +12,8 @@ export function convertToRelativeProjection(visualElement: VisualElement) {
         projectionParent.projection.target,
         visualElement.projection.target
     )
+
+    removeBoxTransforms(offset, projectionParent.getLatestValues())
 
     eachAxis((axis) =>
         visualElement.setProjectionTargetAxis(

--- a/src/render/dom/projection/convert-to-relative.ts
+++ b/src/render/dom/projection/convert-to-relative.ts
@@ -1,19 +1,32 @@
 import { calcRelativeOffset } from "../../../motion/features/layout/utils"
+import { AxisBox2D } from "../../../types/geometry"
 import { eachAxis } from "../../../utils/each-axis"
 import { removeBoxTransforms } from "../../../utils/geometry/delta-apply"
 import { VisualElement } from "../../types"
 
-export function convertToRelativeProjection(visualElement: VisualElement) {
+export function convertToRelativeProjection(
+    visualElement: VisualElement,
+    isLayoutDrag: boolean = true
+) {
     const projectionParent = visualElement.getProjectionParent()
 
     if (!projectionParent) return false
 
-    const offset = calcRelativeOffset(
-        projectionParent.projection.target,
-        visualElement.projection.target
-    )
+    let offset: AxisBox2D
 
-    removeBoxTransforms(offset, projectionParent.getLatestValues())
+    if (isLayoutDrag) {
+        offset = calcRelativeOffset(
+            projectionParent.projection.target,
+            visualElement.projection.target
+        )
+
+        removeBoxTransforms(offset, projectionParent.getLatestValues())
+    } else {
+        offset = calcRelativeOffset(
+            projectionParent.getLayoutState().layout,
+            visualElement.getLayoutState().layout
+        )
+    }
 
     eachAxis((axis) =>
         visualElement.setProjectionTargetAxis(

--- a/src/render/dom/projection/relative-set.ts
+++ b/src/render/dom/projection/relative-set.ts
@@ -7,18 +7,19 @@ export function setCurrentViewportBox(visualElement: VisualElement) {
 
     if (!projectionParent) {
         visualElement.rebaseProjectionTarget()
-    } else {
-        const relativeOffset = calcRelativeOffset(
-            projectionParent.getLayoutState().layout,
-            visualElement.getLayoutState().layout
-        )
-        eachAxis((axis) => {
-            visualElement.setProjectionTargetAxis(
-                axis,
-                relativeOffset[axis].min,
-                relativeOffset[axis].max,
-                true
-            )
-        })
+        return
     }
+
+    const relativeOffset = calcRelativeOffset(
+        projectionParent.getLayoutState().layout,
+        visualElement.getLayoutState().layout
+    )
+    eachAxis((axis) => {
+        visualElement.setProjectionTargetAxis(
+            axis,
+            relativeOffset[axis].min,
+            relativeOffset[axis].max,
+            true
+        )
+    })
 }

--- a/src/render/dom/projection/relative-set.ts
+++ b/src/render/dom/projection/relative-set.ts
@@ -1,0 +1,24 @@
+import { calcRelativeOffset } from "../../../motion/features/layout/utils"
+import { eachAxis } from "../../../utils/each-axis"
+import { VisualElement } from "../../types"
+
+export function setCurrentViewportBox(visualElement: VisualElement) {
+    const projectionParent = visualElement.getProjectionParent()
+
+    if (!projectionParent) {
+        visualElement.rebaseProjectionTarget()
+    } else {
+        const relativeOffset = calcRelativeOffset(
+            projectionParent.getLayoutState().layout,
+            visualElement.getLayoutState().layout
+        )
+        eachAxis((axis) => {
+            visualElement.setProjectionTargetAxis(
+                axis,
+                relativeOffset[axis].min,
+                relativeOffset[axis].max,
+                true
+            )
+        })
+    }
+}

--- a/src/render/dom/projection/utils.ts
+++ b/src/render/dom/projection/utils.ts
@@ -1,0 +1,96 @@
+import sync from "framesync"
+import { copyAxisBox } from "../../../utils/geometry"
+import { VisualElement } from "../../types"
+import { compareByDepth } from "../../utils/compare-by-depth"
+
+export function updateTreeLayoutMeasurements(visualElement: VisualElement) {
+    withoutTreeTransform(visualElement, () => {
+        const allChildren = collectProjectingChildren(visualElement)
+        batchResetAndMeasure(allChildren)
+
+        updateLayoutMeasurement(visualElement)
+    })
+
+    visualElement.rebaseProjectionTarget(
+        true,
+        visualElement.measureViewportBox(false)
+    )
+}
+
+export function collectProjectingChildren(
+    visualElement: VisualElement
+): VisualElement[] {
+    const children: VisualElement[] = []
+
+    const addChild = (child: VisualElement) => {
+        child.isProjecting() && children.push(child)
+        child.children.forEach(addChild)
+    }
+
+    visualElement.children.forEach(addChild)
+
+    return children.sort(compareByDepth)
+}
+
+/**
+ * Perform the callback after temporarily unapplying the transform
+ * upwards through the tree.
+ */
+export function withoutTreeTransform(
+    visualElement: VisualElement,
+    callback: () => void
+) {
+    const { parent } = visualElement
+    const { isEnabled } = visualElement.projection
+    isEnabled && visualElement.resetTransform()
+
+    parent ? withoutTreeTransform(parent, callback) : callback()
+
+    isEnabled && visualElement.restoreTransform()
+}
+
+/**
+ * Update the layoutState by measuring the DOM layout. This
+ * should be called after resetting any layout-affecting transforms.
+ */
+export function updateLayoutMeasurement(visualElement: VisualElement) {
+    const layoutState = visualElement.getLayoutState()
+
+    visualElement.notifyBeforeLayoutMeasure(layoutState.layout)
+
+    layoutState.isHydrated = true
+    layoutState.layout = visualElement.measureViewportBox()
+    layoutState.layoutCorrected = copyAxisBox(layoutState.layout)
+
+    visualElement.notifyLayoutMeasure(
+        layoutState.layout,
+        visualElement.prevViewportBox || layoutState.layout
+    )
+
+    sync.update(() => visualElement.rebaseProjectionTarget())
+}
+
+/**
+ * Record the viewport box as it was before an expected mutation/re-render
+ */
+export function snapshotViewportBox(visualElement: VisualElement) {
+    visualElement.prevViewportBox = visualElement.measureViewportBox(false)
+
+    /**
+     * Update targetBox to match the prevViewportBox. This is just to ensure
+     * that targetBox is affected by scroll in the same way as the measured box
+     */
+    visualElement.rebaseProjectionTarget(false, visualElement.prevViewportBox)
+}
+
+export function batchResetAndMeasure(order: VisualElement[]) {
+    /**
+     * Write: Reset any transforms on children elements so we can read their actual layout
+     */
+    order.forEach((child) => child.resetTransform())
+
+    /**
+     * Read: Measure the actual layout
+     */
+    order.forEach(updateLayoutMeasurement)
+}

--- a/src/render/dom/projection/utils.ts
+++ b/src/render/dom/projection/utils.ts
@@ -61,7 +61,7 @@ export function updateLayoutMeasurement(visualElement: VisualElement) {
     layoutState.isHydrated = true
     layoutState.layout = visualElement.measureViewportBox()
     layoutState.layoutCorrected = copyAxisBox(layoutState.layout)
-    console.log("updating layout measurement")
+
     visualElement.notifyLayoutMeasure(
         layoutState.layout,
         visualElement.prevViewportBox || layoutState.layout

--- a/src/render/dom/projection/utils.ts
+++ b/src/render/dom/projection/utils.ts
@@ -61,7 +61,7 @@ export function updateLayoutMeasurement(visualElement: VisualElement) {
     layoutState.isHydrated = true
     layoutState.layout = visualElement.measureViewportBox()
     layoutState.layoutCorrected = copyAxisBox(layoutState.layout)
-
+    console.log("updating layout measurement")
     visualElement.notifyLayoutMeasure(
         layoutState.layout,
         visualElement.prevViewportBox || layoutState.layout

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -714,19 +714,20 @@ export const visualElement = <Instance, MutableState, Options>({
 
         /**
          * Start a layout animation on a given axis.
-         * TODO: This could be better.
          */
-        startLayoutAnimation(axis, transition) {
+        startLayoutAnimation(axis, transition, isRelative = false) {
             const progress = element.getProjectionAnimationProgress()[axis]
-            const { min, max } = projection.target[axis]
+            const { min, max } = isRelative
+                ? projection.relativeTarget![axis]
+                : projection.target[axis]
             const length = max - min
 
             progress.clearListeners()
             progress.set(min)
             progress.set(min) // Set twice to hard-reset velocity
-            progress.onChange((v) =>
-                element.setProjectionTargetAxis(axis, v, v + length)
-            )
+            progress.onChange((v) => {
+                element.setProjectionTargetAxis(axis, v, v + length, isRelative)
+            })
 
             return element.animateMotionValue!(axis, progress, 0, transition)
         },
@@ -799,7 +800,7 @@ export const visualElement = <Instance, MutableState, Options>({
                 projection.relativeTarget = undefined
                 target = projection.target[axis]
             }
-
+            // console.log(min, max, isRelative)
             target.min = min
             target.max = max
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -769,7 +769,7 @@ export const visualElement = <Instance, MutableState, Options>({
                 projection.relativeTarget = undefined
                 target = projection.target[axis]
             }
-            // console.log(min, max, isRelative)
+
             target.min = min
             target.max = max
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -834,8 +834,6 @@ export const visualElement = <Instance, MutableState, Options>({
              * update projections.
              */
             sync.preRender(updateTreeLayoutProjection, false, true)
-
-            // sync.postRender(() => element.scheduleUpdateLayoutProjection())
         },
 
         getProjectionParent() {

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,7 +4,7 @@ import { Presence } from "../components/AnimateSharedLayout/types"
 import { Crossfader } from "../components/AnimateSharedLayout/utils/crossfader"
 import { MotionStyle } from "../motion/types"
 import { eachAxis } from "../utils/each-axis"
-import { axisBox, copyAxisBox } from "../utils/geometry"
+import { axisBox } from "../utils/geometry"
 import {
     applyBoxTransforms,
     removeBoxTransforms,
@@ -162,17 +162,10 @@ export const visualElement = <Instance, MutableState, Options>({
     /**
      *
      */
-    function isProjecting() {
-        return projection.isEnabled && layoutState.isHydrated
-    }
-
-    /**
-     *
-     */
     function render() {
         if (!instance) return
 
-        if (isProjecting()) {
+        if (element.isProjecting()) {
             /**
              * Apply the latest user-set transforms to the targetBox to produce the targetBoxFinal.
              * This is the final box that we will then project into by calculating a transform delta and
@@ -318,6 +311,10 @@ export const visualElement = <Instance, MutableState, Options>({
          */
         depth: parent ? parent.depth + 1 : 0,
 
+        parent,
+
+        children: new Set(),
+
         /**
          * An ancestor path back to the root visual element. This is used
          * by layout projection to quickly recurse back up the tree.
@@ -386,6 +383,7 @@ export const visualElement = <Instance, MutableState, Options>({
             if (isVariantNode && parent && !isControllingVariants) {
                 removeFromVariantTree = parent?.addVariantChild(element)
             }
+            parent?.children.add(element)
         },
 
         /**
@@ -399,6 +397,7 @@ export const visualElement = <Instance, MutableState, Options>({
             element.stopLayoutAnimation()
             element.layoutTree.remove(element)
             removeFromVariantTree?.()
+            parent?.children.delete(element)
             unsubscribeFromLeadVisualElement?.()
             lifecycles.clearAllListeners()
         },
@@ -693,24 +692,13 @@ export const visualElement = <Instance, MutableState, Options>({
             projection.isTargetLocked = false
         },
 
-        /**
-         * Record the viewport box as it was before an expected mutation/re-render
-         */
-        snapshotViewportBox() {
-            element.prevViewportBox = element.measureViewportBox(false)
-
-            /**
-             * Update targetBox to match the prevViewportBox. This is just to ensure
-             * that targetBox is affected by scroll in the same way as the measured box
-             */
-            element.rebaseProjectionTarget(false, element.prevViewportBox)
-        },
-
         getLayoutState: () => layoutState,
 
         setCrossfader(newCrossfader) {
             crossfader = newCrossfader
         },
+
+        isProjecting: () => projection.isEnabled && layoutState.isHydrated,
 
         /**
          * Start a layout animation on a given axis.
@@ -750,25 +738,6 @@ export const visualElement = <Instance, MutableState, Options>({
             const viewportBox = measureViewportBox(instance, options)
             if (!withTransform) removeBoxTransforms(viewportBox, latestValues)
             return viewportBox
-        },
-
-        /**
-         * Update the layoutState by measuring the DOM layout. This
-         * should be called after resetting any layout-affecting transforms.
-         */
-        updateLayoutMeasurement() {
-            element.notifyBeforeLayoutMeasure(layoutState.layout)
-
-            layoutState.isHydrated = true
-            layoutState.layout = element.measureViewportBox()
-            layoutState.layoutCorrected = copyAxisBox(layoutState.layout)
-
-            element.notifyLayoutMeasure(
-                layoutState.layout,
-                element.prevViewportBox || layoutState.layout
-            )
-
-            sync.update(() => element.rebaseProjectionTarget())
         },
 
         /**
@@ -851,18 +820,7 @@ export const visualElement = <Instance, MutableState, Options>({
          */
         resetTransform: () => resetTransform(element, instance, props),
 
-        /**
-         * Perform the callback after temporarily unapplying the transform
-         * upwards through the tree.
-         */
-        withoutTransform(callback) {
-            const { isEnabled } = projection
-            isEnabled && element.resetTransform()
-
-            parent ? parent.withoutTransform(callback) : callback()
-
-            isEnabled && restoreTransform(instance, renderState)
-        },
+        restoreTransform: () => restoreTransform(instance, renderState),
 
         updateLayoutProjection,
 
@@ -876,6 +834,8 @@ export const visualElement = <Instance, MutableState, Options>({
              * update projections.
              */
             sync.preRender(updateTreeLayoutProjection, false, true)
+
+            // sync.postRender(() => element.scheduleUpdateLayoutProjection())
         },
 
         getProjectionParent() {

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -114,7 +114,11 @@ export interface VisualElement<Instance = any, RenderState = any>
         max: number,
         isRelative?: boolean
     ): void
-    startLayoutAnimation(axis: "x" | "y", transition: Transition): Promise<any>
+    startLayoutAnimation(
+        axis: "x" | "y",
+        transition: Transition,
+        isRelative: boolean
+    ): Promise<any>
     stopLayoutAnimation(): void
     snapshotViewportBox(): void
     updateLayoutProjection(): void

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -24,13 +24,16 @@ export interface VisualElement<Instance = any, RenderState = any>
     extends LifecycleManager {
     treeType: string
     depth: number
+    parent?: VisualElement
+    children: Set<VisualElement>
+    variantChildren?: Set<VisualElement>
     current: Instance | null
     layoutTree: FlatTree
     manuallyAnimateOnMount: boolean
     blockInitialAnimation?: boolean
     presenceId: number | undefined
     projection: TargetProjection
-    variantChildren?: Set<VisualElement>
+    isProjecting: () => boolean
     isMounted(): boolean
     mount(instance: Instance): void
     unmount(): void
@@ -98,13 +101,11 @@ export interface VisualElement<Instance = any, RenderState = any>
      */
     isHoverEventsEnabled: boolean
     suspendHoverEvents(): void
-    withoutTransform(callback: () => void): void
     enableLayoutProjection(): void
     lockProjectionTarget(): void
     unlockProjectionTarget(): void
     rebaseProjectionTarget(force?: boolean, sourceBox?: AxisBox2D): void
     measureViewportBox(withTransform?: boolean): AxisBox2D
-    updateLayoutMeasurement(): void
     getLayoutState: () => LayoutState
     getProjectionParent: () => VisualElement | false
     getProjectionAnimationProgress(): MotionPoint
@@ -120,7 +121,6 @@ export interface VisualElement<Instance = any, RenderState = any>
         isRelative: boolean
     ): Promise<any>
     stopLayoutAnimation(): void
-    snapshotViewportBox(): void
     updateLayoutProjection(): void
     updateTreeLayoutProjection(): void
     resolveRelativeTargetBox(): void
@@ -132,6 +132,7 @@ export interface VisualElement<Instance = any, RenderState = any>
     notifyLayoutReady(config?: SharedLayoutAnimationConfig): void
     pointTo(element: VisualElement): void
     resetTransform(): void
+    restoreTransform(): void
 
     isPresent: boolean
     presence: Presence

--- a/src/render/utils/__tests__/flat-tree.test.ts
+++ b/src/render/utils/__tests__/flat-tree.test.ts
@@ -20,4 +20,18 @@ describe("FlatTree", () => {
             { depth: 1 },
         ])
     })
+
+    test("Doesn't crash when removing child mid-loop", () => {
+        const tree = new FlatTree()
+        const toRemove = { depth: 1 }
+        tree.add({ depth: 0 })
+        tree.add(toRemove)
+
+        const received: WithDepth[] = []
+        tree.forEach((child) => {
+            received.push(child)
+            tree.remove(toRemove)
+        })
+        expect(received).toStrictEqual([{ depth: 0 }])
+    })
 })

--- a/src/render/utils/flat-tree.ts
+++ b/src/render/utils/flat-tree.ts
@@ -18,10 +18,7 @@ export class FlatTree {
 
     forEach(callback: (child: WithDepth) => void) {
         this.isDirty && this.children.sort(compareByDepth)
-
-        const numChildren = this.children.length
-        for (let i = 0; i < numChildren; i++) {
-            callback(this.children[i])
-        }
+        this.isDirty = false
+        this.children.forEach(callback)
     }
 }

--- a/src/render/utils/projection.ts
+++ b/src/render/utils/projection.ts
@@ -5,7 +5,7 @@ import { LayoutState, TargetProjection } from "./state"
 
 export function updateLayoutDeltas(
     { delta, layout, layoutCorrected, treeScale }: LayoutState,
-    { target }: TargetProjection,
+    { target, relativeTarget }: TargetProjection,
     treePath: VisualElement[],
     transformOrigin: ResolvedValues
 ) {
@@ -19,7 +19,12 @@ export function updateLayoutDeltas(
      * Apply all the parent deltas to this box to produce the corrected box. This
      * is the layout box, as it will appear on screen as a result of the transforms of its parents.
      */
-    applyTreeDeltas(layoutCorrected, treeScale, treePath)
+    applyTreeDeltas(
+        layoutCorrected,
+        treeScale,
+        treePath,
+        Boolean(relativeTarget)
+    )
 
     /**
      * Update the delta between the corrected box and the target box before user-set transforms were applied.

--- a/src/render/utils/projection.ts
+++ b/src/render/utils/projection.ts
@@ -25,7 +25,7 @@ export function updateLayoutDeltas(
      * Update the delta between the corrected box and the target box before user-set transforms were applied.
      * This will allow us to calculate the corrected borderRadius and boxShadow to compensate
      * for our layout reprojection, but still allow them to be scaled correctly by the user.
-     * It might be that to simplify this we may want to accept that user-set scale1 is also corrected
+     * It might be that to simplify this we may want to accept that user-set scale is also corrected
      * and we wouldn't have to keep and calc both deltas, OR we could support a user setting
      * to allow people to choose whether these styles are corrected based on just the
      * layout reprojection or the final bounding box.

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -220,7 +220,7 @@ export function applyTreeDeltas(
     box: AxisBox2D,
     treeScale: Point2D,
     treePath: VisualElement[],
-    isRelative: boolean
+    isRelative: boolean = false
 ) {
     const treeLength = treePath.length
     if (!treeLength) return

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -228,8 +228,11 @@ export function applyTreeDeltas(
     // Reset the treeScale
     treeScale.x = treeScale.y = 1
 
+    let node: VisualElement
+    let delta: BoxDelta
     for (let i = 0; i < treeLength; i++) {
-        const { delta } = treePath[i].getLayoutState()
+        node = treePath[i]
+        delta = node.getLayoutState().delta
 
         // Incoporate each ancestor's scale into a culmulative treeScale for this component
         treeScale.x *= delta.x.scale
@@ -238,9 +241,9 @@ export function applyTreeDeltas(
         // Apply each ancestor's calculated delta into this component's recorded layout box
         applyBoxDelta(box, delta)
 
-        // TODO This can be cleaned
-        if (treePath[i].getProps().drag && !isRelative) {
-            applyBoxTransforms(box, box, treePath[i].getLatestValues())
+        // If this is a draggable ancestor, also incorporate the node's transform to the layout box
+        if (!isRelative && node.getProps().drag) {
+            applyBoxTransforms(box, box, node.getLatestValues())
         }
     }
 }

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -1,7 +1,6 @@
 import { Axis, AxisBox2D, BoxDelta, Point2D } from "../../types/geometry"
 import { mix } from "popmotion"
 import { ResolvedValues, VisualElement } from "../../render/types"
-import { copyAxisBox } from "."
 
 /**
  * Reset an axis to the provided origin box.
@@ -220,7 +219,8 @@ export function removeBoxTransforms(
 export function applyTreeDeltas(
     box: AxisBox2D,
     treeScale: Point2D,
-    treePath: VisualElement[]
+    treePath: VisualElement[],
+    isRelative: boolean
 ) {
     const treeLength = treePath.length
     if (!treeLength) return
@@ -239,7 +239,7 @@ export function applyTreeDeltas(
         applyBoxDelta(box, delta)
 
         // TODO This can be cleaned
-        if (treePath[i].getProps().drag) {
+        if (treePath[i].getProps().drag && !isRelative) {
             applyBoxTransforms(box, box, treePath[i].getLatestValues())
         }
     }

--- a/src/utils/geometry/delta-apply.ts
+++ b/src/utils/geometry/delta-apply.ts
@@ -1,6 +1,7 @@
 import { Axis, AxisBox2D, BoxDelta, Point2D } from "../../types/geometry"
 import { mix } from "popmotion"
 import { ResolvedValues, VisualElement } from "../../render/types"
+import { copyAxisBox } from "."
 
 /**
  * Reset an axis to the provided origin box.
@@ -236,5 +237,10 @@ export function applyTreeDeltas(
 
         // Apply each ancestor's calculated delta into this component's recorded layout box
         applyBoxDelta(box, delta)
+
+        // TODO This can be cleaned
+        if (treePath[i].getProps().drag) {
+            applyBoxTransforms(box, box, treePath[i].getLatestValues())
+        }
     }
 }

--- a/src/utils/geometry/delta-calc.ts
+++ b/src/utils/geometry/delta-calc.ts
@@ -96,12 +96,6 @@ export function calcRelativeBox(
         parentProjection.target.x
     )
 
-    console.log(
-        parentProjection.target.x,
-        projection.relativeTarget!.x,
-        projection.target.x
-    )
-
     calcRelativeAxis(
         projection.target.y,
         projection.relativeTarget!.y,

--- a/src/utils/geometry/delta-calc.ts
+++ b/src/utils/geometry/delta-calc.ts
@@ -95,6 +95,13 @@ export function calcRelativeBox(
         projection.relativeTarget!.x,
         parentProjection.target.x
     )
+
+    console.log(
+        parentProjection.target.x,
+        projection.relativeTarget!.x,
+        projection.target.x
+    )
+
     calcRelativeAxis(
         projection.target.y,
         projection.relativeTarget!.y,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2233,9 +2233,9 @@ babel-preset-jest@^24.9.0:
     babel-plugin-jest-hoist "^24.9.0"
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -6449,7 +6449,19 @@ mime-db@1.46.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.46.0.tgz#6267748a7f799594de3cbc8cde91def349661cee"
   integrity sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-db@1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
+  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
+
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
+  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
+  dependencies:
+    mime-db "1.47.0"
+
+mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.24:
   version "2.1.29"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
   integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/956

This PR adds a robust testing environment around, and fixes, nested drag. 

There are three remaining skipped tests, these are for when we're dragging one layer on the `"x"`  axis and a child on the `"y"` simultaneously **and** one or the other is layout-projected. I think this is quite a rare case compared to the amount of fixes this introduces so I'd rather look next at integrating this into `Scroll` first.