### PR TITLE
fix iframe events and measurements

### DIFF
--- a/api/framer-motion.api.md
+++ b/api/framer-motion.api.md
@@ -478,6 +478,7 @@ export interface MotionConfigContext {
     // @internal (undocumented)
     transformPagePoint: TransformPoint2D;
     transition?: Transition;
+    windowContext: typeof window | null;
 }
 
 // @public (undocumented)
@@ -961,11 +962,11 @@ export interface VisualElement<Instance = any, RenderState = any> extends Lifecy
     // (undocumented)
     getStaticValue(key: string): number | string | undefined;
     // (undocumented)
-    getValue(key: string, defaultValue?: string | number): undefined | MotionValue;
+    getValue(key: string): undefined | MotionValue;
     // (undocumented)
     getValue(key: string, defaultValue: string | number): MotionValue;
     // (undocumented)
-    getValue(key: string): undefined | MotionValue;
+    getValue(key: string, defaultValue?: string | number): undefined | MotionValue;
     // (undocumented)
     getVariant(name: string): Variant | undefined;
     // (undocumented)

--- a/dev/examples/MotionConfig-iframe.tsx
+++ b/dev/examples/MotionConfig-iframe.tsx
@@ -13,11 +13,9 @@ function Frame({ children }) {
     const iframeRef = React.useRef(null)
     const [frame, setFrame] = React.useState<{
         container: HTMLElement
-        document: Document
         window: Window
     }>({
         container: null,
-        document: null,
         window: null,
     })
 
@@ -27,7 +25,6 @@ function Frame({ children }) {
         if (container) {
             setFrame({
                 container,
-                document,
                 window: iframeRef.current.contentWindow,
             })
         }
@@ -50,10 +47,7 @@ function Frame({ children }) {
             {frame.container &&
                 children &&
                 ReactDOM.createPortal(
-                    <MotionConfig
-                        documentContext={frame.document}
-                        windowContext={frame.window}
-                    >
+                    <MotionConfig windowContext={frame.window}>
                         {children}
                     </MotionConfig>,
                     frame.container

--- a/dev/examples/MotionConfig-iframe.tsx
+++ b/dev/examples/MotionConfig-iframe.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+import * as ReactDOM from "react-dom"
+import { MotionConfig } from "@framer"
+import { App as UseViewportScrollExample } from "./useViewportScroll"
+
+export const App = () => (
+    <Frame>
+        <UseViewportScrollExample />
+    </Frame>
+)
+
+function Frame({ children }) {
+    const iframeRef = React.useRef(null)
+    const [frame, setFrame] = React.useState<{
+        container: HTMLElement
+        document: Document
+        window: Window
+    }>({
+        container: null,
+        document: null,
+        window: null,
+    })
+
+    function loadFrame() {
+        const document = iframeRef.current.contentDocument
+        const container = document.getElementById("app")
+        if (container) {
+            setFrame({
+                container,
+                document,
+                window: iframeRef.current.contentWindow,
+            })
+        }
+    }
+
+    React.useEffect(loadFrame, [])
+
+    return (
+        <>
+            <iframe
+                ref={iframeRef}
+                onLoad={loadFrame}
+                srcDoc={`<!DOCTYPE html><html><body><div id='app'>`}
+                style={{
+                    width: 600,
+                    height: 600,
+                    border: "none",
+                }}
+            />
+            {frame.container &&
+                children &&
+                ReactDOM.createPortal(
+                    <MotionConfig
+                        documentContext={frame.document}
+                        windowContext={frame.window}
+                    >
+                        {children}
+                    </MotionConfig>,
+                    frame.container
+                )}
+        </>
+    )
+}

--- a/src/context/MotionConfigContext.tsx
+++ b/src/context/MotionConfigContext.tsx
@@ -27,18 +27,11 @@ export interface MotionConfigContext {
     transition?: Transition
 
     /**
-     * Defines the document context to use for the entire tree.
-     *
-     * @public
-     */
-    documentContext: typeof document
-
-    /**
      * Defines the window context to use for the entire tree.
      *
      * @public
      */
-    windowContext: typeof window
+    windowContext: typeof window | null
 }
 
 /**
@@ -47,6 +40,5 @@ export interface MotionConfigContext {
 export const MotionConfigContext = createContext<MotionConfigContext>({
     transformPagePoint: (p) => p,
     isStatic: false,
-    documentContext: document,
-    windowContext: window,
+    windowContext: typeof window === "undefined" ? null : window,
 })

--- a/src/context/MotionConfigContext.tsx
+++ b/src/context/MotionConfigContext.tsx
@@ -25,6 +25,20 @@ export interface MotionConfigContext {
      * @public
      */
     transition?: Transition
+
+    /**
+     * Defines the document context to use for the entire tree.
+     *
+     * @public
+     */
+    documentContext: typeof document
+
+    /**
+     * Defines the window context to use for the entire tree.
+     *
+     * @public
+     */
+    windowContext: typeof window
 }
 
 /**
@@ -33,4 +47,6 @@ export interface MotionConfigContext {
 export const MotionConfigContext = createContext<MotionConfigContext>({
     transformPagePoint: (p) => p,
     isStatic: false,
+    documentContext: document,
+    windowContext: window,
 })

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -155,6 +155,7 @@ interface PanSessionHandlers {
 
 interface PanSessionOptions {
     transformPagePoint?: TransformPoint2D
+    windowContext: typeof window
 }
 
 interface TimestampedPoint extends Point2D {
@@ -203,7 +204,9 @@ export class PanSession {
     constructor(
         event: AnyPointerEvent,
         handlers: Partial<PanSessionHandlers>,
-        { transformPagePoint }: PanSessionOptions = {}
+        { transformPagePoint, windowContext }: PanSessionOptions = {
+            windowContext: window,
+        }
     ) {
         // If we have more than one touch, don't start detecting this gesture
         if (isTouchEvent(event) && event.touches.length > 1) return
@@ -224,9 +227,17 @@ export class PanSession {
             onSessionStart(event, getPanInfo(initialInfo, this.history))
 
         this.removeListeners = pipe(
-            addPointerEvent(window, "pointermove", this.handlePointerMove),
-            addPointerEvent(window, "pointerup", this.handlePointerUp),
-            addPointerEvent(window, "pointercancel", this.handlePointerUp)
+            addPointerEvent(
+                windowContext,
+                "pointermove",
+                this.handlePointerMove
+            ),
+            addPointerEvent(windowContext, "pointerup", this.handlePointerUp),
+            addPointerEvent(
+                windowContext,
+                "pointercancel",
+                this.handlePointerUp
+            )
         )
     }
 

--- a/src/gestures/PanSession.ts
+++ b/src/gestures/PanSession.ts
@@ -155,7 +155,7 @@ interface PanSessionHandlers {
 
 interface PanSessionOptions {
     transformPagePoint?: TransformPoint2D
-    windowContext: typeof window
+    windowContext: typeof window | null
 }
 
 interface TimestampedPoint extends Point2D {
@@ -226,19 +226,25 @@ export class PanSession {
         onSessionStart &&
             onSessionStart(event, getPanInfo(initialInfo, this.history))
 
-        this.removeListeners = pipe(
-            addPointerEvent(
-                windowContext,
-                "pointermove",
-                this.handlePointerMove
-            ),
-            addPointerEvent(windowContext, "pointerup", this.handlePointerUp),
-            addPointerEvent(
-                windowContext,
-                "pointercancel",
-                this.handlePointerUp
+        if (windowContext) {
+            this.removeListeners = pipe(
+                addPointerEvent(
+                    windowContext,
+                    "pointermove",
+                    this.handlePointerMove
+                ),
+                addPointerEvent(
+                    windowContext,
+                    "pointerup",
+                    this.handlePointerUp
+                ),
+                addPointerEvent(
+                    windowContext,
+                    "pointercancel",
+                    this.handlePointerUp
+                )
             )
-        )
+        }
     }
 
     private updatePoint = () => {

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -49,7 +49,7 @@ export const elementDragControls = new WeakMap<
 
 interface DragControlConfig {
     visualElement: VisualElement
-    windowContext: typeof window
+    windowContext: typeof window | null
 }
 
 export interface DragControlOptions {
@@ -112,7 +112,7 @@ export class VisualElementDragControls {
     /**
      * @internal
      */
-    private windowContext: typeof window
+    private windowContext: typeof window | null
 
     /**
      * @internal
@@ -765,13 +765,11 @@ export class VisualElementDragControls {
          * Attach a window resize listener to scale the draggable target within its defined
          * constraints as the window resizes.
          */
-        const stopResizeListener = addDomEvent(
-            this.windowContext,
-            "resize",
-            () => {
-                this.scalePoint()
-            }
-        )
+        const stopResizeListener = this.windowContext
+            ? addDomEvent(this.windowContext, "resize", () => {
+                  this.scalePoint()
+              })
+            : null
 
         /**
          * Ensure drag constraints are resolved correctly relative to the dragging element

--- a/src/gestures/drag/VisualElementDragControls.ts
+++ b/src/gestures/drag/VisualElementDragControls.ts
@@ -49,6 +49,7 @@ export const elementDragControls = new WeakMap<
 
 interface DragControlConfig {
     visualElement: VisualElement
+    windowContext: typeof window
 }
 
 export interface DragControlOptions {
@@ -111,6 +112,11 @@ export class VisualElementDragControls {
     /**
      * @internal
      */
+    private windowContext: typeof window
+
+    /**
+     * @internal
+     */
     private hasMutatedConstraints: boolean = false
 
     /**
@@ -152,8 +158,9 @@ export class VisualElementDragControls {
      */
     private constraintsBox?: AxisBox2D
 
-    constructor({ visualElement }: DragControlConfig) {
+    constructor({ visualElement, windowContext }: DragControlConfig) {
         this.visualElement = visualElement
+        this.windowContext = windowContext
         this.visualElement.enableLayoutProjection()
         elementDragControls.set(visualElement, this)
     }
@@ -335,7 +342,7 @@ export class VisualElementDragControls {
                 onMove,
                 onSessionEnd,
             },
-            { transformPagePoint }
+            { transformPagePoint, windowContext: this.windowContext }
         )
     }
 
@@ -758,9 +765,13 @@ export class VisualElementDragControls {
          * Attach a window resize listener to scale the draggable target within its defined
          * constraints as the window resizes.
          */
-        const stopResizeListener = addDomEvent(window, "resize", () => {
-            this.scalePoint()
-        })
+        const stopResizeListener = addDomEvent(
+            this.windowContext,
+            "resize",
+            () => {
+                this.scalePoint()
+            }
+        )
 
         /**
          * Ensure drag constraints are resolved correctly relative to the dragging element

--- a/src/gestures/drag/use-drag.ts
+++ b/src/gestures/drag/use-drag.ts
@@ -11,11 +11,14 @@ import { FeatureProps } from "../../motion/features/types"
  */
 export function useDrag(props: FeatureProps) {
     const { dragControls: groupDragControls, visualElement } = props
-    const { transformPagePoint } = useContext(MotionConfigContext)
+    const { transformPagePoint, windowContext } = useContext(
+        MotionConfigContext
+    )
 
     const dragControls = useConstant(() => {
         return new VisualElementDragControls({
             visualElement,
+            windowContext,
         })
     })
 

--- a/src/gestures/use-pan-gesture.ts
+++ b/src/gestures/use-pan-gesture.ts
@@ -26,7 +26,9 @@ export function usePanGesture({
 }: FeatureProps) {
     const hasPanEvents = onPan || onPanStart || onPanEnd || onPanSessionStart
     const panSession = useRef<PanSession | null>(null)
-    const { transformPagePoint } = useContext(MotionConfigContext)
+    const { transformPagePoint, windowContext } = useContext(
+        MotionConfigContext
+    )
 
     const handlers = {
         onSessionStart: onPanSessionStart,
@@ -50,6 +52,7 @@ export function usePanGesture({
     function onPointerDown(event: AnyPointerEvent) {
         panSession.current = new PanSession(event, handlers, {
             transformPagePoint,
+            windowContext,
         })
     }
 

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -1,10 +1,11 @@
-import { useRef } from "react"
+import { useContext, useRef } from "react"
 import { EventInfo } from "../events/types"
 import { isNodeOrChild } from "./utils/is-node-or-child"
 import { addPointerEvent, usePointerEvent } from "../events/use-pointer-event"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
 import { pipe } from "popmotion"
 import { AnimationType } from "../render/utils/types"
+import { MotionConfigContext } from "../context/MotionConfigContext"
 import { isDragActive } from "./drag/utils/lock"
 import { FeatureProps } from "../motion/features/types"
 
@@ -19,6 +20,7 @@ export function useTapGesture({
     whileTap,
     visualElement,
 }: FeatureProps) {
+    const { windowContext } = useContext(MotionConfigContext)
     const hasPressListeners = onTap || onTapStart || onTapCancel || whileTap
     const isPressing = useRef(false)
     const cancelPointerEndListeners = useRef<Function | null>(null)
@@ -60,8 +62,8 @@ export function useTapGesture({
         isPressing.current = true
 
         cancelPointerEndListeners.current = pipe(
-            addPointerEvent(window, "pointerup", onPointerUp),
-            addPointerEvent(window, "pointercancel", onPointerCancel)
+            addPointerEvent(windowContext, "pointerup", onPointerUp),
+            addPointerEvent(windowContext, "pointercancel", onPointerCancel)
         )
 
         onTapStart?.(event, info)

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -61,10 +61,12 @@ export function useTapGesture({
         if (isPressing.current) return
         isPressing.current = true
 
-        cancelPointerEndListeners.current = pipe(
-            addPointerEvent(windowContext, "pointerup", onPointerUp),
-            addPointerEvent(windowContext, "pointercancel", onPointerCancel)
-        )
+        if (windowContext) {
+            cancelPointerEndListeners.current = pipe(
+                addPointerEvent(windowContext, "pointerup", onPointerUp),
+                addPointerEvent(windowContext, "pointercancel", onPointerCancel)
+            )
+        }
 
         onTapStart?.(event, info)
 

--- a/src/value/scroll/use-viewport-scroll.ts
+++ b/src/value/scroll/use-viewport-scroll.ts
@@ -13,10 +13,8 @@ let hasListeners = false
 
 function addEventListeners({
     windowContext,
-    documentContext,
 }: {
     windowContext: typeof window
-    documentContext: typeof document
 }) {
     hasListeners = true
     if (typeof windowContext === "undefined") return
@@ -27,9 +25,11 @@ function addEventListeners({
             xOffset: windowContext.pageXOffset,
             yOffset: windowContext.pageYOffset,
             xMaxOffset:
-                documentContext.body.clientWidth - windowContext.innerWidth,
+                windowContext.document.body.clientWidth -
+                windowContext.innerWidth,
             yMaxOffset:
-                documentContext.body.clientHeight - windowContext.innerHeight,
+                windowContext.document.body.clientHeight -
+                windowContext.innerHeight,
         })
     )
 
@@ -76,7 +76,7 @@ function addEventListeners({
  * @public
  */
 export function useViewportScroll(): ScrollMotionValues {
-    const { documentContext, windowContext } = useContext(MotionConfigContext)
+    const { windowContext } = useContext(MotionConfigContext)
     /**
      * Lazy-initialise the viewport scroll values
      */
@@ -85,7 +85,7 @@ export function useViewportScroll(): ScrollMotionValues {
     }
 
     useIsomorphicLayoutEffect(() => {
-        !hasListeners && addEventListeners({ documentContext, windowContext })
+        !hasListeners && windowContext && addEventListeners({ windowContext })
     }, [])
 
     return viewportScrollValues


### PR DESCRIPTION
This PR adds the ability to specify which `document` and `window` context to use by adding two new options to `MotionConfig`. This is most useful when needing to wrap motion components in an iframe and making sure events are attached and measured based on the iframe's `document` and `window`.

I've added a simple example that showcases how this works with `useViewportScroll`. Please let me know if there are any other areas that may be using `document` or `window` and I can get those updated 😃 thanks!

Fixes #379