### PR TITLE
Ensure projection box can't get locked by drag

### DIFF
--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -150,6 +150,7 @@ interface PanSessionHandlers {
     onStart: PanHandler
     onMove: PanHandler
     onEnd: PanHandler
+    onSessionEnd: PanHandler
 }
 
 interface PanSessionOptions {
@@ -274,14 +275,18 @@ export class PanSession {
     private handlePointerUp = (event: AnyPointerEvent, info: EventInfo) => {
         this.end()
 
-        const { onEnd } = this.handlers
-        if (!onEnd || !this.startEvent) return
+        const { onEnd, onSessionEnd } = this.handlers
 
         const panInfo = getPanInfo(
             transformPoint(info, this.transformPagePoint),
             this.history
         )
-        onEnd && onEnd(event, panInfo)
+
+        if (this.startEvent && onEnd) {
+            onEnd(event, panInfo)
+        }
+
+        onSessionEnd && onSessionEnd(event, panInfo)
     }
 
     updateHandlers(handlers: Partial<PanSessionHandlers>) {

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -323,7 +323,8 @@ export class VisualElementDragControls {
             lastPointerEvent = event
         }
 
-        const onEnd: DragHandler = (event, info) => this.stop(event, info)
+        const onSessionEnd: DragHandler = (event, info) =>
+            this.stop(event, info)
 
         const { transformPagePoint } = this.props
         this.panSession = new PanSession(
@@ -332,7 +333,7 @@ export class VisualElementDragControls {
                 onSessionStart,
                 onStart,
                 onMove,
-                onEnd,
+                onSessionEnd,
             },
             { transformPagePoint }
         )
@@ -412,6 +413,7 @@ export class VisualElementDragControls {
     }
 
     cancelDrag() {
+        this.visualElement.unlockProjectionTarget()
         this.cancelLayout?.()
         this.isDragging = false
         this.panSession && this.panSession.end()
@@ -426,7 +428,6 @@ export class VisualElementDragControls {
     }
 
     stop(event: AnyPointerEvent, info: PanInfo) {
-        this.visualElement.unlockProjectionTarget()
         this.panSession?.end()
         this.panSession = null
         const isDragging = this.isDragging


### PR DESCRIPTION
This adds a new callback to `PanSession`, `onSessionEnd`, that will call regardless of whether the drag technically started. Between this and moving `unlockViewportBox` from `stop` to `cancel` it should be even less likely the viewport box will be locked by drag.