### PR TITLE
Improve performance of addEventListener usage

### DIFF
--- a/src/events/use-dom-event.ts
+++ b/src/events/use-dom-event.ts
@@ -6,8 +6,11 @@ export function addDomEvent(
     handler: EventListener,
     options?: AddEventListenerOptions
 ) {
-    target.addEventListener(eventName, handler, options)
+    target.addEventListener(eventName, handler, options || { passive: true })
 
+    /**
+     * no need to care for overrides as only "capture" could be passed @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#parameters
+     */
     return () => target.removeEventListener(eventName, handler, options)
 }
 

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -417,7 +417,8 @@ export class VisualElementDragControls {
 
         const stopMeasureLayoutListener = projection!.addEventListener(
             "measure",
-            measureDragConstraints
+            measureDragConstraints,
+            { passive: true }
         )
 
         if (!projection!.layout) projection!.updateLayout()

--- a/src/motion/features/layout/MeasureLayout.tsx
+++ b/src/motion/features/layout/MeasureLayout.tsx
@@ -40,8 +40,10 @@ class MeasureLayoutWithContext extends React.Component<
         }
 
         projection?.root!.didUpdate()
-        projection?.addEventListener("animationComplete", () =>
-            this.safeToRemove()
+        projection?.addEventListener(
+            "animationComplete",
+            () => this.safeToRemove(),
+            { passive: true }
         )
 
         globalProjectionState.hasEverUpdated = true

--- a/src/projection/node/group.ts
+++ b/src/projection/node/group.ts
@@ -20,7 +20,7 @@ export function nodeGroup(): NodeGroup {
             nodes.add(node)
             subscriptions.set(
                 node,
-                node.addEventListener("willUpdate", dirtyAll)
+                node.addEventListener("willUpdate", dirtyAll, { passive: true })
             )
         },
         remove: (node) => {

--- a/src/projection/node/types.ts
+++ b/src/projection/node/types.ts
@@ -85,7 +85,7 @@ export interface IProjectionNode<I = unknown> {
     resumeFrom?: IProjectionNode
     resumingFrom?: IProjectionNode
 
-    addEventListener(name: LayoutEvents, handler: VoidFunction): VoidFunction
+    addEventListener(name: LayoutEvents, handler: VoidFunction, options?: boolean | AddEventListenerOptions | undefined): VoidFunction
     notifyListeners(name: LayoutEvents, ...args: any): void
     hasListeners(name: LayoutEvents): boolean
 }

--- a/src/value/scroll/use-element-scroll.ts
+++ b/src/value/scroll/use-element-scroll.ts
@@ -90,7 +90,6 @@ export function useElementScroll(
             element,
             "scroll",
             updateScrollValues,
-            { passive: true }
         )
 
         const resizeListener = addDomEvent(

--- a/src/value/scroll/use-viewport-scroll.ts
+++ b/src/value/scroll/use-viewport-scroll.ts
@@ -28,7 +28,7 @@ function addEventListeners() {
         getViewportScrollOffsets
     )
 
-    addDomEvent(window, "scroll", updateScrollValues, { passive: true })
+    addDomEvent(window, "scroll", updateScrollValues)
     addDomEvent(window, "resize", updateScrollValues)
 }
 


### PR DESCRIPTION
Based on the issue/discussion here https://github.com/framer/motion/issues/1143#issuecomment-838398183
In short, since:
- there's no usage of `event.preventDefault()`
  - so there is no possibility of affecting any code within `motion` repo and users
- you bump the major version due to other improvements
  - so users who use `useDomEvent` method in their projects and depend on `event.preventDefault()` won't pull this PR changes if they have `^` for the version of the library