### PR TITLE
Fix: relative projection for instant transition

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -554,6 +554,7 @@ export interface LayoutProps {
     layoutDependency?: any;
     layoutId?: string;
     onLayoutAnimationComplete?(): void;
+    shouldMeasureScroll?: boolean;
 }
 
 // @public (undocumented)

--- a/dev/projection/animate-relative-instant.html
+++ b/dev/projection/animate-relative-instant.html
@@ -7,38 +7,28 @@
             }
 
             #parent {
-                width: 100px;
-                height: 100px;
+                position: relative;
+                width: 200px;
+                height: 200px;
                 background-color: #00cc88;
+            }
+
+            #mid {
+                position: absolute;
+                width: auto;
+                height: auto;
+                left: 0;
+                top: 0;
+            }
+
+            .b #mid {
+                left: 100px;
             }
 
             #child {
                 width: 50px;
                 height: 50px;
                 background-color: #0077ff;
-            }
-
-            #parent.b {
-                width: 200px;
-                position: absolute;
-                top: 100px;
-                left: 200px;
-                padding: 20px;
-                display: flex;
-                justify-content: flex-end;
-            }
-
-            .b #child {
-                width: 100px;
-                height: 100px;
-            }
-
-            #trigger-overflow {
-                width: 1px;
-                height: 1px;
-                position: absolute;
-                top: 2000px;
-                left: 2000px;
             }
 
             [data-layout-correct="false"] {
@@ -48,8 +38,9 @@
         </style>
     </head>
     <body>
-        <div id="parent"><div id="child" /></div>
-        <div id="trigger-overflow"></div>
+        <div id="parent">
+            <div id="mid"><div id="child" /></div>
+        </div>
 
         <script src="../../dist/projection.dev.js"></script>
         <script src="./script-assert.js"></script>
@@ -59,22 +50,30 @@
             const { matchViewportBox } = window.Assert
 
             const parent = document.getElementById("parent")
+            const mid = document.getElementById("mid")
             const child = document.getElementById("child")
 
             const parentProjection = createNode(
                 parent,
                 undefined,
                 {},
-                { ease: relativeEase() }
+                { duration: 200, ease: relativeEase() }
+            )
+            const midProjection = createNode(
+                mid,
+                parentProjection,
+                {},
+                { duration: 200, ease: relativeEase() }
             )
             const childProjection = createNode(
                 child,
-                parentProjection,
+                midProjection,
                 {},
-                { delay: 1000, ease: relativeEase() }
+                { duration: 0 }
             )
 
             parentProjection.willUpdate()
+            midProjection.willUpdate()
             childProjection.willUpdate()
 
             parent.classList.add("b")
@@ -83,17 +82,17 @@
 
             sync.postRender(() => {
                 sync.postRender(() => {
-                    matchViewportBox(parent, {
-                        bottom: 170,
-                        left: 100,
-                        right: 270,
-                        top: 50,
+                    matchViewportBox(mid, {
+                        bottom: 50,
+                        left: 50,
+                        right: 100,
+                        top: 0,
                     })
                     matchViewportBox(child, {
-                        bottom: 100,
-                        left: 100,
-                        right: 150,
-                        top: 50,
+                        bottom: 50,
+                        left: 50,
+                        right: 100,
+                        top: 0,
                     })
                 })
             })

--- a/dev/projection/animate-relative-interrupt.html
+++ b/dev/projection/animate-relative-interrupt.html
@@ -60,18 +60,20 @@
 
             const parent = document.getElementById("parent")
             const child = document.getElementById("child")
+            const parentOrigin = parent.getBoundingClientRect()
+            const childOrigin = child.getBoundingClientRect()
 
             const parentProjection = createNode(
                 parent,
                 undefined,
                 {},
-                { ease: relativeEase() }
+                { duration: 1000, ease: relativeEase() }
             )
             const childProjection = createNode(
                 child,
                 parentProjection,
                 {},
-                { delay: 1000, ease: relativeEase() }
+                { duration: 200, ease: relativeEase() }
             )
 
             parentProjection.willUpdate()
@@ -81,19 +83,48 @@
 
             parentProjection.root.didUpdate()
 
+            matchViewportBox(parent, parentOrigin)
+            matchViewportBox(child, childOrigin)
+
             sync.postRender(() => {
                 sync.postRender(() => {
                     matchViewportBox(parent, {
+                        top: 50,
                         bottom: 170,
                         left: 100,
                         right: 270,
-                        top: 50,
                     })
                     matchViewportBox(child, {
-                        bottom: 100,
-                        left: 100,
-                        right: 150,
-                        top: 50,
+                        top: 60,
+                        bottom: 135,
+                        left: 160,
+                        right: 235,
+                    })
+
+                    parentProjection.willUpdate()
+                    childProjection.willUpdate()
+
+                    parent.classList.remove("b")
+
+                    parentProjection.root.didUpdate()
+
+                    sync.postRender(() => {
+                        sync.postRender(() => {
+                            matchViewportBox(parent, {
+                                top: 25,
+                                bottom: 135,
+                                height: 110,
+                                left: 50,
+                                right: 185,
+                            })
+                            matchViewportBox(child, {
+                                top: 30,
+                                bottom: 92.5,
+                                height: 62.5,
+                                left: 80,
+                                right: 142.5,
+                            })
+                        })
                     })
                 })
             })

--- a/dev/projection/animate-relative-parent-delayed.html
+++ b/dev/projection/animate-relative-parent-delayed.html
@@ -77,16 +77,18 @@
 
             parentProjection.root.didUpdate()
 
-            requestAnimationFrame(() => {
-                matchViewportBox(parent, parentOrigin)
-                matchViewportBox(child, {
-                    bottom: 127.50002670288086,
-                    height: 87.50003051757812,
-                    left: 140.0000762939453,
-                    right: 227.50013732910156,
-                    top: 39.999996185302734,
-                    width: 87.50006103515625,
-                    x: 140.0000762939453,
+            sync.postRender(() => {
+                sync.postRender(() => {
+                    matchViewportBox(parent, parentOrigin)
+                    matchViewportBox(child, {
+                        bottom: 85,
+                        height: 75,
+                        left: 60,
+                        right: 135,
+                        top: 10,
+                        width: 75,
+                        x: 60,
+                    })
                 })
             })
         </script>

--- a/dev/projection/animate-single-element-layout-change-with-child.html
+++ b/dev/projection/animate-single-element-layout-change-with-child.html
@@ -85,23 +85,25 @@
 
             boxProjection.root.didUpdate()
 
-            requestAnimationFrame(() => {
-                matchViewportBox(box, {
-                    top: 50,
-                    right: 270,
-                    bottom: 170,
-                    left: 100,
+            sync.postRender(() => {
+                sync.postRender(() => {
+                    matchViewportBox(box, {
+                        top: 50,
+                        right: 270,
+                        bottom: 170,
+                        left: 100,
+                    })
+                    matchViewportBox(child, {
+                        top: 60,
+                        right: 160,
+                        bottom: 110,
+                        left: 110,
+                    })
+                    matchOpacity(box, 1)
+                    matchOpacity(child, 1)
+                    matchBorderRadius(box, 0)
+                    matchBorderRadius(child, "40%")
                 })
-                matchViewportBox(child, {
-                    top: 60,
-                    right: 160,
-                    bottom: 110,
-                    left: 110,
-                })
-                matchOpacity(box, 1)
-                matchOpacity(child, 1)
-                matchBorderRadius(box, 0)
-                matchBorderRadius(child, "40%")
             })
         </script>
     </body>

--- a/dev/projection/element-scroll-remove.html
+++ b/dev/projection/element-scroll-remove.html
@@ -65,6 +65,7 @@
             const box = document.getElementById("box-1")
             const scrollProjection = createNode(scroll, undefined, {
                 layoutId: "scroll",
+                shouldMeasureScroll: true,
             })
             const containerProjection = createNode(
                 container,

--- a/dev/projection/element-scroll-remove.html
+++ b/dev/projection/element-scroll-remove.html
@@ -1,0 +1,123 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #scroll {
+                overflow: scroll;
+                position: relative;
+                height: 500px;
+                width: 500px;
+            }
+
+            #container {
+                position: relative;
+            }
+
+            #box-1,
+            #box-2 {
+                position: absolute;
+                top: 100px;
+                width: 100px;
+                height: 100px;
+                background: #00cc88;
+            }
+
+            .trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="scroll">
+            <div id="container">
+                <div id="box-1"></div>
+            </div>
+            <div class="trigger-overflow"></div>
+        </div>
+
+        <script src="../../dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchOpacity,
+                matchBorderRadius,
+                addPageScroll,
+            } = window.Assert
+
+            const scroll = document.getElementById("scroll")
+            const container = document.getElementById("container")
+            const box = document.getElementById("box-1")
+            const scrollProjection = createNode(scroll, undefined, {
+                layoutId: "scroll",
+            })
+            const containerProjection = createNode(
+                container,
+                scrollProjection,
+                { layoutId: "container" }
+            )
+            const boxProjection = createNode(box, containerProjection, {
+                layoutId: "a",
+            })
+
+            scroll.scrollTop = 100
+
+            // unmount box-1, mount box-2
+            boxProjection.willUpdate()
+            boxProjection.unmount()
+            container.removeChild(box)
+
+            const box2 = document.createElement("div")
+            box2.id = "box-2"
+
+            container.appendChild(box2)
+            const box2Projection = createNode(box2, containerProjection, {
+                layoutId: "b",
+            })
+
+            box2Projection.root.didUpdate()
+
+            matchViewportBox(box2, { top: 0, bottom: 100, left: 0, right: 100 })
+
+            // update the scroll while box-1 is unmounted
+            scroll.scrollTop = 50
+
+            // unmount box-2, mount box-1
+            box2Projection.willUpdate()
+            box2Projection.unmount()
+            container.removeChild(box2)
+
+            const box1 = document.createElement("div")
+            box1.id = "box-1"
+
+            container.appendChild(box1)
+            const box1Projection = createNode(box1, containerProjection, {
+                layoutId: "a",
+            })
+
+            box1Projection.root.didUpdate()
+
+            matchViewportBox(box1, {
+                top: 50,
+                bottom: 150,
+                left: 0,
+                right: 100,
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/script-animate.js
+++ b/dev/projection/script-animate.js
@@ -93,6 +93,10 @@ Animate.relativeEase = () => {
     let frame = 0
     return () => {
         frame++
+        // one frame for the first synchronous call of mixTargetDelta at the very start,
+        // don't lock it to 0.5 otherwise the relative boxes can't be measure correctly.
+        // Then the first animation frame when we resolve relative delta,
+        // and then finally the first relative frame.
         return frame >= 2 ? 0.5 : 0
     }
 }

--- a/dev/projection/script-undo.js
+++ b/dev/projection/script-undo.js
@@ -73,7 +73,9 @@ Undo.createNode = (element, parent, options = {}, overrideId) => {
             node.resumingFrom.resumingFrom = undefined
         }
         // hasLayoutChanged && // or existing delta is not nothing - this needs to be reinstated to fix breaking tests
-        hasLayoutChanged && node.setAnimationOrigin(delta)
+        if((node.resumeFrom && node.resumeFrom.instance) || hasLayoutChanged) {
+             node.setAnimationOrigin(delta)
+        }
     })
 
     node.setValue = (key, value) => {

--- a/dev/projection/shared-nested-promote-new-mix-interrupt.html
+++ b/dev/projection/shared-nested-promote-new-mix-interrupt.html
@@ -98,34 +98,38 @@
             newBoxProjection.root.didUpdate()
 
             let midBox = { bottom: 100, left: 50, right: 125, top: 50 }
-            matchViewportBox(child, midBox)
-            matchViewportBox(newChild, midBox)
-            matchVisibility(child, "visible")
-            matchVisibility(newChild, "visible")
-            matchOpacity(box, 1)
-            matchOpacity(newBox, 1)
-            matchOpacity(child, 1)
-            matchOpacity(newChild, 1)
+            sync.postRender(() => {
+                matchViewportBox(child, midBox)
+                matchViewportBox(newChild, midBox)
+                matchVisibility(child, "visible")
+                matchVisibility(newChild, "visible")
+                matchOpacity(box, 1)
+                matchOpacity(newBox, 1)
+                matchOpacity(child, 1)
+                matchOpacity(newChild, 1)
 
-            boxProjection.willUpdate()
-            childProjection.willUpdate()
-            newBoxProjection.willUpdate()
-            newChildProjection.willUpdate()
+                boxProjection.willUpdate()
+                childProjection.willUpdate()
+                newBoxProjection.willUpdate()
+                newChildProjection.willUpdate()
 
-            boxProjection.promote()
-            childProjection.promote()
+                boxProjection.promote()
+                childProjection.promote()
 
-            newBoxProjection.root.didUpdate()
+                newBoxProjection.root.didUpdate()
 
-            midBox = { bottom: 75, left: 25, right: 87.5, top: 25 }
-            matchViewportBox(child, midBox)
-            matchViewportBox(newChild, midBox)
-            matchVisibility(child, "visible")
-            matchVisibility(newChild, "visible")
-            matchOpacity(box, 1)
-            matchOpacity(newBox, 1)
-            matchOpacity(child, 1)
-            matchOpacity(newChild, 1)
+                midBox = { bottom: 75, left: 25, right: 87.5, top: 25 }
+                sync.postRender(() => {
+                    matchViewportBox(child, midBox)
+                    matchViewportBox(newChild, midBox)
+                    matchVisibility(child, "visible")
+                    matchVisibility(newChild, "visible")
+                    matchOpacity(box, 1)
+                    matchOpacity(newBox, 1)
+                    matchOpacity(child, 1)
+                    matchOpacity(newChild, 1)
+                })
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-promote-needs-reset.html
+++ b/dev/projection/shared-promote-needs-reset.html
@@ -150,23 +150,25 @@
 
             childProjection.root.didUpdate()
 
-            // only update child layout
-            childProjection.willUpdate()
+            sync.postRender(() => {
+                // only update child layout
+                childProjection.willUpdate()
 
-            child.classList.add("moved")
+                child.classList.add("moved")
 
-            childProjection.root.didUpdate()
+                childProjection.root.didUpdate()
 
-            const midChildBox = {
-                left: 0,
-                right: 50,
-                top: 75,
-                bottom: 125,
-            }
+                sync.postRender(() => {
+                    const midChildBox = {
+                        left: 0,
+                        right: 50,
+                        top: 75,
+                        bottom: 125,
+                    }
 
-            setTimeout(() => {
-                matchViewportBox(child, midChildBox)
-            }, 50)
+                    matchViewportBox(child, midChildBox)
+                })
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-promote-new-mix-interrupt.html
+++ b/dev/projection/shared-promote-new-mix-interrupt.html
@@ -72,8 +72,10 @@
             newBoxProjection.root.didUpdate()
 
             let midBox = { bottom: 250, left: 50, right: 200, top: 50 }
-            matchViewportBox(box, midBox)
-            matchViewportBox(newBox, midBox)
+            sync.postRender(() => {
+                matchViewportBox(box, midBox)
+                matchViewportBox(newBox, midBox)
+            })
             // matchVisibility(box, "visible")
             // matchVisibility(newBox, "visible")
             // matchOpacity(box, 1)

--- a/dev/projection/shared-promote-new-mix-remove.html
+++ b/dev/projection/shared-promote-new-mix-remove.html
@@ -71,16 +71,18 @@
 
             newBoxProjection.root.didUpdate()
 
-            const midBox = { bottom: 250, left: 50, right: 200, top: 50 }
-            matchViewportBox(newBox, midBox)
-            matchVisibility(newBox, "visible")
+            sync.postRender(() => {
+                const midBox = { bottom: 250, left: 50, right: 200, top: 50 }
+                matchViewportBox(newBox, midBox)
+                matchVisibility(newBox, "visible")
 
-            /**
-             * Should animate from the old opacity to the new one
-             * IMPORTANT: Don't make the previous opacity something non-default
-             */
-            matchOpacity(newBox, 0.9)
-            matchBorderRadius(newBox, "6.66667% / 5%")
+                /**
+                 * Should animate from the old opacity to the new one
+                 * IMPORTANT: Don't make the previous opacity something non-default
+                 */
+                matchOpacity(newBox, 0.9)
+                matchBorderRadius(newBox, "6.66667% / 5%")
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-promote-new-mix-rotate-layout.html
+++ b/dev/projection/shared-promote-new-mix-rotate-layout.html
@@ -112,17 +112,19 @@
             })
             childAProjection.root.didUpdate()
 
-            const parentBbox = parentB.getBoundingClientRect()
-            matchViewportBox(parentA, parentBbox)
+            sync.postRender(() => {
+                const parentBbox = parentB.getBoundingClientRect()
+                matchViewportBox(parentA, parentBbox)
 
-            const childBbox = childB.getBoundingClientRect()
-            // TODO: Nested transforms not expected to match currently
-            // matchViewportBox(childA, childBbox)
+                const childBbox = childB.getBoundingClientRect()
+                // TODO: Nested transforms not expected to match currently
+                // matchViewportBox(childA, childBbox)
 
-            matchRotate(parentA, 22.5)
-            matchRotate(childA, 22.5)
-            matchRotate(parentB, 22.5)
-            matchRotate(childB, 22.5)
+                matchRotate(parentA, 22.5)
+                matchRotate(childA, 22.5)
+                matchRotate(parentB, 22.5)
+                matchRotate(childB, 22.5)
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-promote-new-mix-rotate-remove.html
+++ b/dev/projection/shared-promote-new-mix-rotate-remove.html
@@ -72,10 +72,12 @@
 
             newBoxProjection.root.didUpdate()
 
-            matchVisibility(newBox, "visible")
-            matchOpacity(newBox, 1)
-            matchRotate(newBox, 20)
-            matchBorderRadius(newBox, "6.66667% / 5%")
+            sync.postRender(() => {
+                matchVisibility(newBox, "visible")
+                matchOpacity(newBox, 1)
+                matchRotate(newBox, 20)
+                matchBorderRadius(newBox, "6.66667% / 5%")
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-promote-new-mix-rotate.html
+++ b/dev/projection/shared-promote-new-mix-rotate.html
@@ -70,17 +70,19 @@
 
             newBoxProjection.root.didUpdate()
 
-            const bbox = newBox.getBoundingClientRect()
-            matchViewportBox(box, bbox)
-            matchVisibility(box, "visible")
-            matchVisibility(newBox, "visible")
-            matchOpacity(box, 0.8)
-            matchOpacity(newBox, 1)
-            matchRotate(box, 20)
-            matchRotate(newBox, 20)
+            sync.postRender(() => {
+                const bbox = newBox.getBoundingClientRect()
+                matchViewportBox(box, bbox)
+                matchVisibility(box, "visible")
+                matchVisibility(newBox, "visible")
+                matchOpacity(box, 0.8)
+                matchOpacity(newBox, 1)
+                matchRotate(box, 20)
+                matchRotate(newBox, 20)
 
-            matchBorderRadius(box, "6.66667% / 5%")
-            matchBorderRadius(newBox, "6.66667% / 5%")
+                matchBorderRadius(box, "6.66667% / 5%")
+                matchBorderRadius(newBox, "6.66667% / 5%")
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-promote-new-mix.html
+++ b/dev/projection/shared-promote-new-mix.html
@@ -68,16 +68,18 @@
 
             newBoxProjection.root.didUpdate()
 
-            const midBox = { bottom: 250, left: 50, right: 200, top: 50 }
-            matchViewportBox(box, midBox)
-            matchViewportBox(newBox, midBox)
-            matchVisibility(box, "visible")
-            matchVisibility(newBox, "visible")
-            matchOpacity(box, 0.8)
-            matchOpacity(newBox, 1)
+            sync.postRender(() => {
+                const midBox = { bottom: 250, left: 50, right: 200, top: 50 }
+                matchViewportBox(box, midBox)
+                matchViewportBox(newBox, midBox)
+                matchVisibility(box, "visible")
+                matchVisibility(newBox, "visible")
+                matchOpacity(box, 0.8)
+                matchOpacity(newBox, 1)
 
-            matchBorderRadius(box, "6.66667% / 5%")
-            matchBorderRadius(newBox, "6.66667% / 5%")
+                matchBorderRadius(box, "6.66667% / 5%")
+                matchBorderRadius(newBox, "6.66667% / 5%")
+            })
         </script>
     </body>
 </html>

--- a/dev/projection/shared-relative-new-child.html
+++ b/dev/projection/shared-relative-new-child.html
@@ -88,18 +88,20 @@
 
             newBoxProjection.root.didUpdate()
 
-            matchViewportBox(newBox, {
-                bottom: 400,
-                left: 100,
-                right: 400,
-                top: 150,
-            })
+            sync.postRender(() => {
+                matchViewportBox(newBox, {
+                    bottom: 400,
+                    left: 100,
+                    right: 400,
+                    top: 150,
+                })
 
-            matchViewportBox(child, {
-                bottom: 210,
-                left: 340,
-                right: 390,
-                top: 160,
+                matchViewportBox(child, {
+                    bottom: 210,
+                    left: 340,
+                    right: 390,
+                    top: 160,
+                })
             })
         </script>
     </body>

--- a/dev/projection/shared-transform-parents-animate-2.html
+++ b/dev/projection/shared-transform-parents-animate-2.html
@@ -84,12 +84,18 @@
 
                 aProjection.root.didUpdate()
 
-                matchViewportBox(a, b.getBoundingClientRect())
-                matchViewportBox(a, {
-                    bottom: 349.9999313354492,
-                    left: 55.00004959106445,
-                    right: 304.999942779541,
-                    top: 100.00005340576172,
+                sync.postRender(() => {
+                    matchViewportBox(a, b.getBoundingClientRect())
+                    matchViewportBox(a, {
+                        bottom: 350,
+                        height: 250,
+                        left: 55,
+                        right: 305,
+                        top: 100,
+                        width: 250,
+                        x: 55,
+                        y: 100,
+                    })
                 })
             })
         </script>

--- a/dev/projection/shared-transform-parents-animate.html
+++ b/dev/projection/shared-transform-parents-animate.html
@@ -90,9 +90,11 @@
 
                 newChildProjection.root.didUpdate()
 
-                matchViewportBox(child, newChild.getBoundingClientRect())
-                matchOpacity(child, 1)
-                matchOpacity(newChild, 1)
+                sync.postRender(() => {
+                    matchViewportBox(child, newChild.getBoundingClientRect())
+                    matchOpacity(child, 1)
+                    matchOpacity(newChild, 1)
+                })
             })
         </script>
     </body>

--- a/src/motion/features/layout/types.ts
+++ b/src/motion/features/layout/types.ts
@@ -63,4 +63,11 @@ export interface LayoutProps {
      * @public
      */
     layoutDependency?: any
+
+    /**
+     * Wether a projection node should measure its scroll when it or its descendants update their layout.
+     *
+     * @public
+     */
+    shouldMeasureScroll?: boolean
 }

--- a/src/motion/features/use-projection.ts
+++ b/src/motion/features/use-projection.ts
@@ -13,6 +13,7 @@ export function useProjection(
         drag,
         dragConstraints,
         onProjectionUpdate,
+        shouldMeasureScroll,
     }: MotionProps,
     visualElement?: VisualElement,
     initialPromotionConfig?: InitialPromotionConfig
@@ -57,5 +58,6 @@ export function useProjection(
          */
         animationType: typeof layout === "string" ? layout : "both",
         initialPromotionConfig,
+        shouldMeasureScroll,
     })
 }

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -56,6 +56,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "whileFocus",
     "whileTap",
     "whileHover",
+    "shouldMeasureScroll",
 ])
 
 /**

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -363,20 +363,6 @@ export function createProjectionNode<I>({
                 this.root.registerSharedNode(layoutId, this)
             }
 
-            if (
-                this !== this.root &&
-                this.options.shouldMeasureScroll === undefined &&
-                this.instance instanceof Element
-            ) {
-                const computedStyle = getComputedStyle(this.instance)
-                if (
-                    computedStyle.overflowX === "scroll" ||
-                    computedStyle.overflowY === "scroll"
-                ) {
-                    this.setOptions({ shouldMeasureScroll: true })
-                }
-            }
-
             // Only register the handler if it requires layout animation
             if (
                 this.options.animate !== false &&

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -854,7 +854,9 @@ export function createProjectionNode<I>({
              * delete our target sources for the following frame.
              */
             this.isTreeAnimating = Boolean(
-                this.parent?.isTreeAnimating || this.currentAnimation
+                this.parent?.isTreeAnimating ||
+                    this.currentAnimation ||
+                    this.pendingAnimation
             )
             if (!this.isTreeAnimating) {
                 this.targetDelta = this.relativeTarget = undefined
@@ -1044,6 +1046,7 @@ export function createProjectionNode<I>({
             }
             if (this.pendingAnimation) {
                 cancelSync.update(this.pendingAnimation)
+                this.pendingAnimation = undefined
             }
             /**
              * Start the animation in the next frame to have a frame with progress 0,
@@ -1068,6 +1071,8 @@ export function createProjectionNode<I>({
                 if (this.resumingFrom) {
                     this.resumingFrom.currentAnimation = this.currentAnimation
                 }
+
+                this.pendingAnimation = undefined
             })
         }
 


### PR DESCRIPTION
This PR fixes 2 issues:
- Relative projection for child components with a 0s transition. https://github.com/framer/company/issues/22848 
By starting the animation one frame later we ensure there's an animation frame with progress 0, so on the first frame the target should be the same as when the animation actually starts. This prevents elements with a 0s transition from shooting out of their parent boxes.
- A projection node might get an outdated layout on mount if the ancestors update their scroll after the prev lead unmounts. https://github.com/framer/company/issues/22872