### PR TITLE
add dragSnapToOrigin to valid props

### DIFF
--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -36,6 +36,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "dragListener",
     "dragConstraints",
     "dragDirectionLock",
+    "dragSnapToOrigin",
     "_dragX",
     "_dragY",
     "dragElastic",


### PR DESCRIPTION
It clears react warning in dev console for dragSnapToOrigin (Reorder.Item)