### PR TITLE
Optimise PresenceChild's onExitComplete check for incomplete children

### DIFF
--- a/src/components/AnimatePresence/PresenceChild.tsx
+++ b/src/components/AnimatePresence/PresenceChild.tsx
@@ -39,12 +39,12 @@ export const PresenceChild = ({
             custom,
             onExitComplete: (childId: number) => {
                 presenceChildren.set(childId, true)
-                let allComplete = true
-                presenceChildren.forEach((isComplete) => {
-                    if (!isComplete) allComplete = false
-                })
 
-                allComplete && onExitComplete?.()
+                for (const isComplete of presenceChildren.values()) {
+                    if (!isComplete) return // can stop searching when any is incomplete
+                }
+
+                onExitComplete?.()
             },
             register: (childId: number) => {
                 presenceChildren.set(childId, false)


### PR DESCRIPTION
This should be a transparent optimisation: Previously, the loop would continue overwriting `allCompleted` with `false` for every incomplete child, but any incomplete child causes an abort, so it is unnecessary to check them all.

I ran the tests locally, and it appears the same tests that fail after my change were also failing before.