### PR TITLE
Add layoutDependency to valid props

### DIFF
--- a/src/motion/utils/valid-prop.ts
+++ b/src/motion/utils/valid-prop.ts
@@ -19,6 +19,7 @@ const validMotionProps = new Set<keyof MotionProps>([
     "inherit",
     "layout",
     "layoutId",
+    "layoutDependency",
     "onLayoutAnimationComplete",
     "onLayoutMeasure",
     "onBeforeLayoutMeasure",


### PR DESCRIPTION
Resolves unrecognized prop warning from react.