### PR TITLE
Fix unwanted crossfade for Present childs

### DIFF
--- a/src/components/AnimateSharedLayout/__tests__/AnimateSharedLayout.test.tsx
+++ b/src/components/AnimateSharedLayout/__tests__/AnimateSharedLayout.test.tsx
@@ -1,0 +1,33 @@
+import { render } from "../../../../jest.setup"
+import * as React from "react"
+import { AnimatePresence, AnimateSharedLayout, motion } from "../../.."
+
+describe("AnimateSharedLayout", () => {
+    test("Don't animate childs that are already present", async () => {
+        const promise = new Promise<HTMLDivElement>((resolve) => {
+            const Component = () => {
+                return (
+                    <AnimateSharedLayout type="crossfade">
+                        <motion.div layoutId="thumbnail-or-modal" />
+                        <AnimatePresence>
+                            <motion.div
+                                layoutId="thumbnail-or-modal"
+                                className="modal"
+                            />
+                        </AnimatePresence>
+                    </AnimateSharedLayout>
+                )
+            }
+
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+
+            setTimeout(() => {
+                resolve(container.querySelector(".modal") as HTMLDivElement)
+            }, 500)
+        })
+
+        const element = await promise
+        expect(element).not.toHaveStyle("opacity: 0")
+    })
+})

--- a/src/components/AnimateSharedLayout/utils/stack.ts
+++ b/src/components/AnimateSharedLayout/utils/stack.ts
@@ -143,9 +143,11 @@ export function layoutStack(): LayoutStack {
                     needsCrossfadeAnimation = false
                     const transition = child.getDefaultTransition()
 
-                    child.presence === Presence.Entering
-                        ? crossfader.toLead(transition)
-                        : crossfader.fromLead(transition)
+                    if (child.presence === Presence.Entering) {
+                        crossfader.toLead(transition)
+                    } else if (child.presence === Presence.Exiting) {
+                        crossfader.fromLead(transition)
+                    }
                 }
 
                 child.notifyLayoutReady(config)


### PR DESCRIPTION
For more details, see #1024.

More succinct reproduction: https://codesandbox.io/s/framer-motion-340-state-update-triggers-layout-animation-forked-c22oe?file=/src/Board.tsx