### PR TITLE
Rename `shouldMeasureScroll` to `layoutScroll`

### DIFF
--- a/cypress/integration/layout-viewport-jump.ts
+++ b/cypress/integration/layout-viewport-jump.ts
@@ -48,7 +48,7 @@ describe("Viewport jump", () => {
     /**
      * This passes locally but can't get it to pass in Cypress
      */
-    it("If div scroll jumps, don't trigger layout animation if provided shouldMeasureScroll prop", () => {
+    it("If div scroll jumps, don't trigger layout animation if provided layoutScroll prop", () => {
         cy.viewport(1000, 600)
             .visit("?test=layout-viewport-jump&nested=true")
             .wait(50)

--- a/dev/projection/element-page-scroll-non-zero.html
+++ b/dev/projection/element-page-scroll-non-zero.html
@@ -61,7 +61,7 @@
             const boxOrigin = box.getBoundingClientRect()
 
             const scrollProjection = createNode(scroll, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
 
             const boxProjection = createNode(box, scrollProjection)

--- a/dev/projection/element-scroll-layout-change.html
+++ b/dev/projection/element-scroll-layout-change.html
@@ -67,7 +67,7 @@
             const boxOrigin = box.getBoundingClientRect()
 
             const scrollProjection = createNode(scroll, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
 
             const boxProjection = createNode(box, scrollProjection)

--- a/dev/projection/element-scroll-non-zero.html
+++ b/dev/projection/element-scroll-non-zero.html
@@ -59,7 +59,7 @@
             const boxOrigin = box.getBoundingClientRect()
 
             const scrollProjection = createNode(scroll, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
 
             const boxProjection = createNode(box, scrollProjection)

--- a/dev/projection/element-scroll-remove.html
+++ b/dev/projection/element-scroll-remove.html
@@ -65,7 +65,7 @@
             const box = document.getElementById("box-1")
             const scrollProjection = createNode(scroll, undefined, {
                 layoutId: "scroll",
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
             const containerProjection = createNode(
                 container,

--- a/dev/projection/element-scroll-to-layout.html
+++ b/dev/projection/element-scroll-to-layout.html
@@ -69,7 +69,7 @@
             scroll.scrollLeft = 50
 
             const scrollProjection = createNode(scroll, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
 
             const boxProjection = createNode(box, scrollProjection)

--- a/dev/projection/element-scroll.html
+++ b/dev/projection/element-scroll.html
@@ -58,7 +58,7 @@
             const boxOrigin = box.getBoundingClientRect()
 
             const scrollProjection = createNode(scroll, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
 
             const boxProjection = createNode(box, scrollProjection)

--- a/dev/projection/shared-scroll-a-b-animate.html
+++ b/dev/projection/shared-scroll-a-b-animate.html
@@ -55,7 +55,7 @@
 
             const scrollScreen = document.querySelector(".screen")
             const scrollScreenProjection = createNode(scrollScreen, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
             scrollScreen.scrollTop = 1000
 

--- a/dev/projection/shared-scroll-a-b.html
+++ b/dev/projection/shared-scroll-a-b.html
@@ -55,7 +55,7 @@
 
             const scrollScreen = document.querySelector(".screen")
             const scrollScreenProjection = createNode(scrollScreen, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
             scrollScreen.scrollTop = 1000
 

--- a/dev/projection/single-element-element-scroll-scale.html
+++ b/dev/projection/single-element-element-scroll-scale.html
@@ -56,7 +56,7 @@
 
             const scroll = document.getElementById("scroll")
             const scrollProjection = createNode(scroll, undefined, {
-                shouldMeasureScroll: true,
+                layoutScroll: true,
             })
             const box = document.getElementById("box")
             const boxProjection = createNode(box, scrollProjection)

--- a/dev/tests/layout-viewport-jump.tsx
+++ b/dev/tests/layout-viewport-jump.tsx
@@ -24,7 +24,7 @@ export const App = () => {
 
     if (nested) {
         content = (
-            <motion.div shouldMeasureScroll id="scrollable" style={scrollable}>
+            <motion.div layoutScroll id="scrollable" style={scrollable}>
                 {content}
             </motion.div>
         )

--- a/src/motion/features/layout/types.ts
+++ b/src/motion/features/layout/types.ts
@@ -69,5 +69,5 @@ export interface LayoutProps {
      *
      * @public
      */
-    shouldMeasureScroll?: boolean
+    layoutScroll?: boolean
 }

--- a/src/motion/features/use-projection.ts
+++ b/src/motion/features/use-projection.ts
@@ -7,13 +7,7 @@ import { SwitchLayoutGroupContext } from "../../context/SwitchLayoutGroupContext
 
 export function useProjection(
     projectionId: number | undefined,
-    {
-        layoutId,
-        layout,
-        drag,
-        dragConstraints,
-        shouldMeasureScroll,
-    }: MotionProps,
+    { layoutId, layout, drag, dragConstraints, layoutScroll }: MotionProps,
     visualElement?: VisualElement,
     ProjectionNodeConstructor?: any
 ) {
@@ -49,6 +43,6 @@ export function useProjection(
          */
         animationType: typeof layout === "string" ? layout : "both",
         initialPromotionConfig,
-        shouldMeasureScroll,
+        layoutScroll,
     })
 }

--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -55,7 +55,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "whileFocus",
     "whileTap",
     "whileHover",
-    "shouldMeasureScroll",
+    "layoutScroll",
 ])
 
 /**

--- a/src/projection/geometry/delta-apply.ts
+++ b/src/projection/geometry/delta-apply.ts
@@ -93,7 +93,7 @@ export function applyTreeDeltas(
 
         if (
             isSharedTransition &&
-            node.options.shouldMeasureScroll &&
+            node.options.layoutScroll &&
             node.scroll &&
             node !== node.root
         ) {

--- a/src/projection/node/HTMLProjectionNode.ts
+++ b/src/projection/node/HTMLProjectionNode.ts
@@ -15,7 +15,7 @@ export const HTMLProjectionNode = createProjectionNode<HTMLElement>({
         if (!rootProjectionNode.current) {
             const documentNode = new DocumentProjectionNode(0, {})
             documentNode.mount(window)
-            documentNode.setOptions({ shouldMeasureScroll: true })
+            documentNode.setOptions({ layoutScroll: true })
             rootProjectionNode.current = documentNode
         }
         return rootProjectionNode.current

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -674,7 +674,7 @@ export function createProjectionNode<I>({
         }
 
         updateScroll() {
-            if (this.options.shouldMeasureScroll && this.instance) {
+            if (this.options.layoutScroll && this.instance) {
                 this.scroll = measureScroll(this.instance)
             }
         }
@@ -735,11 +735,7 @@ export function createProjectionNode<I>({
                 const node = this.path[i]
                 const { scroll, options } = node
 
-                if (
-                    node !== this.root &&
-                    scroll &&
-                    options.shouldMeasureScroll
-                ) {
+                if (node !== this.root && scroll && options.layoutScroll) {
                     translateAxis(boxWithoutScroll.x, scroll.x)
                     translateAxis(boxWithoutScroll.y, scroll.y)
                 }
@@ -756,7 +752,7 @@ export function createProjectionNode<I>({
 
                 if (
                     !transformOnly &&
-                    node.options.shouldMeasureScroll &&
+                    node.options.layoutScroll &&
                     node.scroll &&
                     node !== node.root
                 ) {
@@ -924,7 +920,7 @@ export function createProjectionNode<I>({
                     this.relativeParent &&
                     Boolean(this.relativeParent.resumingFrom) ===
                         Boolean(this.resumingFrom) &&
-                    !this.relativeParent.options.shouldMeasureScroll &&
+                    !this.relativeParent.options.layoutScroll &&
                     this.relativeParent.target
                 ) {
                     this.relativeTarget = createBox()

--- a/src/projection/node/types.ts
+++ b/src/projection/node/types.ts
@@ -140,7 +140,7 @@ export interface ProjectionNodeConfig<I> {
 
 export interface ProjectionNodeOptions {
     animate?: boolean
-    shouldMeasureScroll?: boolean
+    layoutScroll?: boolean
     alwaysMeasureLayout?: boolean
     scheduleRender?: VoidFunction
     onExitComplete?: VoidFunction


### PR DESCRIPTION
Bit of bikeshedding but getting closer to the release I want to bring the `shouldMeasureScroll` prop into the layout namespace and also make it shorter.