### PR TITLE
Remove hover event supression during layout measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
--   Fixing SVG gradientTransform
+-   Fixing SVG `gradientTransform`.
+-   Removing hover event suspension during layout measurements.
 
 ## [4.1.16] 2021-05-12
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "22.3 kB"
+            "maxSize": "22.5 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",

--- a/src/gestures/use-hover-gesture.ts
+++ b/src/gestures/use-hover-gesture.ts
@@ -5,7 +5,6 @@ import { usePointerEvent } from "../events/use-pointer-event"
 import { VisualElement } from "../render/types"
 import { FeatureProps } from "../motion/features/types"
 import { isDragActive } from "./drag/utils/lock"
-import { layoutState } from "../render/dom/utils/batch-layout"
 
 function createHoverEvent(
     visualElement: VisualElement,
@@ -13,13 +12,7 @@ function createHoverEvent(
     callback?: (event: MouseEvent, info: EventInfo) => void
 ) {
     return (event: MouseEvent, info: EventInfo) => {
-        if (
-            !isMouseEvent(event) ||
-            layoutState.isMeasuringLayout ||
-            isDragActive()
-        ) {
-            return
-        }
+        if (!isMouseEvent(event) || isDragActive()) return
 
         callback?.(event, info)
         visualElement.animationState?.setActive(AnimationType.Hover, isActive)

--- a/src/render/dom/utils/batch-layout.ts
+++ b/src/render/dom/utils/batch-layout.ts
@@ -1,5 +1,3 @@
-import sync from "framesync"
-
 type Job = () => void
 
 type JobSetter = (job: Job) => void
@@ -7,10 +5,6 @@ type JobSetter = (job: Job) => void
 type ReadWrites = (read: JobSetter, write: JobSetter) => void
 
 const unresolvedJobs = new Set<ReadWrites>()
-
-export const layoutState = {
-    isMeasuringLayout: false,
-}
 
 function pushJob(stack: Job[][], job: Job, pointer: number) {
     if (!stack[pointer]) stack[pointer] = []
@@ -44,25 +38,6 @@ export function flushLayout() {
     })
 
     unresolvedJobs.clear()
-
-    /**
-     * Mark that we're currently measuring layouts. This allows us to, for instance, ignore
-     * hover events that might be triggered as a result of resetting transforms.
-     *
-     * The postRender/setTimeout combo seems like an odd bit of scheduling but what it's saying
-     * is *after* the next render, wait 10ms before re-enabling hover events. Waiting until the
-     * next frame completely will result in missed, valid hover events. But events seem to
-     * be fired async from their actual action, so setting this to false too soon can still
-     * trigger events from layout measurements.
-     *
-     * Note: If we figure out a way of measuring layout while transforms remain applied, this can be removed.
-     * I have attempted unregistering event listeners and setting CSS to pointer-events: none
-     * but neither seem to work as expected.
-     */
-    layoutState.isMeasuringLayout = true
-    sync.postRender(() => {
-        setTimeout(() => (layoutState.isMeasuringLayout = false), 10)
-    })
 
     /**
      * Execute jobs


### PR DESCRIPTION
From testing, hover events don't fire if an element moves from under the element. I remember there was an effect like this in Framer but fundamentally they don't. So in this PR we remove this, if this kind of effect causes more issues we can find an alternative fix for the actual problem.