### PR TITLE
Fix unmounting component in a LayoutGroup doesn't trigger sibling animation

### DIFF
--- a/cypress/integration/layout-shared.ts
+++ b/cypress/integration/layout-shared.ts
@@ -825,3 +825,22 @@ describe("Shared layout: nested crossfade transition", () => {
             })
     })
 })
+
+describe("Shared layout: component unmounts in a LayoutGroup", () => {
+    it("Should trigger sibling animation when unmount", () => {
+        cy.visit("?test=layout-group-unmount")
+            .wait(50)
+            .get("#a")
+            .trigger("click")
+            .wait(50)
+            .get("#b")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 90,
+                    left: 20,
+                    width: 100,
+                    height: 100,
+                })
+            })
+    })
+})

--- a/dev/tests/layout-group-unmount.tsx
+++ b/dev/tests/layout-group-unmount.tsx
@@ -1,0 +1,55 @@
+import { motion, LayoutGroup } from "@framer"
+import * as React from "react"
+import { useState } from "react"
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "red",
+    opacity: 1,
+    borderRadius: 20,
+    margin: 20,
+}
+
+const stackStyle = {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "start",
+}
+
+const Item = () => {
+    const [variant, setVariant] = useState("a")
+    const isVisible = () => variant === "a"
+    return (
+        <LayoutGroup id="group-2">
+            <motion.div style={{ display: "contents" }}>
+                {isVisible() && (
+                    <motion.div
+                        id="a"
+                        layoutId="a"
+                        style={style}
+                        onClick={() => setVariant(variant === "a" ? "b" : "a")}
+                    />
+                )}
+            </motion.div>
+        </LayoutGroup>
+    )
+}
+
+export const App = () => {
+    return (
+        <LayoutGroup id="group-1">
+            <motion.div style={{ display: "contents" }}>
+                <motion.div style={stackStyle}>
+                    <Item />
+                </motion.div>
+                <motion.div
+                    layoutId="b"
+                    style={{ ...style, backgroundColor: "blue" }}
+                    id="b"
+                    transition={{ duration: 0.2, ease: () => 0.5 }}
+                />
+            </motion.div>
+        </LayoutGroup>
+    )
+}

--- a/src/motion/features/layout/MeasureLayout.tsx
+++ b/src/motion/features/layout/MeasureLayout.tsx
@@ -127,10 +127,21 @@ class MeasureLayoutWithContext extends React.Component<
 
 export function MeasureLayout(props: FeatureProps) {
     const [isPresent, safeToRemove] = usePresence()
+    const layoutGroup = useContext(LayoutGroupContext)
+    // Trigger a didUpdate onUnmount for siblings in the same layout group
+    React.useEffect(() => {
+        return () => {
+            const { visualElement } = props
+            const { projection } = visualElement
+            if (layoutGroup.group && projection?.isLayoutDirty) {
+                projection.root?.didUpdate()
+            }
+        }
+    }, [])
     return (
         <MeasureLayoutWithContext
             {...props}
-            layoutGroup={useContext(LayoutGroupContext)}
+            layoutGroup={layoutGroup}
             switchLayoutGroup={useContext(SwitchLayoutGroupContext)}
             isPresent={isPresent}
             safeToRemove={safeToRemove}


### PR DESCRIPTION
Partially fixes https://github.com/framer/company/issues/22855

If an unmounting component is the only thing triggering an update in a `LayoutGroup`, it marks all members in the same layout group dirty but doesn't trigger a `didUpdate` so siblings won't animate. This PR fixes it by running `didUpdate` in the cleanup of an unmount effect.