### PR TITLE
Add test with realistic crossfade and switch to different item

### DIFF
--- a/cypress/integration/layout-shared-lightbox-crossfade-repeated.ts
+++ b/cypress/integration/layout-shared-lightbox-crossfade-repeated.ts
@@ -16,7 +16,7 @@ function expectBbox(element: HTMLElement, expectedBbox: BoundingBox) {
 }
 
 describe("AnimateSharedLayout lightbox example, toggle back and forth", () => {
-    it("Correctly animates back and forth with crossfade", () => {
+    it("Correctly animates back and forth with a very quick crossfade", () => {
         function open(session: Cypress.cy) {
             return session
                 .get("#item-parent")
@@ -160,6 +160,97 @@ describe("AnimateSharedLayout lightbox example, toggle back and forth", () => {
             cy
                 .visit(
                     `?test=layout-shared-lightbox-crossfade&type=crossfade&partial-ease=true`
+                )
+                .wait(50)
+        )
+    })
+    it("Correctly animates back and forth with a normal crossfade", () => {
+        const beCrossfading = ([$box]: any) => {
+            const { borderRadius, opacity } = window.getComputedStyle($box)
+            expect(borderRadius).not.to.equal("0%")
+            expect(borderRadius).not.to.equal("8.33333% / 12.5%")
+            expect(opacity).to.be.greaterThan(0)
+
+            // Fade out has a delay; see easeCrossfadeOut()
+            // expect(opacity).to.be.lessThan(1)
+
+            const { width, height } = $box.getBoundingClientRect()
+            expect(width).to.be.greaterThan(180)
+            expect(width).to.be.lessThan(600)
+            expect(height).to.be.lessThan(580)
+            expect(height).to.be.greaterThan(400)
+        }
+
+        const beCircle = ([$box]: any) => {
+            const { borderRadius, opacity } = window.getComputedStyle($box)
+            expect(opacity).to.equal("0.5")
+            expect(borderRadius).to.equal("50%")
+
+            const { width, height } = $box.getBoundingClientRect()
+            expect(width).to.equal(50)
+            expect(height).to.equal(50)
+        }
+
+        const beOpen = ([$box]: any) => {
+            const { borderRadius, opacity } = window.getComputedStyle($box)
+            expect(borderRadius).to.equal("8.33333% / 12.5%")
+            expect(opacity).to.equal("1")
+
+            const { width, height } = $box.getBoundingClientRect()
+            expect(width).to.equal(600)
+            expect(height).to.equal(400)
+        }
+
+        const beInvisible = ([$box]: any) => {
+            const { opacity } = window.getComputedStyle($box)
+            expect(opacity).to.equal("0")
+        }
+
+        function open(num: number, session: Cypress.cy) {
+            return session
+                .get(`li:nth-child(${num})`)
+                .trigger("click")
+                .should(beCrossfading)
+                .get(`li:nth-child(${num}) > div`)
+                .should(beCircle)
+                .get("#parent")
+                .should(beCrossfading)
+                .get("#child")
+                .should(beCircle)
+                .wait(2000)
+                .get("#parent")
+                .should(beOpen)
+                .get(`li:nth-child(${num})`)
+                .should(beInvisible)
+        }
+
+        function close(num: number, session: Cypress.cy) {
+            return session
+                .get("#overlay")
+                .trigger("click")
+                .get(`li:nth-child(${num})`)
+                .should(beCrossfading)
+                .get(`li:nth-child(${num}) > div`)
+                .should(beCircle)
+                .get("#parent")
+                .should(beCrossfading)
+                .get("#child")
+                .should(beCircle)
+        }
+
+        pipe(
+            (session: Cypress.cy) => open(2, session),
+            (session: Cypress.cy) => close(2, session),
+            (session: Cypress.cy) => session.wait(1000),
+            (session: Cypress.cy) => open(2, session),
+            (session: Cypress.cy) => close(2, session),
+            (session: Cypress.cy) => session.wait(1000),
+            (session: Cypress.cy) => open(3, session),
+            (session: Cypress.cy) => close(3, session)
+        )(
+            cy
+                .visit(
+                    `?test=layout-shared-lightbox-crossfade&type=crossfade&duration=3`
                 )
                 .wait(50)
         )

--- a/dev/tests/layout-shared-lightbox-crossfade.tsx
+++ b/dev/tests/layout-shared-lightbox-crossfade.tsx
@@ -15,9 +15,10 @@ import {
 
 const params = new URLSearchParams(window.location.search)
 const instant = params.get("instant") || false
+const duration = params.get("duration") || 0.01
 const partialEase = params.get("partial-ease") || false
 const type = params.get("type") || "crossfade"
-let transition: Transition = instant ? { type: false } : { duration: 0.01 }
+let transition: Transition = instant ? { type: false } : { duration }
 if (partialEase) {
     transition = {
         duration: 0.15,


### PR DESCRIPTION
I am attempting to contribute by adding tests that replicate issues I'm seeing in my codebase. Please let me know if this is welcome or not.

- This test checks if the crossfade from thumbnail to modal is running, by checking if the width and height are between start and end values. 
- To do this I made `duration` configurable by querystring.
- The test currently fails because switching selected item before the previous item's transition has completed completely messes up the layout projection. I don't know why, but I figure it must have something to do with reparenting/rebasing because the breakage is lasting in the tree.
- You can see this happening yourself when starting a dev server and opening http://localhost:9990/?test=layout-shared-lightbox-crossfade&duration=1:


https://user-images.githubusercontent.com/159500/122555549-b8150d00-d03a-11eb-952a-dfc12902c7c8.mov



https://user-images.githubusercontent.com/159500/122555377-813ef700-d03a-11eb-9d78-c2e0e2c58ea1.mov

