### PR TITLE
Fix: don't assign non-lead element layout to lead target 

### DIFF
--- a/dev/projection/shared-promote-target.html
+++ b/dev/projection/shared-promote-target.html
@@ -1,0 +1,148 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box-a {
+                position: absolute;
+                left: 100px;
+                top: 100px;
+                width: 200px;
+                height: 200px;
+                background-color: #00cc88;
+            }
+
+            #box-b {
+                position: absolute;
+                left: 600px;
+                top: 100px;
+                width: 200px;
+                height: 200px;
+                background-color: #09f;
+            }
+
+            #button {
+                width: 100px;
+                height: 100px;
+                top: 0;
+                left: 0;
+                background-color: rgb(132, 0, 255);
+            }
+
+            #button.b {
+                width: 300px;
+            }
+
+            #child-a,
+            #child-b {
+                position: absolute;
+                left: 0;
+                top: 0;
+                width: 50px;
+                height: 50px;
+                background-color: yellow;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="box-a"><div id="child-a"></div></div>
+        <div id="button"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode } = window.Animate
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+            } = window.Assert
+
+            const a = document.getElementById("box-a")
+            const childA = document.getElementById("child-a")
+            const c = document.getElementById("button")
+
+            const aProjection = createNode(
+                a,
+                undefined,
+                { layoutId: "box" },
+                { duration: 0.1 }
+            )
+
+            const childAProjection = createNode(
+                childA,
+                aProjection,
+                {
+                    layoutId: "child",
+                },
+                { duration: 0.1 }
+            )
+            const cProjection = createNode(
+                c,
+                undefined,
+                { layoutId: "foo" },
+                { duration: 0.1 }
+            )
+
+            aProjection.willUpdate()
+            childAProjection.willUpdate()
+
+            const b = document.createElement("div")
+            const childB = document.createElement("div")
+            b.id = "box-b"
+            childB.id = "child-b"
+            b.appendChild(childB)
+            document.body.appendChild(b)
+            const bProjection = createNode(
+                b,
+                undefined,
+                {
+                    layoutId: "box",
+                },
+                { duration: 0.1 }
+            )
+            const childBProjection = createNode(
+                childB,
+                bProjection,
+                {
+                    layoutId: "child",
+                },
+                { duration: 0.1 }
+            )
+
+            aProjection.root.didUpdate()
+
+            // After the shared animation finished
+            setTimeout(() => {
+                cProjection.willUpdate()
+                c.classList.add("b")
+                cProjection.root.didUpdate()
+
+                matchViewportBox(childB, {
+                    left: 600,
+                    top: 100,
+                    height: 50,
+                    width: 50,
+                })
+            }, 200)
+        </script>
+    </body>
+</html>

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -971,22 +971,6 @@ export function createProjectionNode<I>({
                 Boolean(this.resumingFrom) || this !== lead
             )
 
-            // If the child's layout hasn't changed but the parent has changed,
-            // we should calculate a scale to keep the child at the same size.
-            if (!lead.target) {
-                const isScaleOnly = !boxEquals(
-                    this.layoutCorrected,
-                    this.layout.actual
-                )
-
-                if (isScaleOnly) {
-                    lead.target = createBox()
-                    lead.targetWithTransforms = createBox()
-
-                    copyBoxInto(lead.target, this.layout.actual)
-                }
-            }
-
             const { target } = lead
             if (!target) return
 

--- a/src/projection/styles/scale-border-radius.ts
+++ b/src/projection/styles/scale-border-radius.ts
@@ -16,6 +16,7 @@ export function pixelsToPercent(pixels: number, axis: Axis): number {
  */
 export const correctBorderRadius: ScaleCorrectorDefinition = {
     correct: (latest, node) => {
+        if (!node.target) return latest
         /**
          * If latest is a string, if it's a percentage we can return immediately as it's
          * going to be stretched appropriately. Otherwise, if it's a pixel, convert it to a number.
@@ -32,8 +33,8 @@ export const correctBorderRadius: ScaleCorrectorDefinition = {
          * If latest is a number, it's a pixel value. We use the current viewportBox to calculate that
          * pixel value as a percentage of each axis
          */
-        const x = pixelsToPercent(latest, node.target!.x)
-        const y = pixelsToPercent(latest, node.target!.y)
+        const x = pixelsToPercent(latest, node.target.x)
+        const y = pixelsToPercent(latest, node.target.y)
 
         return `${x}% ${y}%`
     },


### PR DESCRIPTION
1. We already cover the case where an element's layout didn't change but its position relative to its parent changed, so this part of the code should not be needed anymore. Removing this bit also fixes a bug where after a shared layout animation, an update will project the lead to its prevLead's layout.

2. If `node.target` doesn't exist, don't attempt to do scale correction

fixes: https://framer-team.slack.com/archives/CR3CYA1D4/p1632927233499800?thread_ts=1632843233.472300&cid=CR3CYA1D4