### PR TITLE
Allow `controls.start()` dynamic functions to return variant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ## [5.0.2] 2021-11-02
 
 -   Convert x/y from percent to pixels before drag. [Issue](https://github.com/framer/motion/issues/424)
+-   Dynamic functions passed to `controls.start()` can now return variant names. [Issue](https://github.com/framer/motion/issues/503)
 
 ## [5.0.1] 2021-11-01
 

--- a/src/render/utils/__tests__/variants.test.ts
+++ b/src/render/utils/__tests__/variants.test.ts
@@ -1,0 +1,30 @@
+import { resolveVariantFromProps } from "../variants"
+
+describe("resolveVariantFromProps", () => {
+    test("Resolves string", () => {
+        const resolved = resolveVariantFromProps(
+            { variants: { hidden: { opacity: 0 } } },
+            "hidden"
+        )
+
+        expect(resolved).toEqual({ opacity: 0 })
+    })
+
+    test("Resolves function that returns object", () => {
+        const resolved = resolveVariantFromProps(
+            { variants: { hidden: { opacity: 0 } } },
+            () => ({ opacity: 1 })
+        )
+
+        expect(resolved).toEqual({ opacity: 1 })
+    })
+
+    test("Resolves function that returns string", () => {
+        const resolved = resolveVariantFromProps(
+            { variants: { hidden: { opacity: 0 } } },
+            () => "hidden"
+        )
+
+        expect(resolved).toEqual({ opacity: 0 })
+    })
+})

--- a/src/render/utils/variants.ts
+++ b/src/render/utils/variants.ts
@@ -58,6 +58,9 @@ export function resolveVariantFromProps(
     currentValues: ResolvedValues = {},
     currentVelocity: ResolvedValues = {}
 ) {
+    /**
+     * If the variant definition is a function, resolve.
+     */
     if (typeof definition === "function") {
         definition = definition(
             custom ?? props.custom,
@@ -66,10 +69,19 @@ export function resolveVariantFromProps(
         )
     }
 
+    /**
+     * If the variant definition is a variant label, or
+     * the function returned a variant label, resolve.
+     */
     if (typeof definition === "string") {
         definition = props.variants?.[definition]
     }
 
+    /**
+     * At this point we've resolved both functions and variant labels,
+     * but the resolved variant label might itself have been a function.
+     * If so, resolve. This can only have returned a valid target object.
+     */
     if (typeof definition === "function") {
         definition = definition(
             custom ?? props.custom,

--- a/src/render/utils/variants.ts
+++ b/src/render/utils/variants.ts
@@ -58,13 +58,27 @@ export function resolveVariantFromProps(
     currentValues: ResolvedValues = {},
     currentVelocity: ResolvedValues = {}
 ) {
+    if (typeof definition === "function") {
+        definition = definition(
+            custom ?? props.custom,
+            currentValues,
+            currentVelocity
+        )
+    }
+
     if (typeof definition === "string") {
         definition = props.variants?.[definition]
     }
 
-    return typeof definition === "function"
-        ? definition(custom ?? props.custom, currentValues, currentVelocity)
-        : definition
+    if (typeof definition === "function") {
+        definition = definition(
+            custom ?? props.custom,
+            currentValues,
+            currentVelocity
+        )
+    }
+
+    return definition
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1083,7 +1083,7 @@ export type TargetResolver = (
     custom: any,
     current: Target,
     velocity: Target
-) => TargetAndTransition
+) => TargetAndTransition | string
 
 /**
  * @public


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/503