### PR TITLE
Fix: sibling animations triggered by unmount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,12 @@ publish: clean bootstrap
 	npm publish
 	git push
 
-test: yarn test
+test: bootstrap
+	yarn test
 	yarn tsc dist/framer-motion.d.ts --skipLibCheck
 
-test-ci: mkdir -p $(TEST_REPORT_PATH)
+test-ci: bootstrap
+	mkdir -p $(TEST_REPORT_PATH)
 	JEST_JUNIT_OUTPUT=$(TEST_REPORT_PATH)/framer-motion.xml yarn test-ci --ci --reporters=jest-junit
 	yarn tsc dist/framer-motion.d.ts --skipLibCheck
 

--- a/Makefile
+++ b/Makefile
@@ -70,12 +70,10 @@ publish: clean bootstrap
 
 test: bootstrap
 	yarn test
-	yarn tsc dist/framer-motion.d.ts --skipLibCheck
 
 test-ci: bootstrap
 	mkdir -p $(TEST_REPORT_PATH)
 	JEST_JUNIT_OUTPUT=$(TEST_REPORT_PATH)/framer-motion.xml yarn test-ci --ci --reporters=jest-junit
-	yarn tsc dist/framer-motion.d.ts --skipLibCheck
 
 lint: bootstrap
 	yarn lint

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "build": "yarn clean && tsc -p . && rollup -c",
         "clean": "rm -rf types dist lib",
         "test-ci": "yarn test-client && yarn test-server",
-        "test-client": "jest --coverage --config jest.config.json",
+        "test-client": "jest --coverage --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-projection": "yarn run collect-projection-tests && start-server-and-test 'python -m SimpleHTTPServer' http://localhost:8000 'yarn run cypress run -s cypress/integration/projection.ts --config baseUrl=http://0.0.0.0:8000/'",
         "test-e2e": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --config ignoreTestFiles=projection.ts'",

--- a/src/motion/features/layout/MeasureLayout.tsx
+++ b/src/motion/features/layout/MeasureLayout.tsx
@@ -27,12 +27,8 @@ class MeasureLayoutWithContext extends React.Component<
      * in order to incorporate transforms
      */
     componentDidMount() {
-        const {
-            visualElement,
-            layoutGroup,
-            switchLayoutGroup,
-            layoutId,
-        } = this.props
+        const { visualElement, layoutGroup, switchLayoutGroup, layoutId } =
+            this.props
         const { projection } = visualElement
 
         addScaleCorrector(defaultScaleCorrectors)
@@ -110,7 +106,7 @@ class MeasureLayoutWithContext extends React.Component<
         const { projection } = visualElement
 
         if (projection) {
-            projection.root!.scheduleUpdateFailedCheck()
+            projection.scheduleCheckAfterUnmount()
             if (layoutGroup?.group) layoutGroup.group.remove(projection)
             if (promoteContext?.deregister)
                 promoteContext.deregister(projection)
@@ -129,16 +125,7 @@ class MeasureLayoutWithContext extends React.Component<
 export function MeasureLayout(props: FeatureProps) {
     const [isPresent, safeToRemove] = usePresence()
     const layoutGroup = useContext(LayoutGroupContext)
-    // Trigger a didUpdate onUnmount for siblings in the same layout group
-    React.useEffect(() => {
-        return () => {
-            const { visualElement } = props
-            const { projection } = visualElement
-            if (layoutGroup.group && projection?.isLayoutDirty) {
-                projection.root?.didUpdate()
-            }
-        }
-    }, [])
+
     return (
         <MeasureLayoutWithContext
             {...props}

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -571,8 +571,19 @@ export function createProjectionNode<I>({
             sync.preRender(this.updateProjection, false, true)
         }
 
-        scheduleUpdateFailedCheck() {
-            sync.postRender(this.checkUpdateFailed)
+        scheduleCheckAfterUnmount() {
+            /**
+             * If the unmounting node is in a layoutGroup and did trigger a willUpdate,
+             * we manually call didUpdate to give a chance to the siblings to animate.
+             * Otherwise, cleanup all snapshots to prevents future nodes from reusing them.
+             */
+            sync.postRender(() => {
+                if (this.isLayoutDirty) {
+                    this.root.didUpdate()
+                } else {
+                    this.root.checkUpdateFailed()
+                }
+            })
         }
 
         checkUpdateFailed = () => {

--- a/src/projection/node/types.ts
+++ b/src/projection/node/types.ts
@@ -69,7 +69,8 @@ export interface IProjectionNode<I = unknown> {
     clearSnapshot(): void
     updateScroll(): void
     scheduleUpdateProjection(): void
-    scheduleUpdateFailedCheck(): void
+    scheduleCheckAfterUnmount(): void
+    checkUpdateFailed(): void
     potentialNodes: Map<number, IProjectionNode>
     sharedNodes: Map<string, NodeStack>
     registerPotentialNode(id: number, node: IProjectionNode): void


### PR DESCRIPTION
Previously we fixed the sibling animation triggered by an unmounting element by calling `didUpdate` in a React effect cleanup, but that no longer works because `checkUpdateFailed` cancel the update before the effect runs.
This PR moves it into `scheduleCheckUpdateFailed` (renamed to `scheduleCheckAfterUnmount`) so that we either run `didUpdate` or clear all the snapshots.