### PR TITLE
Fix prematurely removing elements that are still crossfading out

### DIFF
--- a/src/components/AnimatePresence/PresenceChild.tsx
+++ b/src/components/AnimatePresence/PresenceChild.tsx
@@ -39,11 +39,8 @@ export const PresenceChild = ({
             custom,
             onExitComplete: (childId: number) => {
                 presenceChildren.set(childId, true)
-                let allComplete = true
-                presenceChildren.forEach((isComplete) => {
-                    if (!isComplete) allComplete = false
-                })
-
+                const completed = [...presenceChildren.values()]
+                const allComplete = completed.every(Boolean)
                 allComplete && onExitComplete?.()
             },
             register: (childId: number) => {

--- a/src/components/AnimateSharedLayout/index.tsx
+++ b/src/components/AnimateSharedLayout/index.tsx
@@ -121,7 +121,9 @@ class AnimateSharedLayoutWithContext extends React.Component<
                 const id = child.getLayoutId()
                 if (id !== undefined) {
                     const stack = this.getStack(child)!
-                    stack.animate(child, type === "crossfade")
+                    stack
+                        .animate(child, type === "crossfade")
+                        ?.then(child.notifyLayoutAnimationComplete)
                 } else {
                     child.notifyLayoutReady()
                 }

--- a/src/components/AnimateSharedLayout/utils/stack.ts
+++ b/src/components/AnimateSharedLayout/utils/stack.ts
@@ -19,7 +19,7 @@ export interface LayoutStack {
         element: VisualElement,
         crossfade: boolean,
         isControlled?: boolean
-    ): void
+    ): Promise<void> | undefined
     updateLeadAndFollow(): void
 }
 
@@ -117,6 +117,7 @@ export function layoutStack(): LayoutStack {
             }
         },
         animate(child, shouldCrossfade = false) {
+            let promise
             if (child === state.lead) {
                 if (shouldCrossfade) {
                     /**
@@ -150,7 +151,7 @@ export function layoutStack(): LayoutStack {
                     if (child.presence === Presence.Entering) {
                         crossfader.toLead(transition)
                     } else if (child.presence === Presence.Exiting) {
-                        crossfader.fromLead(transition)
+                        promise = crossfader.fromLead(transition)
                     }
                 }
 
@@ -162,6 +163,8 @@ export function layoutStack(): LayoutStack {
                     child.setVisibility(false)
                 }
             }
+
+            return promise
         },
     }
 }


### PR DESCRIPTION
I'll add some specific tests for this tomorrow, but I wanted to get this out already so you can take a look. I've ran all existing tests and the e2e tests.

Fixes #1085. 

For a succinct reproduction, see [this Sandbox](https://codesandbox.io/s/framer-motion-state-update-during-layout-transition-issue-9eh9p?file=/src/Test.tsx).

Basically what currently happens is elements in a AnimateSharedLayout + AnimatePresence tree are not animated out nicely, they just disappear, leaving only the following item to complete the crossfade. This can be faked by adding an `exit` animation with the same duration as the crossfade, but that's a workaround for something that should work out of the box.

This changeset defers calling `visualElement.notifyLayoutAnimationComplete()` from `animate` if the element is currently being crossfaded. Instead, the complete call is done from the AnimateSharedLayout stack when the crossfade is completed. I've slightly changed some signatures there, as there was no way yet to know when the crossfade was done; opted to add a Promise return to `stack.animate()`.