### PR TITLE
Update 'static.framer.com' references in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img src="http://static.framer.com/repos/api-logo.png" width="40"/>
+    <img src="http://misc.framerstatic.com/repos/api-logo.png" width="40"/>
     <br>
     Contributing
 </h1>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://static.framer.com/motion/motion-readme-4.gif" width="400" height="250" alt="Framer Motion" />
+  <img src="https://misc.framerstatic.com/motion/motion-readme-4.gif" width="400" height="250" alt="Framer Motion" />
 </p>
 
 <h3 align="center">


### PR DESCRIPTION
We are moving away from serving unmanaged files on the `framer.com` domain, part of which is migrating content from `static.framer.com` to `misc.framerstatic.com`. The old links will keep on working through a 302 redirect, but let's update all the links anyway.

Ref: https://github.com/framer/company/issues/20653