### PR TITLE
Fixing unwanted animations when scroll changes

### DIFF
--- a/cypress/integration/layout-viewport-jump.ts
+++ b/cypress/integration/layout-viewport-jump.ts
@@ -51,7 +51,7 @@ describe("Viewport jump", () => {
     /**
      * This passes locally but can't get it to pass in Cypress
      */
-    it.skip("If div scroll jumps, don't trigger layout animation if provided shouldMeasureScroll prop", () => {
+    it("If div scroll jumps, don't trigger layout animation if provided shouldMeasureScroll prop", () => {
         cy.visit("?test=layout-viewport-jump&nested=true")
             .wait(50)
             .get("#box")

--- a/dev/projection/element-scroll-to-layout.html
+++ b/dev/projection/element-scroll-to-layout.html
@@ -65,9 +65,8 @@
             const scroll = document.getElementById("scroll")
             const box = document.getElementById("box")
 
-            scroll.scrollLeft = 50
-
             const boxOrigin = box.getBoundingClientRect()
+            scroll.scrollLeft = 50
 
             const scrollProjection = createNode(scroll, undefined, {
                 shouldMeasureScroll: true,
@@ -82,6 +81,9 @@
 
             boxProjection.root.didUpdate()
 
+            /**
+             * Don't animate the box from its previous position if the scroll has changed.
+             */
             matchViewportBox(box, boxOrigin)
             matchOpacity(box, 1)
             matchBorderRadius(box, "20%")

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -604,14 +604,13 @@ export function createProjectionNode<I>({
         updateSnapshot() {
             if (this.snapshot || !this.instance) return
             const measured = this.measure()!
-
-            const visible = this.removeTransform(measured)!
-            const layout = this.removeElementScroll(visible)
+            const layout = this.removeElementScroll(
+                this.removeTransform(measured)
+            )
             roundBox(layout)
 
             this.snapshot = {
                 measured,
-                visible,
                 layout,
                 latestValues: {},
             }
@@ -722,6 +721,7 @@ export function createProjectionNode<I>({
             for (let i = 0; i < this.path.length; i++) {
                 const node = this.path[i]
                 const { scroll, options } = node
+
                 if (
                     node !== this.root &&
                     scroll &&
@@ -1445,7 +1445,7 @@ function notifyLayoutUpdate(node: IProjectionNode) {
             eachAxis((axis) => {
                 const axisSnapshot = snapshot.isShared
                     ? snapshot.measured[axis]
-                    : snapshot.visible[axis]
+                    : snapshot.layout[axis]
                 const length = calcLength(axisSnapshot)
                 axisSnapshot.min = layout[axis].min
                 axisSnapshot.max = axisSnapshot.min + length
@@ -1454,7 +1454,7 @@ function notifyLayoutUpdate(node: IProjectionNode) {
             eachAxis((axis) => {
                 const axisSnapshot = snapshot.isShared
                     ? snapshot.measured[axis]
-                    : snapshot.visible[axis]
+                    : snapshot.layout[axis]
                 const length = calcLength(layout[axis])
                 axisSnapshot.max = axisSnapshot.min + length
             })
@@ -1463,7 +1463,6 @@ function notifyLayoutUpdate(node: IProjectionNode) {
         const layoutDelta = createDelta()
         calcBoxDelta(layoutDelta, layout, snapshot.layout)
         const visualDelta = createDelta()
-
         if (snapshot.isShared) {
             calcBoxDelta(
                 visualDelta,
@@ -1471,7 +1470,7 @@ function notifyLayoutUpdate(node: IProjectionNode) {
                 snapshot.measured
             )
         } else {
-            calcBoxDelta(visualDelta, measuredLayout, snapshot.visible)
+            calcBoxDelta(visualDelta, layout, snapshot.layout)
         }
 
         const hasLayoutChanged = !isDeltaZero(layoutDelta)

--- a/src/projection/node/types.ts
+++ b/src/projection/node/types.ts
@@ -10,7 +10,6 @@ import { InitialPromotionConfig } from "../../context/SwitchLayoutGroupContext"
 export interface Snapshot {
     measured: Box
     layout: Box
-    visible: Box
     latestValues: ResolvedValues
     isShared?: boolean
 }


### PR DESCRIPTION
This PR changes the snapshot used to calculate layout animations when the layout changes to correctly incorporate parent element scrolls.

Related https://github.com/framer/company/issues/22983