### PR TITLE
fix: fixed wrong structure of package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.js",
     "exports": {
+        ".": {
+            "require": "./dist/framer-motion.cjs.js",
+            "import": "./dist/es/index.js",
+            "default": "./dist/es/index.js"
+        },
         "package.json": "./package.json",
-        "require": "./dist/framer-motion.cjs.js",
-        "import": "./dist/es/index.js",
-        "default": "./dist/es/index.js"
     },
     "types": "types/index.d.ts",
     "author": "Framer",


### PR DESCRIPTION
Fixed wrong use of package.json exports, see preactjs/preact@[master/package.json#L12](https://github.com/preactjs/preact/blob/master/package.json#L12)