### PR TITLE
Make layoutAnimations exportable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { LazyMotion } from "./components/LazyMotion"
  * Features
  */
 export { domAnimation } from "./render/dom/features-animation"
+export { layoutAnimations } from "./motion/features/layout"
 export { domMax } from "./render/dom/features-max"
 
 /**


### PR DESCRIPTION
Make layoutAnimations exportable so it can be used in LazyMotion without needing to load the `drag` feature