### PR TITLE
Enable pathLength animations for more SVG shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.1.0] 2021-11-02
+
+### Added
+
+-   Adding path drawing support for `circle`, `ellipse`, `line`, `path`, `polygon`, `polyline` and `rect` components.
+
 ### Fixed
 
+-   Fixed SSR for `pathLength`.
 -   Downgrading `whileFocus` to lowest gesture priority. [Issue](https://github.com/framer/motion/issues/1221)
-
-### Fixed
-
+-   Fixed path length for elements with `vectorEffect="non-scaling-stroke"` [Issue](https://github.com/framer/motion/issues/521)
 -   Stripping `dragSnapToOrigin` from DOM output. [PR by @Evalon](https://github.com/framer/motion/pull/1326)
 
 ## [5.0.2] 2021-11-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 -   Adding path drawing support for `circle`, `ellipse`, `line`, `path`, `polygon`, `polyline` and `rect` components.
+-   Add SSR support for `pathLength`.
 
 ### Fixed
 

--- a/dev/examples/SVG-path.tsx
+++ b/dev/examples/SVG-path.tsx
@@ -37,7 +37,7 @@ export const App = () => {
             <motion.path
                 d="M 72 136 C 72 100.654 100.654 72 136 72 L 304 72 C 339.346 72 368 100.654 368 136 L 368 304 C 368 339.346 339.346 368 304 368 L 136 368 C 100.654 368 72 339.346 72 304 Z"
                 fill="transparent"
-                strokeWidth="50"
+                strokeWidth={50}
                 stroke="#FF008C"
                 variants={boxVariants}
             />

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "build": "yarn clean && tsc -p . && rollup -c",
         "clean": "rm -rf types dist lib",
         "test-ci": "yarn test-client && yarn test-server",
-        "test-client": "jest --coverage --config jest.config.json",
+        "test-client": "jest --coverage --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-projection": "yarn run collect-projection-tests && start-server-and-test 'python -m SimpleHTTPServer' http://localhost:8000 'yarn run cypress run -s cypress/integration/projection.chrome.ts --config baseUrl=http://0.0.0.0:8000/'",
         "test-e2e-chrome": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --headless --browser chrome  --spec \"cypress/integration/layout-relative.chrome.ts\"'",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "build": "yarn clean && tsc -p . && rollup -c",
         "clean": "rm -rf types dist lib",
         "test-ci": "yarn test-client && yarn test-server",
-        "test-client": "jest --coverage --config jest.config.json --max-workers=2",
+        "test-client": "jest --coverage --config jest.config.json",
         "test-server": "jest --config jest.config.ssr.json",
         "test-projection": "yarn run collect-projection-tests && start-server-and-test 'python -m SimpleHTTPServer' http://localhost:8000 'yarn run cypress run -s cypress/integration/projection.chrome.ts --config baseUrl=http://0.0.0.0:8000/'",
         "test-e2e-chrome": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --headless --browser chrome  --spec \"cypress/integration/layout-relative.chrome.ts\"'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "5.0.2",
+    "version": "5.1.0-rc.1",
     "description": "A simple and powerful React animation library",
     "main": "dist/framer-motion.cjs.js",
     "module": "dist/es/index.mjs",

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -60,7 +60,7 @@ function runTests(render: (components: any) => string) {
 
     test("correctly renders SVG", () => {
         const cx = motionValue(100)
-        const pathLength = motionValue(100)
+        const pathLength = motionValue(0.5)
         const circle = render(
             <motion.circle
                 cx={cx}
@@ -74,7 +74,7 @@ function runTests(render: (components: any) => string) {
         )
 
         expect(circle).toBe(
-            '<circle cx="100" style="background:#fff" stroke-width="10"></circle>'
+            '<circle cx="100" style="background:#fff" stroke-width="10" pathLength="1" stroke-dashoffset="0px" stroke-dasharray="0.5px 1px"></circle>'
         )
         const rect = render(
             <AnimatePresence>

--- a/src/motion/__tests__/svg-path.test.tsx
+++ b/src/motion/__tests__/svg-path.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "../../../jest.setup"
+import { motion } from "../.."
+import * as React from "react"
+
+describe("SVG path", () => {
+    test("accepts custom transition prop", async () => {
+        const element = await new Promise((resolve) => {
+            const ref = React.createRef<SVGRectElement>()
+            const Component = () => (
+                <motion.rect
+                    ref={ref}
+                    animate={{ pathLength: 1 }}
+                    transition={{ duration: 0.01 }}
+                    onAnimationComplete={() => resolve(ref.current)}
+                />
+            )
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(element).toHaveAttribute("stroke-dashoffset", "0px")
+        expect(element).toHaveAttribute("stroke-dasharray", "1px 1px")
+        expect(element).toHaveAttribute("pathLength", "1")
+    })
+})

--- a/src/motion/__tests__/svg-path.test.tsx
+++ b/src/motion/__tests__/svg-path.test.tsx
@@ -20,6 +20,5 @@ describe("SVG path", () => {
 
         expect(element).toHaveAttribute("stroke-dashoffset", "0px")
         expect(element).toHaveAttribute("stroke-dasharray", "1px 1px")
-        expect(element).toHaveAttribute("pathLength", "1")
     })
 })

--- a/src/motion/__tests__/svg-path.test.tsx
+++ b/src/motion/__tests__/svg-path.test.tsx
@@ -20,5 +20,6 @@ describe("SVG path", () => {
 
         expect(element).toHaveAttribute("stroke-dashoffset", "0px")
         expect(element).toHaveAttribute("stroke-dasharray", "1px 1px")
+        expect(element).toHaveAttribute("pathLength", "1")
     })
 })

--- a/src/render/svg/__tests__/use-props.test.ts
+++ b/src/render/svg/__tests__/use-props.test.ts
@@ -33,6 +33,21 @@ describe("SVG useProps", () => {
         })
     })
 
+    test("should return correct styles for element with pathLength", () => {
+        const { result } = renderHook(() =>
+            useSVGProps({ style: {} } as any, {
+                pathLength: 0.5,
+            })
+        )
+
+        expect(result.current).toStrictEqual({
+            pathLength: 1,
+            strokeDasharray: "0.5px 1px",
+            strokeDashoffset: "0px",
+            style: {},
+        })
+    })
+
     test("should correctly remove props as motionvalues", () => {
         const { result } = renderHook(() =>
             useSVGProps({ y: motionValue(2) } as any, { attrY: 3 })

--- a/src/render/svg/config-motion.ts
+++ b/src/render/svg/config-motion.ts
@@ -29,10 +29,6 @@ export const svgMotionConfig: Partial<
                 }
             }
 
-            if (isPath(instance)) {
-                renderState.totalPathLength = instance.getTotalLength()
-            }
-
             buildSVGAttrs(
                 renderState,
                 latestValues,
@@ -44,10 +40,4 @@ export const svgMotionConfig: Partial<
             renderSVG(instance, renderState)
         },
     }),
-}
-
-function isPath(
-    element: SVGElement | SVGPathElement
-): element is SVGPathElement {
-    return element.tagName === "path"
 }

--- a/src/render/svg/types.ts
+++ b/src/render/svg/types.ts
@@ -15,11 +15,6 @@ export interface SVGRenderState extends HTMLRenderState {
      * every frame. We use a mutable data structure to reduce GC during animations.
      */
     attrs: ResolvedValues
-
-    /**
-     * Measured path length if this is a SVGPathElement
-     */
-    totalPathLength?: number
 }
 
 export type SVGDimensions = {

--- a/src/render/svg/utils/__tests__/path.test.ts
+++ b/src/render/svg/utils/__tests__/path.test.ts
@@ -5,9 +5,9 @@ describe("buildSVGPath", () => {
     it("correctly generates SVG path props", () => {
         const attrs = {}
 
-        buildSVGPath(attrs, 200, 0.5, 0.25, 0.25)
+        buildSVGPath(attrs, 0.5, 0.25, 0.25)
 
-        expect(attrs["stroke-dashoffset"]).toBe("-50px")
-        expect(attrs["stroke-dasharray"]).toBe("100px 50px")
+        expect(attrs["stroke-dashoffset"]).toBe("-0.25px")
+        expect(attrs["stroke-dasharray"]).toBe("0.5px 0.25px")
     })
 })

--- a/src/render/svg/utils/build-attrs.ts
+++ b/src/render/svg/utils/build-attrs.ts
@@ -29,7 +29,7 @@ export function buildSVGAttrs(
 
     state.attrs = state.style
     state.style = {}
-    const { attrs, style, dimensions, totalPathLength } = state
+    const { attrs, style, dimensions } = state
     /**
      * However, we apply transforms as CSS transforms. So if we detect a transform we take it from attrs
      * and copy it into style.
@@ -55,11 +55,10 @@ export function buildSVGAttrs(
     if (attrX !== undefined) attrs.x = attrX
     if (attrY !== undefined) attrs.y = attrY
 
-    // Build SVG path if one has been measured
-    if (totalPathLength !== undefined && pathLength !== undefined) {
+    // Build SVG path if one has been defined
+    if (pathLength !== undefined) {
         buildSVGPath(
             attrs,
-            totalPathLength,
             pathLength as number,
             pathSpacing as number,
             pathOffset as number,

--- a/src/render/svg/utils/camel-case-attrs.ts
+++ b/src/render/svg/utils/camel-case-attrs.ts
@@ -21,4 +21,5 @@ export const camelCaseAttributes = new Set([
     "tableValues",
     "viewBox",
     "gradientTransform",
+    "pathLength",
 ])

--- a/src/render/svg/utils/path.ts
+++ b/src/render/svg/utils/path.ts
@@ -1,10 +1,6 @@
 import { px } from "style-value-types"
 import { ResolvedValues } from "../../types"
 
-// Convert a progress 0-1 to a pixels value based on the provided length
-const progressToPixels = (progress: number, length: number) =>
-    (px as any).transform(progress * length)
-
 const dashKeys = {
     offset: "stroke-dashoffset",
     array: "stroke-dasharray",
@@ -24,21 +20,23 @@ const camelKeys = {
  */
 export function buildSVGPath(
     attrs: ResolvedValues,
-    totalLength: number,
     length: number,
     spacing = 1,
     offset = 0,
     useDashCase: boolean = true
 ): void {
+    // Normalise path length by setting SVG attribute pathLength to 1
+    attrs.pathLength = 1
+
     // We use dash case when setting attributes directly to the DOM node and camel case
     // when defining props on a React component.
     const keys = useDashCase ? dashKeys : camelKeys
 
     // Build the dash offset
-    attrs[keys.offset] = progressToPixels(-offset, totalLength)
+    attrs[keys.offset] = px.transform!(-offset)
 
     // Build the dash array
-    const pathLength = progressToPixels(length, totalLength)
-    const pathSpacing = progressToPixels(spacing, totalLength)
+    const pathLength = px.transform!(length)
+    const pathSpacing = px.transform!(spacing)
     attrs[keys.array] = `${pathLength} ${pathSpacing}`
 }


### PR DESCRIPTION
Instead of measuring path length with `getTotalLength`, we now set the [`pathLength` attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pathLength) to `1`.

This change:
- Fixes path animations for elements with `vector-effect="non-scaling-stroke"` applied
- Extends path animations from `path` to `circle`, `ellipse`, `line`, `polygon`, `polyline` and `rect` components
- Adds SSR support for `pathLength`

Fixes https://github.com/framer/motion/issues/521