### PR TITLE
Fix snapshot in scrolled & scaled parent

### DIFF
--- a/dev/projection/single-element-element-scroll-scale.html
+++ b/dev/projection/single-element-element-scroll-scale.html
@@ -1,0 +1,89 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 300px;
+                height: 100px;
+                position: absolute;
+                top: 200px;
+                left: 50%;
+            }
+
+            #button {
+                position: absolute;
+                inset: 0;
+                background-color: #00cc88;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+
+            #scroll {
+                position: relative;
+                width: 800px;
+                height: 400px;
+                overflow: scroll;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="scroll">
+            <div id="box"><div id="button"></div></div>
+            <div id="trigger-overflow"></div>
+        </div>
+
+        <script src="../../dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox } = window.Assert
+
+            const scroll = document.getElementById("scroll")
+            const scrollProjection = createNode(scroll, undefined, {
+                shouldMeasureScroll: true,
+            })
+            const box = document.getElementById("box")
+            const boxProjection = createNode(box, scrollProjection)
+
+            const button = document.getElementById("button")
+            const buttonProjection = createNode(button, boxProjection)
+
+            const scrollDistance = 100
+
+            scroll.scrollTop = scrollDistance
+            scroll.scrollLeft = scrollDistance
+
+            boxProjection.setValue("scale", 2)
+            boxProjection.options.visualElement.syncRender()
+
+            const boxOrigin = box.getBoundingClientRect()
+            const buttonOrigin = button.getBoundingClientRect()
+
+            requestAnimationFrame(() => {
+                buttonProjection.willUpdate()
+                boxProjection.willUpdate()
+
+                boxProjection.root.didUpdate()
+
+                matchViewportBox(box, boxOrigin)
+                matchViewportBox(button, buttonOrigin)
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/single-element-page-scroll-scale.html
+++ b/dev/projection/single-element-page-scroll-scale.html
@@ -1,0 +1,73 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 300px;
+                height: 100px;
+                position: absolute;
+                top: 200px;
+                left: 50%;
+            }
+
+            #button {
+                position: absolute;
+                inset: 0;
+                background-color: #00cc88;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="box"><div id="button"></div></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+            const box = document.getElementById("box")
+            const boxProjection = createNode(box)
+
+            const button = document.getElementById("button")
+            const buttonProjection = createNode(button, boxProjection)
+
+            const scrollDistance = 100
+
+            window.scrollTo(scrollDistance, scrollDistance)
+            boxProjection.setValue("scale", 2)
+            boxProjection.options.visualElement.syncRender()
+
+            const boxOrigin = box.getBoundingClientRect()
+            const buttonOrigin = button.getBoundingClientRect()
+
+            requestAnimationFrame(() => {
+                buttonProjection.willUpdate()
+                boxProjection.willUpdate()
+
+                boxProjection.root.didUpdate()
+
+                matchViewportBox(box, boxOrigin)
+                matchViewportBox(button, buttonOrigin)
+            })
+        </script>
+    </body>
+</html>

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -608,20 +608,7 @@ export function createProjectionNode<I>({
                 this.removeElementScroll(measured)
             )
             roundBox(layout)
-            // if (this.instance.id === "box")
-            //     console.log(
-            //         "box measured as",
-            //         measured.y,
-            //         this.removeTransform(measured).y,
-            //         layout.y
-            //     )
-            // if (this.instance.id === "button")
-            //     console.log(
-            //         "button measured as",
-            //         measured.y,
-            //         this.removeTransform(measured).y,
-            //         layout.y
-            //     )
+
             this.snapshot = {
                 measured,
                 layout,

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -604,11 +604,24 @@ export function createProjectionNode<I>({
         updateSnapshot() {
             if (this.snapshot || !this.instance) return
             const measured = this.measure()!
-            const layout = this.removeElementScroll(
-                this.removeTransform(measured)
+            const layout = this.removeTransform(
+                this.removeElementScroll(measured)
             )
             roundBox(layout)
-
+            // if (this.instance.id === "box")
+            //     console.log(
+            //         "box measured as",
+            //         measured.y,
+            //         this.removeTransform(measured).y,
+            //         layout.y
+            //     )
+            // if (this.instance.id === "button")
+            //     console.log(
+            //         "button measured as",
+            //         measured.y,
+            //         this.removeTransform(measured).y,
+            //         layout.y
+            //     )
             this.snapshot = {
                 measured,
                 layout,
@@ -645,6 +658,7 @@ export function createProjectionNode<I>({
 
             const measured = this.measure()
             roundBox(measured)
+
             const prevLayout = this.layout
             this.layout = {
                 measured,


### PR DESCRIPTION
Snapshots were being recorded incorrectly within one parent that was scrolled and another that was a scaled.

I suspect this was from an improperly computed `originPoint`. Switching the order we removed scroll & transform fixes it, I'm not 100% sure why but the measured viewport box is returned with the page scroll already removed so it makes sense to remove the element scroll next and then transforms.