### PR TITLE
Allowing individual layers to reset transforms during layout measurements

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -426,6 +426,8 @@ export const LayoutGroupContext: import("react").Context<string | null>;
 export interface LayoutProps {
     layout?: boolean | "position";
     layoutId?: string;
+    // @internal
+    _layoutResetTransform?: boolean;
     onLayoutAnimationComplete?(): void;
 }
 
@@ -1047,6 +1049,8 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     setStaticValue(key: string, value: number | string): void;
     // (undocumented)
     setVisibility(visibility: boolean): void;
+    // (undocumented)
+    shouldSnapshot(): boolean;
     // (undocumented)
     sortNodePosition(element: VisualElement): number;
     // (undocumented)

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "19.15 kB"
+            "maxSize": "19.2 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -154,7 +154,7 @@ export class AnimateSharedLayout extends React.Component<
          */
         this.children.forEach((child) => {
             resetRotate(child)
-            if (!child.shouldSnapshot()) child.resetTransform()
+            if (child.shouldResetTransform()) child.resetTransform()
         })
 
         /**

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -150,7 +150,7 @@ export class AnimateSharedLayout extends React.Component<
         this.updateScheduled = true
 
         /**
-         * Write: Reset rotation transforms so bounding boxes can be accurately measured.
+         * Write: Reset transforms so bounding boxes can be accurately measured.
          */
         this.children.forEach((child) => {
             resetRotate(child)

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -152,7 +152,10 @@ export class AnimateSharedLayout extends React.Component<
         /**
          * Write: Reset rotation transforms so bounding boxes can be accurately measured.
          */
-        this.children.forEach((child) => resetRotate(child))
+        this.children.forEach((child) => {
+            resetRotate(child)
+            if (!child.shouldSnapshot()) child.resetTransform()
+        })
 
         /**
          * Read: Snapshot children

--- a/src/motion/features/definitions.ts
+++ b/src/motion/features/definitions.ts
@@ -6,7 +6,12 @@ const createDefinition = (propNames: string[]) => ({
 })
 
 export const featureDefinitions: FeatureDefinitions = {
-    measureLayout: createDefinition(["layout", "layoutId", "drag"]),
+    measureLayout: createDefinition([
+        "layout",
+        "layoutId",
+        "drag",
+        "_layoutResetTransform",
+    ]),
     animation: createDefinition([
         "animate",
         "exit",

--- a/src/motion/features/layout/Measure.tsx
+++ b/src/motion/features/layout/Measure.tsx
@@ -73,6 +73,7 @@ class Measure extends React.Component<SyncProps> {
 export function MeasureContextProvider(props: FeatureProps) {
     const syncLayout = useContext(SharedLayoutContext)
     const framerSyncLayout = useContext(FramerTreeLayoutContext)
+
     return (
         <Measure
             {...props}

--- a/src/motion/features/layout/types.ts
+++ b/src/motion/features/layout/types.ts
@@ -52,6 +52,16 @@ export interface LayoutProps {
     layoutId?: string
 
     /**
+     * This enables a component's transform to be reset during layout
+     * measurements. This is intended to be used independently of the
+     * layout prop, for instance if a parent component's transform is
+     * interfering with the measurement of a child.
+     *
+     * @internal
+     */
+    _layoutResetTransform?: boolean
+
+    /**
      * A callback that will fire when a layout animation on this component completes.
      *
      * @public

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -19,6 +19,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "inherit",
     "layout",
     "layoutId",
+    "_layoutResetTransform",
     "onLayoutAnimationComplete",
     "onViewportBoxUpdate",
     "onLayoutMeasure",

--- a/src/render/dom/projection/utils.ts
+++ b/src/render/dom/projection/utils.ts
@@ -29,9 +29,10 @@ export function collectProjectingChildren(
     const addChild = (child: VisualElement) => {
         if (
             child.projection.isEnabled ||
-            child.getProps()._layoutResetTransform
-        )
+            visualElement.shouldResetTransform()
+        ) {
             children.push(child)
+        }
         child.children.forEach(addChild)
     }
 
@@ -50,8 +51,7 @@ export function withoutTreeTransform(
 ) {
     const { parent } = visualElement
     const { isEnabled } = visualElement.projection
-    const shouldReset =
-        isEnabled || visualElement.getProps()._layoutResetTransform
+    const shouldReset = isEnabled || visualElement.shouldResetTransform()
 
     shouldReset && visualElement.resetTransform()
 
@@ -65,7 +65,7 @@ export function withoutTreeTransform(
  * should be called after resetting any layout-affecting transforms.
  */
 export function updateLayoutMeasurement(visualElement: VisualElement) {
-    if (!visualElement.shouldSnapshot()) return
+    if (visualElement.shouldResetTransform()) return
 
     const layoutState = visualElement.getLayoutState()
 
@@ -87,7 +87,7 @@ export function updateLayoutMeasurement(visualElement: VisualElement) {
  * Record the viewport box as it was before an expected mutation/re-render
  */
 export function snapshotViewportBox(visualElement: VisualElement) {
-    if (!visualElement.shouldSnapshot()) return
+    if (visualElement.shouldResetTransform()) return
     visualElement.prevViewportBox = visualElement.measureViewportBox(false)
 
     /**

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -875,6 +875,10 @@ export const visualElement = <Instance, MutableState, Options>({
             }
         },
 
+        shouldSnapshot() {
+            return !props._layoutResetTransform
+        },
+
         /**
          *
          */

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -875,8 +875,8 @@ export const visualElement = <Instance, MutableState, Options>({
             }
         },
 
-        shouldSnapshot() {
-            return !props._layoutResetTransform
+        shouldResetTransform() {
+            return Boolean(props._layoutResetTransform)
         },
 
         /**

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -133,6 +133,7 @@ export interface VisualElement<Instance = any, RenderState = any>
     pointTo(element: VisualElement): void
     resetTransform(): void
     restoreTransform(): void
+    shouldSnapshot(): boolean
 
     isPresent: boolean
     presence: Presence

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -133,7 +133,7 @@ export interface VisualElement<Instance = any, RenderState = any>
     pointTo(element: VisualElement): void
     resetTransform(): void
     restoreTransform(): void
-    shouldSnapshot(): boolean
+    shouldResetTransform(): boolean
 
     isPresent: boolean
     presence: Presence


### PR DESCRIPTION
This allows us to reset the transform of a component so its children can be measured without its effects.