### PR TITLE
Adding check for mixing layout animation types

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,23 +140,23 @@
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "6.5 kB"
+            "maxSize": "5.95 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "17.2 kB"
+            "maxSize": "16.3 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "28.2 kB"
+            "maxSize": "27.2 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
-            "maxSize": "6.5 kB"
+            "maxSize": "6.2 kB"
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "19 kB"
+            "maxSize": "1.7 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",

--- a/package.json
+++ b/package.json
@@ -144,11 +144,11 @@
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "16.3 kB"
+            "maxSize": "16.4 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "27.2 kB"
+            "maxSize": "27.4 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
@@ -156,7 +156,7 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "18.7 kB"
+            "maxSize": "18.8 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "1.7 kB"
+            "maxSize": "18.7 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -90,6 +90,14 @@ const es = Object.assign({}, config, {
     external,
 })
 
+const sizePlugins = [
+    resolve(),
+    replace({
+        "process.env.NODE_ENV": JSON.stringify("production"),
+    }),
+    terser({ output: { comments: false } }),
+]
+
 const m = Object.assign({}, es, {
     input: "lib/render/dom/motion-minimal.js",
     output: Object.assign({}, es.output, {
@@ -97,7 +105,7 @@ const m = Object.assign({}, es, {
         preserveModules: false,
         dir: undefined,
     }),
-    plugins: [resolve(), terser({ output: { comments: false } })],
+    plugins: sizePlugins,
     external: ["react", "react-dom"],
 })
 
@@ -113,7 +121,7 @@ const domAnimation = Object.assign({}, es, {
         chunkFileNames: "size-rollup-dom-animation-assets.js",
         dir: `dist`,
     },
-    plugins: [resolve(), terser({ output: { comments: false } })],
+    plugins: sizePlugins,
     external: ["react", "react-dom"],
 })
 
@@ -125,7 +133,7 @@ const domMax = Object.assign({}, es, {
         ...domAnimation.output,
         chunkFileNames: "size-rollup-dom-max-assets.js",
     },
-    plugins: [resolve(), terser({ output: { comments: false } })],
+    plugins: sizePlugins,
     external: ["react", "react-dom"],
 })
 

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -1699,9 +1699,9 @@ function roundBox(box: Box): void {
  * layout-affecting animation.
  */
 function isTreeAnimatingLayoutAffectingStyle(
-    visualElement: VisualElement
+    visualElement: VisualElement | undefined
 ): boolean {
-    while (visualElement.parent) {
+    while (visualElement) {
         if (Boolean(visualElement.layoutAffectingAnimations)) return true
         visualElement = visualElement.parent
     }

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -41,7 +41,7 @@ import { FlatTree } from "../../render/utils/flat-tree"
 import { Transition } from "../../types"
 import { resolveMotionValue } from "../../value/utils/resolve-motion-value"
 import { MotionStyle } from "../../motion/types"
-import { warnOnce } from "../../utils/warn-once"
+import { hasWarned, warnOnce } from "../../utils/warn-once"
 
 /**
  * We use 1000 as the animation target as 0-1000 maps better to pixels than 0-1
@@ -1165,22 +1165,29 @@ export function createProjectionNode<I>({
                 /**
                  * Check if this component or any of its ancestors are animating
                  */
+                const { visualElement } = this.options
                 if (
                     process.env.NODE_ENV !== "production" &&
-                    this.options.visualElement
+                    visualElement &&
+                    !hasWarned(layoutWarningMessage)
                 ) {
                     /**
                      * We need to fire this in a setTimeout because layout animations will start
                      * before any layout-affecting animations.
                      */
                     setTimeout(() => {
-                        warnOnce(
-                            () =>
-                                !isTreeAnimatingLayoutAffectingStyle(
-                                    this.options.visualElement
-                                ),
-                            `Attempting to animate layout within a component performing an animation on a layout-affecting properties (e.g. "width", "height", "top"). This is likely to break layout animations. Attempt to replace with the layout and style prop, e.g. <motion.div layout style={{ width: 100px }} />.`
-                        )
+                        const animatingParent =
+                            getClosestElementAnimatingLayoutAffectingStyle(
+                                visualElement
+                            )
+
+                        if (animatingParent) {
+                            warnOnce(
+                                false,
+                                layoutWarningMessage,
+                                animatingParent.getInstance()
+                            )
+                        }
                     }, 50)
                 }
 
@@ -1705,13 +1712,16 @@ function roundBox(box: Box): void {
  * Look up the tree and check whether any element is performing a
  * layout-affecting animation.
  */
-function isTreeAnimatingLayoutAffectingStyle(
+function getClosestElementAnimatingLayoutAffectingStyle(
     visualElement: VisualElement | undefined
-): boolean {
+): VisualElement | undefined {
     while (visualElement) {
-        if (Boolean(visualElement.layoutAffectingAnimations)) return true
+        if (Boolean(visualElement.layoutAffectingAnimations))
+            return visualElement
         visualElement = visualElement.parent
     }
 
-    return false
+    return undefined
 }
+
+const layoutWarningMessage = `Attempting to animate layout within a component performing an animation on a layout-affecting properties (e.g. "width", "height", "top"). This is likely to break layout animations. Attempt to replace with the layout and style prop, e.g. <motion.div layout style={{ width: 100px }} />. Element is:`

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -1169,14 +1169,18 @@ export function createProjectionNode<I>({
                     process.env.NODE_ENV !== "production" &&
                     this.options.visualElement
                 ) {
-                    sync.update(() => {
+                    /**
+                     * We need to fire this in a setTimeout because layout animations will start
+                     * before any layout-affecting animations.
+                     */
+                    setTimeout(() => {
                         warnOnce(
                             !isTreeAnimatingLayoutAffectingStyle(
                                 this.options.visualElement
                             ),
                             `Attempting to animate layout within a component performing an animation on a layout-affecting properties (e.g. "width", "height", "top"). This is likely to break layout animations. Attempt to replace with the layout and style prop, e.g. <motion.div layout style={{ width: 100px }} />.`
                         )
-                    })
+                    }, 50)
                 }
 
                 this.currentAnimation = animate(0, animationTarget, {

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -5,7 +5,7 @@ import {
     AnimationOptions,
     AnimationPlaybackControls,
 } from "../../animation/animate"
-import { ResolvedValues } from "../../render/types"
+import { ResolvedValues, VisualElement } from "../../render/types"
 import { SubscriptionManager } from "../../utils/subscription-manager"
 import { mixValues } from "../animation/mix-values"
 import { copyBoxInto } from "../geometry/copy"
@@ -41,6 +41,7 @@ import { FlatTree } from "../../render/utils/flat-tree"
 import { Transition } from "../../types"
 import { resolveMotionValue } from "../../value/utils/resolve-motion-value"
 import { MotionStyle } from "../../motion/types"
+import { warning } from "hey-listen"
 
 /**
  * We use 1000 as the animation target as 0-1000 maps better to pixels than 0-1
@@ -1161,6 +1162,18 @@ export function createProjectionNode<I>({
             this.pendingAnimation = sync.update(() => {
                 globalProjectionState.hasAnimatedSinceResize = true
 
+                /**
+                 *
+                 */
+                if (process.env.NODE_ENV !== "production") {
+                    warning(
+                        !isAnimatingLayoutAffectingProperty(
+                            this.options.visualElement
+                        ),
+                        ``
+                    )
+                }
+
                 this.currentAnimation = animate(0, animationTarget, {
                     ...(options as any),
                     onUpdate: (latest: number) => {
@@ -1676,4 +1689,18 @@ function roundAxis(axis: Axis): void {
 function roundBox(box: Box): void {
     roundAxis(box.x)
     roundAxis(box.y)
+}
+
+/**
+ *
+ */
+function isAnimatingLayoutAffectingProperty(
+    visualElement: VisualElement
+): boolean {
+    while (visualElement.parent) {
+        if (Boolean(visualElement.layoutAffectingAnimations)) return true
+        visualElement = visualElement.parent
+    }
+
+    return false
 }

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -1169,12 +1169,14 @@ export function createProjectionNode<I>({
                     process.env.NODE_ENV !== "production" &&
                     this.options.visualElement
                 ) {
-                    warnOnce(
-                        !isTreeAnimatingLayoutAffectingStyle(
-                            this.options.visualElement
-                        ),
-                        `Attempting to animate layout within a component performing an animation on a layout-affecting properties (e.g. "width", "height", "top"). This is likely to break layout animations. Attempt to replace with the layout and style prop, e.g. <motion.div layout style={{ width: 100px }} />.`
-                    )
+                    sync.update(() => {
+                        warnOnce(
+                            !isTreeAnimatingLayoutAffectingStyle(
+                                this.options.visualElement
+                            ),
+                            `Attempting to animate layout within a component performing an animation on a layout-affecting properties (e.g. "width", "height", "top"). This is likely to break layout animations. Attempt to replace with the layout and style prop, e.g. <motion.div layout style={{ width: 100px }} />.`
+                        )
+                    })
                 }
 
                 this.currentAnimation = animate(0, animationTarget, {

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -1175,9 +1175,10 @@ export function createProjectionNode<I>({
                      */
                     setTimeout(() => {
                         warnOnce(
-                            !isTreeAnimatingLayoutAffectingStyle(
-                                this.options.visualElement
-                            ),
+                            () =>
+                                !isTreeAnimatingLayoutAffectingStyle(
+                                    this.options.visualElement
+                                ),
                             `Attempting to animate layout within a component performing an animation on a layout-affecting properties (e.g. "width", "height", "top"). This is likely to break layout animations. Attempt to replace with the layout and style prop, e.g. <motion.div layout style={{ width: 100px }} />.`
                         )
                     }, 50)

--- a/src/render/dom/utils/layout-keys.ts
+++ b/src/render/dom/utils/layout-keys.ts
@@ -1,0 +1,8 @@
+export const layoutKeys = new Set([
+    "width",
+    "height",
+    "top",
+    "left",
+    "right",
+    "bottom",
+])

--- a/src/render/dom/utils/layout-keys.ts
+++ b/src/render/dom/utils/layout-keys.ts
@@ -1,3 +1,7 @@
+/**
+ * Each of these is given a unique bit value so we can check if any of these is animating
+ * with a simple falsey check.
+ */
 export const layoutFlags = {
     width: 1,
     height: 2,

--- a/src/render/dom/utils/layout-keys.ts
+++ b/src/render/dom/utils/layout-keys.ts
@@ -1,8 +1,10 @@
-export const layoutKeys = new Set([
-    "width",
-    "height",
-    "top",
-    "left",
-    "right",
-    "bottom",
-])
+export const layoutFlags = {
+    width: 1,
+    height: 2,
+    top: 4,
+    left: 8,
+    right: 16,
+    bottom: 32,
+}
+
+export const layoutKeys = new Set(Object.keys(layoutFlags))

--- a/src/render/dom/utils/unit-conversion.ts
+++ b/src/render/dom/utils/unit-conversion.ts
@@ -7,17 +7,9 @@ import { transformProps } from "../../html/utils/transform"
 import { ResolvedValues, VisualElement } from "../../types"
 import { findDimensionValueType } from "../value-types/dimensions"
 import { Box } from "../../../projection/geometry/types"
+import { layoutKeys } from "./layout-keys"
 
-const positionalKeys = new Set([
-    "width",
-    "height",
-    "top",
-    "left",
-    "right",
-    "bottom",
-    "x",
-    "y",
-])
+const positionalKeys = new Set([...layoutKeys, "x", "y"])
 const isPositionalKey = (key: string) => positionalKeys.has(key)
 const hasPositionalKey = (target: TargetWithKeyframes) => {
     return Object.keys(target).some(isPositionalKey)

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -222,6 +222,11 @@ export const visualElement =
              */
             isMounted: () => Boolean(instance),
 
+            /**
+             *
+             */
+            layoutAffectingAnimations: 0,
+
             mount(newInstance: Instance) {
                 isMounted = true
                 instance = element.current = newInstance

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -223,7 +223,10 @@ export const visualElement =
             isMounted: () => Boolean(instance),
 
             /**
-             *
+             * In development mode, when a layout-affecting value is animating its unqiue
+             * bit gets added to this value. If a layout animation is started on this,
+             * or any child, it can check back up the tree with a simple falsey check on this
+             * value to see if its conflicting with a layout-affecting value.
              */
             layoutAffectingAnimations: 0,
 

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -93,6 +93,7 @@ export interface VisualElement<Instance = any, RenderState = any>
     prevDragCursor?: Point
     getLayoutId(): string | undefined
     animationState?: AnimationState
+    layoutAffectingAnimations: number
 }
 
 export interface VisualElementConfig<Instance, RenderState, Options> {

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -175,16 +175,18 @@ function animateTarget(
          * Here we check if this component or any above it are animating layout
          * and warn if an animation is started on some popular layout-effecting properties.
          */
-        if (process.env.NODE_ENV !== "production" && layoutFlags[key]) {
-            warnOnce(
-                !visualElement.projection?.isTreeAnimating,
-                `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
-            )
+        if (process.env.NODE_ENV !== "production") {
+            if (layoutFlags[key]) {
+                warnOnce(
+                    !visualElement.projection?.isTreeAnimating,
+                    `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
+                )
 
-            visualElement.layoutAffectingAnimations += layoutFlags[key]
-            animation.then(() => {
-                visualElement.layoutAffectingAnimations -= layoutFlags[key]
-            })
+                visualElement.layoutAffectingAnimations += layoutFlags[key]
+                animation.then(() => {
+                    visualElement.layoutAffectingAnimations -= layoutFlags[key]
+                })
+            }
         }
 
         animations.push(animation)

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -12,8 +12,8 @@ import { AnimationTypeState } from "./animation-state"
 import { AnimationType } from "./types"
 import { setTarget } from "./setters"
 import { resolveVariant } from "./variants"
-import { layoutFlags, layoutKeys } from "../dom/utils/layout-keys"
-import { warning } from "hey-listen"
+import { layoutFlags } from "../dom/utils/layout-keys"
+import { warnOnce } from "../../utils/warn-once"
 
 export type AnimationDefinition =
     | VariantLabels
@@ -170,23 +170,17 @@ function animateTarget(
         })
 
         /**
-         *
+         * Layout animations rely on synchronous rendering of layout, which
+         * is incompatible with animating layout-affecting properties.
+         * Here we check if this component or any above it are animating layout
+         * and warn if an animation is started on some popular layout-effecting properties.
          */
         if (process.env.NODE_ENV !== "production" && layoutFlags[key]) {
-            /**
-             * Layout animations rely on synchronous rendering of layout, which
-             * is incompatible with animating layout-affecting properties.
-             * Here we check if this component or any above it are animating layout
-             * and warn if an animation is started on some popular layout-effecting properties.
-             */
-            warning(
+            warnOnce(
                 !visualElement.projection?.isTreeAnimating,
                 `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
             )
 
-            /**
-             *
-             */
             visualElement.layoutAffectingAnimations += layoutFlags[key]
             animation.then(() => {
                 visualElement.layoutAffectingAnimations -= layoutFlags[key]

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -12,6 +12,8 @@ import { AnimationTypeState } from "./animation-state"
 import { AnimationType } from "./types"
 import { setTarget } from "./setters"
 import { resolveVariant } from "./variants"
+import { layoutKeys } from "../dom/utils/layout-keys"
+import { warning } from "hey-listen"
 
 export type AnimationDefinition =
     | VariantLabels
@@ -161,6 +163,17 @@ function animateTarget(
         ) {
             continue
         }
+
+        /**
+         * Layout animations rely on synchronous rendering of layout, which
+         * is incompatible with animating layout-affecting properties.
+         * Here we check if this component or any above it are animating layout
+         * and warn if an animation is started on some popular layout-effecting properties.
+         */
+        warning(
+            !(visualElement.projection?.isTreeAnimating && layoutKeys.has(key)),
+            `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
+        )
 
         const animation = startAnimation(key, value, valueTarget, {
             delay,

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -178,7 +178,7 @@ function animateTarget(
         if (process.env.NODE_ENV !== "production") {
             if (layoutFlags[key]) {
                 warnOnce(
-                    !visualElement.projection?.isTreeAnimating,
+                    () => !visualElement.projection?.isTreeAnimating,
                     `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
                 )
 

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -12,7 +12,7 @@ import { AnimationTypeState } from "./animation-state"
 import { AnimationType } from "./types"
 import { setTarget } from "./setters"
 import { resolveVariant } from "./variants"
-import { layoutKeys } from "../dom/utils/layout-keys"
+import { layoutFlags, layoutKeys } from "../dom/utils/layout-keys"
 import { warning } from "hey-listen"
 
 export type AnimationDefinition =
@@ -164,21 +164,34 @@ function animateTarget(
             continue
         }
 
-        /**
-         * Layout animations rely on synchronous rendering of layout, which
-         * is incompatible with animating layout-affecting properties.
-         * Here we check if this component or any above it are animating layout
-         * and warn if an animation is started on some popular layout-effecting properties.
-         */
-        warning(
-            !(visualElement.projection?.isTreeAnimating && layoutKeys.has(key)),
-            `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
-        )
-
         const animation = startAnimation(key, value, valueTarget, {
             delay,
             ...transition,
         })
+
+        /**
+         *
+         */
+        if (process.env.NODE_ENV !== "production" && layoutFlags[key]) {
+            /**
+             * Layout animations rely on synchronous rendering of layout, which
+             * is incompatible with animating layout-affecting properties.
+             * Here we check if this component or any above it are animating layout
+             * and warn if an animation is started on some popular layout-effecting properties.
+             */
+            warning(
+                !visualElement.projection?.isTreeAnimating,
+                `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />). This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
+            )
+
+            /**
+             *
+             */
+            visualElement.layoutAffectingAnimations += layoutFlags[key]
+            animation.then(() => {
+                visualElement.layoutAffectingAnimations -= layoutFlags[key]
+            })
+        }
 
         animations.push(animation)
     }

--- a/src/render/utils/animation.ts
+++ b/src/render/utils/animation.ts
@@ -176,7 +176,7 @@ function animateTarget(
          * and warn if an animation is started on some popular layout-effecting properties.
          */
         if (process.env.NODE_ENV !== "production" && layoutFlags[key]) {
-            const warning = `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />), or is the child of a component performing layout animations. This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />.`
+            const warning = `Attempting to animate layout-affecting style "${key}" to ${valueTarget} on a component that is performing a layout animation (e.g. <motion.div layout />), or is the child of a component performing layout animations. This is likely to break layout animations. Attempt to replace with <motion.div layout style={{ ${key}: ${valueTarget} }} />. Element is:`
             if (!hasWarned(warning)) {
                 const isTreeAnimating =
                     visualElement.projection?.isTreeAnimating

--- a/src/utils/warn-once.ts
+++ b/src/utils/warn-once.ts
@@ -1,9 +1,10 @@
 import { warning } from "hey-listen"
 
 const warned = new Set<string>()
-export function warnOnce(condition: boolean, message: string) {
-    if (condition || warned.has(message)) return
+export function warnOnce(condition: () => boolean, message: string) {
+    if (warned.has(message)) return
 
-    warning(condition, message)
-    warned.add(message)
+    const resolvedCondition = condition()
+    warning(resolvedCondition, message)
+    if (!resolvedCondition) warned.add(message)
 }

--- a/src/utils/warn-once.ts
+++ b/src/utils/warn-once.ts
@@ -1,10 +1,17 @@
-import { warning } from "hey-listen"
-
 const warned = new Set<string>()
-export function warnOnce(condition: () => boolean, message: string) {
-    if (warned.has(message)) return
 
-    const resolvedCondition = condition()
-    warning(resolvedCondition, message)
-    if (!resolvedCondition) warned.add(message)
+export function hasWarned(message: string) {
+    return warned.has(message)
+}
+
+export function warnOnce(
+    condition: boolean,
+    message: string,
+    element?: Element
+) {
+    if (condition || warned.has(message)) return
+
+    console.warn(message)
+    if (element) console.warn(element)
+    warned.add(message)
 }

--- a/src/utils/warn-once.ts
+++ b/src/utils/warn-once.ts
@@ -1,0 +1,9 @@
+import { warning } from "hey-listen"
+
+const warned = new Set<string>()
+export function warnOnce(condition: boolean, message: string) {
+    if (condition || warned.has(message)) return
+
+    warning(condition, message)
+    warned.add(message)
+}

--- a/webpack.size.config.js
+++ b/webpack.size.config.js
@@ -1,4 +1,5 @@
 const tsconfig = require("./tsconfig.json")
+const webpack = require("webpack")
 const path = require("path")
 const convertPathsToAliases =
     require("convert-tsconfig-paths-to-webpack-aliases").default
@@ -75,4 +76,9 @@ module.exports = {
             },
         ],
     },
+    plugins: [
+        new webpack.DefinePlugin({
+            "process.env.NODE_ENV": JSON.stringify("production"),
+        }),
+    ],
 }


### PR DESCRIPTION
This now checks for 

- Layout animations happening within layout-affecting animations
- Layout-affecting animations happening within layout animations
