### PR TITLE
Fix: don't parse shadow string starts with 0

### DIFF
--- a/src/render/utils/setters.ts
+++ b/src/render/utils/setters.ts
@@ -7,6 +7,7 @@ import {
     Transition,
 } from "../../types"
 import { isNumericalString } from "../../utils/is-numerical-string"
+import { isZeroValueString } from "../../utils/is-zero-value-string"
 import { resolveFinalValueInKeyframes } from "../../utils/resolve-value"
 import { motionValue } from "../../value"
 import { getAnimatableNone } from "../dom/value-types/animatable-none"
@@ -116,7 +117,7 @@ export function checkTargetForNewValues(
 
         if (
             typeof value === "string" &&
-            (isNumericalString(value) || value.startsWith("0"))
+            (isNumericalString(value) || isZeroValueString(value))
         ) {
             // If this is a number read as a string, ie "0", "200",
             // or a zero number like "0px", convert it to a number type

--- a/src/utils/__tests__/is-zero-value-string.test.ts
+++ b/src/utils/__tests__/is-zero-value-string.test.ts
@@ -1,0 +1,14 @@
+import { isZeroValueString } from "../is-zero-value-string"
+
+describe("isZeroValueString", () => {
+    test("should correctly identify numerical strings", () => {
+        expect(isZeroValueString("0px")).toBe(true)
+        expect(isZeroValueString("0%")).toBe(true)
+        expect(isZeroValueString("0.5%")).toBe(true)
+        expect(isZeroValueString("10.1%")).toBe(false)
+        expect(isZeroValueString("0")).toBe(false)
+        expect(isZeroValueString("10.1")).toBe(false)
+        expect(isZeroValueString("rgb(0,0,0)")).toBe(false)
+        expect(isZeroValueString("0px 0px rgba(0,0,0,0)")).toBe(false)
+    })
+})

--- a/src/utils/__tests__/is-zero-value-string.test.ts
+++ b/src/utils/__tests__/is-zero-value-string.test.ts
@@ -4,7 +4,7 @@ describe("isZeroValueString", () => {
     test("should correctly identify numerical strings", () => {
         expect(isZeroValueString("0px")).toBe(true)
         expect(isZeroValueString("0%")).toBe(true)
-        expect(isZeroValueString("0.5%")).toBe(true)
+        expect(isZeroValueString("0.5%")).toBe(false)
         expect(isZeroValueString("10.1%")).toBe(false)
         expect(isZeroValueString("0")).toBe(false)
         expect(isZeroValueString("10.1")).toBe(false)

--- a/src/utils/is-zero-value-string.ts
+++ b/src/utils/is-zero-value-string.ts
@@ -1,4 +1,4 @@
 /**
  * Check if the value is a zero value string like "0px" or "0%"
  */
-export const isZeroValueString = (v: string) => /^0[\S]+$/.test(v)
+export const isZeroValueString = (v: string) => /^0[^.\s]+$/.test(v)

--- a/src/utils/is-zero-value-string.ts
+++ b/src/utils/is-zero-value-string.ts
@@ -1,0 +1,4 @@
+/**
+ * Check if the value is a zero value string like "0px" or "0%"
+ */
+export const isZeroValueString = (v: string) => /^0[\S]+$/.test(v)


### PR DESCRIPTION
Shadow string like `0px 0px rgba(0,0,0,0)` is parsed to `0`, causing the code to crash when the shadow corrector checks `latest.includes`, see: https://github.com/framer/company/issues/22628