### PR TITLE
Calculate visualDelta with measured layout

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -398,8 +398,10 @@ export interface IProjectionNode<I = unknown> {
     // 
     // (undocumented)
     latestValues: ResolvedValues;
+    // Warning: (ae-forgotten-export) The symbol "Layout" needs to be exported by the entry point index.d.ts
+    // 
     // (undocumented)
-    layout?: Box;
+    layout?: Layout;
     // (undocumented)
     measure(): Box;
     // (undocumented)

--- a/dev/projection/element-scroll-layout-change.html
+++ b/dev/projection/element-scroll-layout-change.html
@@ -1,0 +1,87 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #scroll {
+                overflow: scroll;
+                position: relative;
+                height: 200px;
+                width: 500px;
+            }
+
+            #box {
+                position: absolute;
+                left: 0px;
+                top: 0px;
+                width: 100px;
+                height: 100px;
+                background: #00cc88;
+            }
+
+            #box.b {
+                left: 100px;
+            }
+
+            .trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="scroll">
+            <div id="box"></div>
+            <div class="trigger-overflow"></div>
+        </div>
+        <div class="trigger-overflow"></div>
+
+        <script src="../../dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchOpacity,
+                matchBorderRadius,
+                addPageScroll,
+            } = window.Assert
+
+            const scroll = document.getElementById("scroll")
+            const box = document.getElementById("box")
+
+            scroll.scrollTop = 50
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            const scrollProjection = createNode(scroll, undefined, {
+                shouldMeasureScroll: true,
+            })
+
+            const boxProjection = createNode(box, scrollProjection)
+            boxProjection.setValue("borderRadius", 20)
+
+            boxProjection.willUpdate()
+
+            box.classList.add("b")
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, boxOrigin)
+            matchOpacity(box, 1)
+            matchBorderRadius(box, "20%")
+        </script>
+    </body>
+</html>

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -239,7 +239,7 @@ export class VisualElementDragControls {
         } else {
             if (dragConstraints && layout) {
                 this.constraints = calcRelativeConstraints(
-                    layout,
+                    layout.actual,
                     dragConstraints
                 )
             } else {
@@ -262,7 +262,7 @@ export class VisualElementDragControls {
             eachAxis((axis) => {
                 if (this.getAxisMotionValue(axis)) {
                     this.constraints[axis] = rebaseAxisConstraints(
-                        layout[axis],
+                        layout.actual[axis],
                         this.constraints[axis]
                     )
                 }
@@ -296,7 +296,7 @@ export class VisualElementDragControls {
         )
 
         let measuredConstraints = calcViewportConstraints(
-            projection.layout,
+            projection.layout.actual,
             constraintsBox
         )
 

--- a/src/projection/node/types.ts
+++ b/src/projection/node/types.ts
@@ -15,6 +15,11 @@ export interface Snapshot {
     isShared?: boolean
 }
 
+export interface Layout {
+    measured: Box
+    actual: Box // with scroll removed
+}
+
 export type LayoutEvents =
     | "willUpdate"
     | "didUpdate"
@@ -34,7 +39,7 @@ export interface IProjectionNode<I = unknown> {
     unmount: () => void
     options: ProjectionNodeOptions
     setOptions(options: ProjectionNodeOptions): void
-    layout?: Box
+    layout?: Layout
     snapshot?: Snapshot
     target?: Box
     targetWithTransforms?: Box


### PR DESCRIPTION
Our `visualDelta` was calculated using the measured snapshot and the actual layout (without the scroll), as a result it would always contain the scroll offset regardless of the layout change if there's a parent scroll. This PR extends the `layout` prop to record the measured layout, and use it to calculate the `visualDelta`.

Fixes issue flagged in https://github.com/framer/FramerStudio/pull/9739