### PR TITLE
Disable hover events during layout measurements globally

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -931,7 +931,6 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     current: Instance | null;
     // (undocumented)
     depth: number;
-    // (undocumented)
     enableLayoutProjection(): void;
     // (undocumented)
     forEachValue(callback: (value: MotionValue, key: string) => void): void;
@@ -981,7 +980,6 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     };
     // (undocumented)
     hasValue(key: string): boolean;
-    isHoverEventsEnabled: boolean;
     // (undocumented)
     isMounted(): boolean;
     // (undocumented)
@@ -1065,8 +1063,6 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     startLayoutAnimation(axis: "x" | "y", transition: Transition, isRelative: boolean): Promise<any>;
     // (undocumented)
     stopLayoutAnimation(): void;
-    // (undocumented)
-    suspendHoverEvents(): void;
     // (undocumented)
     syncRender(): void;
     // (undocumented)

--- a/src/gestures/use-hover-gesture.ts
+++ b/src/gestures/use-hover-gesture.ts
@@ -5,6 +5,7 @@ import { usePointerEvent } from "../events/use-pointer-event"
 import { VisualElement } from "../render/types"
 import { FeatureProps } from "../motion/features/types"
 import { isDragActive } from "./drag/utils/lock"
+import { layoutState } from "../render/dom/utils/batch-layout"
 
 function createHoverEvent(
     visualElement: VisualElement,
@@ -14,7 +15,7 @@ function createHoverEvent(
     return (event: MouseEvent, info: EventInfo) => {
         if (
             !isMouseEvent(event) ||
-            !visualElement.isHoverEventsEnabled ||
+            layoutState.isMeasuringLayout ||
             isDragActive()
         ) {
             return

--- a/src/render/dom/utils/batch-layout.ts
+++ b/src/render/dom/utils/batch-layout.ts
@@ -75,27 +75,3 @@ export function flushLayout() {
 }
 
 const executeJob = (job: Job) => job()
-
-/**
- * updateConstraints
- *  - write: prepareDom (resetTransforms)
- *  - read: measure
- *  - write: restoreDom (restoreTransforms)
- *  - read: resolveConstraints
- *
- * startDrag
- *  - write: prepareDom (resetTransforms)
- *  - read: measure
- *  - write: restoreDom & snapToCursor
- *  - read: rebase projection target & init cursor info
- *  - write: sync flush frame jobs
- *  - read: resolveConstraints
- *
- * AnimateSharedLayout
- *  - write: prepareDom (reset)
- *  - read: measure
- *  - write: notify layout ready (start animations)
- *  - batched: set presence info
- *  - write: flush render
- *  - batch: assign projection
- */

--- a/src/render/html/visual-element.ts
+++ b/src/render/html/visual-element.ts
@@ -66,13 +66,6 @@ export const htmlConfig: VisualElementConfig<
      * works
      */
     resetTransform(element, domElement, props) {
-        /**
-         * When we reset the transform of an element, there's a fair possibility that
-         * the element will visually move from underneath the pointer, triggering attached
-         * pointerenter/leave events. We temporarily suspend these while measurement takes place.
-         */
-        element.suspendHoverEvents()
-
         const { transformTemplate } = props
         domElement.style.transform = transformTemplate
             ? transformTemplate({}, "")

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -367,14 +367,6 @@ export const visualElement = <Instance, MutableState, Options>({
         blockInitialAnimation,
 
         /**
-         * A boolean that can be used to determine whether to respect hover events.
-         * For layout measurements we often have to reposition the instance by
-         * removing its transform. This can trigger hover events, which is
-         * undesired.
-         */
-        isHoverEventsEnabled: true,
-
-        /**
          * Determine whether this component has mounted yet. This is mostly used
          * by variant children to determine whether they need to trigger their
          * own animations on mount.
@@ -493,23 +485,6 @@ export const visualElement = <Instance, MutableState, Options>({
          */
         makeTargetAnimatable(target, canMutate = true) {
             return makeTargetAnimatable(element, target, props, canMutate)
-        },
-
-        /**
-         * Temporarily suspend hover events while we remove transforms in order to measure the layout.
-         *
-         * This seems like an odd bit of scheduling but what we're doing is saying after
-         * the next render, wait 10 milliseconds before reenabling hover events. Waiting until
-         * the next frame results in missed, valid hover events. But triggering on the postRender
-         * frame is too soon to avoid triggering events with layout measurements.
-         *
-         * Note: If we figure out a way of measuring layout while transforms remain applied, this can be removed.
-         */
-        suspendHoverEvents() {
-            element.isHoverEventsEnabled = false
-            sync.postRender(() =>
-                setTimeout(() => (element.isHoverEventsEnabled = true), 10)
-            )
         },
 
         // Motion values ========================

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -99,8 +99,6 @@ export interface VisualElement<Instance = any, RenderState = any>
      * Layout projection - perhaps a candidate for lazy-loading
      * or an external interface. Move into Projection?
      */
-    isHoverEventsEnabled: boolean
-    suspendHoverEvents(): void
     enableLayoutProjection(): void
     lockProjectionTarget(): void
     unlockProjectionTarget(): void


### PR DESCRIPTION
Currently, hover events are disabled during layout measurements on a per-component basis. Every component schedules a timeout that re-enables the hover events. On large trees the scheduling and execution of these timeouts is actually adding up to several ms of work.

There's no reason to do this on a per-component basis. Any time elements are repositioned for measurement purposes, the entire doc is in an invalid/transitory state. This PR sets a global flag to use instead, with only one `setTimeout` scheduled. 

**Note: ** This PR is ready for review but shouldn't be merged until layout animations are moved to the layout batcher in a separate PR.