### PR TITLE
Fix layout animations interrupted by rerenders

### DIFF
--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -289,11 +289,13 @@ class Animate extends React.Component<AnimateProps> {
          * kept in by the tree by AnimatePresence) then call safeToRemove when all axis animations
          * have successfully finished.
          */
-        return Promise.all(animations).then(() => {
-            this.isAnimatingTree = false
-            onComplete && onComplete()
-            visualElement.notifyLayoutAnimationComplete()
-        })
+        if (animations.filter(Boolean).length) {
+            return Promise.all(animations).then(() => {
+                this.isAnimatingTree = false
+                onComplete && onComplete()
+                visualElement.notifyLayoutAnimationComplete()
+            })
+        }
     }
 
     /**

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -281,15 +281,15 @@ class Animate extends React.Component<AnimateProps> {
             }
         })
 
-        // Force a render to ensure there's no flash of uncorrected bounding box.
-        visualElement.syncRender()
-
         /**
          * If this visualElement isn't present (ie it's been removed from the tree by the user but
          * kept in by the tree by AnimatePresence) then call safeToRemove when all axis animations
          * have successfully finished.
          */
         if (animations.filter(Boolean).length) {
+            // Force a render to ensure there's no flash of uncorrected bounding box.
+            visualElement.syncRender()
+
             return Promise.all(animations).then(() => {
                 this.isAnimatingTree = false
                 onComplete && onComplete()

--- a/src/motion/features/layout/Animate.tsx
+++ b/src/motion/features/layout/Animate.tsx
@@ -295,6 +295,8 @@ class Animate extends React.Component<AnimateProps> {
                 onComplete && onComplete()
                 visualElement.notifyLayoutAnimationComplete()
             })
+        } else if (shouldStackAnimate) {
+            this.isAnimatingTree = false
         }
     }
 

--- a/src/motion/features/layout/__tests__/Animate.test.tsx
+++ b/src/motion/features/layout/__tests__/Animate.test.tsx
@@ -1,0 +1,59 @@
+import { render } from "../../../../../jest.setup"
+import * as React from "react"
+import { AnimatePresence, AnimateSharedLayout, motion } from "../../../.."
+
+describe("Layout Animate", () => {
+    test("Continues layout exit transition across rerenders", async () => {
+        const promise = new Promise<Element | null>((resolve) => {
+            const Component = ({ open = false }) => {
+                return (
+                    <AnimateSharedLayout type="crossfade">
+                        <motion.div
+                            layoutId="item"
+                            transition={{ duration: 0.1 }}
+                            style={{
+                                width: 10,
+                                height: 10,
+                            }}
+                        />
+                        <AnimatePresence>
+                            {open && (
+                                <motion.div
+                                    layoutId="item"
+                                    transition={{ duration: 3 }}
+                                    className="modal"
+                                    style={{
+                                        width: 600,
+                                        height: 600,
+                                    }}
+                                />
+                            )}
+                        </AnimatePresence>
+                    </AnimateSharedLayout>
+                )
+            }
+
+            const { container, rerender } = render(<Component open />)
+            const modal = container.querySelector(".modal") as HTMLDivElement
+
+            // Check it's animating out
+            setTimeout(() => {
+                expect(modal.style.opacity).not.toBe(1)
+                expect(modal.style.opacity).not.toBe(0)
+            }, 500)
+
+            // Component rerenders (e.g. an internal state change)
+            rerender(<Component />)
+
+            // Check if it's still animating to the original transition
+            setTimeout(() => {
+                resolve(container.querySelector(".modal"))
+            }, 1000)
+        })
+
+        const child = await promise
+        expect(child).toBeTruthy()
+        expect((child as HTMLDivElement).style.opacity).not.toBe(1)
+        expect((child as HTMLDivElement).style.opacity).not.toBe(0)
+    })
+})


### PR DESCRIPTION
Supersedes #1181.

**Problem**
State updates that happen during a layout transition, trigger a new call to `animate()`. What then happens is this:

1. For the intial layout animation, the axis animations are added to `Promise.all()` and all is well
2. A state change happens, triggering a new call to `animate()`
3. No (new) animations; `Promise.all()` is called with no animations and resolves immediately
4. `visualElement.notifyLayoutAnimationComplete()` is called — before the promises from step 1 have resolved.

As a result the exiting element disappears mid transition, and a new transition is started for the following element. This can be seen in the Sandbox from the linked issue. 

**Solution**
This change prevents no-op rerenders (e.g. internal state changes that don’t result in a layout animation) from calling `Promise.all()` with `[undefined, undefined]` resulting in a preliminary call to `onComplete()` and `visualElement.notifyLayoutAnimationComplete()`.

Fixes #1085.