### PR TITLE
Fix typo on repeatType API documentation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -440,7 +440,7 @@ export interface Repeat {
      *
      * "reverse": Alternates between forward and backwards playback
      *
-     * "mirror": Switchs `from` and `to` alternately
+     * "mirror": Switches `from` and `to` alternately
      *
      * @library
      *


### PR DESCRIPTION
Hey @mattgperry! I was implementing a similar `repeatType` API to `framer-motion`'ss over on `renature` and noticed this tiniest of typos in the docs. From what I can glean in the `api-docs` repo, all content for API properties like `repeatType` is sourced from TSDoc references in the source here. Let me know if I do indeed need to open an accompanying PR in that repo. As always, thanks for all your hard work on `framer-motion` ❤️ 