### PR TITLE
Update ref if externalRef changes

### DIFF
--- a/src/motion/utils/use-motion-ref.ts
+++ b/src/motion/utils/use-motion-ref.ts
@@ -31,6 +31,6 @@ export function useMotionRef<Instance, RenderState>(
                 }
             }
         },
-        [visualElement]
+        [visualElement, externalRef]
     )
 }


### PR DESCRIPTION
Trigger an update if a `ref` callback function changes - This ensures everything is kept in sync.

I've gotten a bug report on this being an issue: https://github.com/thebuilder/react-intersection-observer/issues/466

See also: #742 

This could potentially cause an infinite rerender if the `ref` is not defined as `useCallback` method, but that would be a bug on the consumer side.
The correct implementation is listed in the Hooks FAQ: https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node