### PR TITLE
Call gesture animation before calling gesture callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 -   Removing `layoutDependency` from forwarded props. [Issue](https://github.com/framer/motion/issues/1350)
 -   `Reorder.Item` correctly fires `onDrag`. [Issue](https://github.com/framer/motion/issues/1348)
+-   Fires `onPressStart` and `onHoverStart` **after** triggering animations.
 
-## [5.3.0] 2021-11-1
+## [5.3.0] 2021-11-11
 
 ### Added
 

--- a/src/gestures/__tests__/press.test.tsx
+++ b/src/gestures/__tests__/press.test.tsx
@@ -275,6 +275,51 @@ describe("press", () => {
         return expect(promise).resolves.toEqual([0.5, 1, 0.5])
     })
 
+    test("press gesture works with animation state", async () => {
+        const [a, b] = await new Promise((resolve) => {
+            const childProps = {
+                variants: {
+                    rest: { opacity: 0.5 },
+                    pressed: { opacity: 0.8 },
+                },
+                transition: { duration: 0.01 },
+            }
+
+            const Component = () => {
+                const [isPressed, setPressedState] = React.useState(false)
+                return (
+                    <motion.div
+                        data-testid="parent"
+                        animate={isPressed ? ["pressed"] : ["rest"]}
+                    >
+                        <motion.div
+                            data-testid="a"
+                            {...childProps}
+                            onTapStart={() => setPressedState(true)}
+                        />
+                        <motion.div data-testid="b" {...childProps} />
+                    </motion.div>
+                )
+            }
+
+            const { getByTestId } = render(<Component />)
+
+            // Trigger mouse down
+            mouseDown(getByTestId("a") as Element)
+            setTimeout(
+                () =>
+                    resolve([
+                        getByTestId("a") as Element,
+                        getByTestId("b") as Element,
+                    ]),
+                100
+            )
+        })
+
+        expect(a).toHaveStyle("opacity: 0.8")
+        expect(b).toHaveStyle("opacity: 0.8")
+    })
+
     /**
      * TODO: We want the behaviour that we can override individual componnets with their
      * own whileX props to apply gesture behaviour just on that component.
@@ -377,15 +422,7 @@ describe("press", () => {
         })
 
         return expect(promise).resolves.toEqual([
-            0.5,
-            0.75,
-            1,
-            0.75,
-            0.5,
-            0.75,
-            1,
-            1,
-            0.5,
+            0.5, 0.75, 1, 0.75, 0.5, 0.75, 1, 1, 0.5,
         ])
     })
 
@@ -452,15 +489,7 @@ describe("press", () => {
         })
 
         return expect(promise).resolves.toEqual([
-            0.5,
-            0.75,
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
-            1,
+            0.5, 0.75, 1, 1, 1, 1, 1, 1, 1,
         ])
     })
 })

--- a/src/gestures/use-hover-gesture.ts
+++ b/src/gestures/use-hover-gesture.ts
@@ -14,8 +14,11 @@ function createHoverEvent(
     return (event: MouseEvent, info: EventInfo) => {
         if (!isMouseEvent(event) || isDragActive()) return
 
-        callback?.(event, info)
+        /**
+         * Ensure we trigger animations before firing event callback
+         */
         visualElement.animationState?.setActive(AnimationType.Hover, isActive)
+        callback?.(event, info)
     }
 }
 

--- a/src/gestures/use-tap-gesture.ts
+++ b/src/gestures/use-tap-gesture.ts
@@ -64,9 +64,12 @@ export function useTapGesture({
             addPointerEvent(window, "pointercancel", onPointerCancel)
         )
 
-        onTapStart?.(event, info)
-
+        /**
+         * Ensure we trigger animations before firing event callback
+         */
         visualElement.animationState?.setActive(AnimationType.Tap, true)
+
+        onTapStart?.(event, info)
     }
 
     usePointerEvent(


### PR DESCRIPTION
After a few hours of trying to replicate the press gesture bug we're seeing in Framer as a test, I haven't managed to. The included test doesn't fail on `main`. But this change does fix the bug. By firing the gesture's callback before triggering the animations, it was possible in some circumstances (in Framer we seem to be adding two gestures, maybe this was something to do with it) to change the active variants while effectively in the middle of sorting out all the animations for that gesture. 

This PR makes it so we don't fire these callbacks until after the gesture animation has fired.