### PR TITLE
Fixes `staggerChildren` for value-specific transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   Removing context memoisation to ensure removed values are correctly animated to.
 -   Adding unmount check to `AnimatePresence` before updating state. [PR by @ctrlplusb](https://github.com/framer/motion/pull/796)
 -   Fixing types for multi-input `useTransform`. [PR by @kena0ki](https://github.com/framer/motion/pull/843)
+-   Fixing `staggerChildren` for value-specific transitions. [Issue](https://github.com/framer/motion/issues/1081)
 
 ## [5.0.0] 2021-10-27
 

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -106,7 +106,7 @@ export function convertTransitionToAnimationOptions<T>({
  */
 export function getDelayFromTransition(transition: Transition, key: string) {
     const valueTransition = getValueTransition(transition, key) || {}
-    return valueTransition.delay ?? 0
+    return valueTransition.delay ?? transition.delay ?? 0
 }
 
 export function hydrateKeyframes(options: PermissiveTransitionDefinition) {

--- a/src/motion/__tests__/variant.test.tsx
+++ b/src/motion/__tests__/variant.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import { motion } from "../../"
+import { motion, useMotionValue } from "../../"
 import * as React from "react"
 import { Variants } from "../../types"
 import { motionValue } from "../../value"
@@ -476,6 +476,109 @@ describe("animate prop as variant", () => {
         })
 
         return expect(promise).resolves.toEqual([0.3, 0.5])
+    })
+
+    test("Child variants correctly calculate delay based on staggerChildren", async () => {
+        const isCorrectlyStaggered = await new Promise((resolve) => {
+            const childVariants = {
+                hidden: { opacity: 0 },
+                visible: { opacity: 1, transition: { duration: 0.1 } },
+            }
+
+            function Component() {
+                const a = useMotionValue(0)
+                const b = useMotionValue(0)
+
+                React.useEffect(
+                    () =>
+                        a.onChange((latest) => {
+                            if (latest >= 1 && b.get() === 0) resolve(true)
+                        }),
+                    [a, b]
+                )
+
+                return (
+                    <motion.div
+                        variants={{
+                            hidden: {},
+                            visible: {
+                                x: 100,
+                                transition: { staggerChildren: 0.15 },
+                            },
+                        }}
+                        initial="hidden"
+                        animate="visible"
+                    >
+                        <motion.div
+                            variants={childVariants}
+                            style={{ opacity: a }}
+                        />
+                        <motion.div
+                            variants={childVariants}
+                            style={{ opacity: b }}
+                        />
+                    </motion.div>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(isCorrectlyStaggered).toBe(true)
+    })
+
+    test("Child variants with value-specific transitions correctly calculate delay based on staggerChildren", async () => {
+        const isCorrectlyStaggered = await new Promise((resolve) => {
+            const childVariants = {
+                hidden: { opacity: 0 },
+                visible: {
+                    opacity: 1,
+                    transition: { opacity: { duration: 0.1 } },
+                },
+            }
+
+            function Component() {
+                const a = useMotionValue(0)
+                const b = useMotionValue(0)
+
+                React.useEffect(
+                    () =>
+                        a.onChange((latest) => {
+                            if (latest >= 1 && b.get() === 0) resolve(true)
+                        }),
+                    [a, b]
+                )
+
+                return (
+                    <motion.div
+                        variants={{
+                            hidden: {},
+                            visible: {
+                                x: 100,
+                                transition: { staggerChildren: 0.15 },
+                            },
+                        }}
+                        initial="hidden"
+                        animate="visible"
+                    >
+                        <motion.div
+                            variants={childVariants}
+                            style={{ opacity: a }}
+                        />
+                        <motion.div
+                            variants={childVariants}
+                            style={{ opacity: b }}
+                        />
+                    </motion.div>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(isCorrectlyStaggered).toBe(true)
     })
 
     test("components without variants are transparent to stagger order", async () => {


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/1294