### PR TITLE
Keyframe fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   `Reorder.Item` correctly fires `onDrag`. [Issue](https://github.com/framer/motion/issues/1348)
 -   Fires `onPressStart` and `onHoverStart` **after** triggering animations.
 -   Replay keyframes when variant changes. [Issue](https://github.com/framer/motion/issues/1346)
--   Correctly SSR first keyframe when `initial` is `true` and final keyframe when `initial` is `false`.
+-   Correctly SSR final keyframe when `initial` is `false`.
 
 ## [5.3.0] 2021-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 -   Removing `layoutDependency` from forwarded props. [Issue](https://github.com/framer/motion/issues/1350)
 -   `Reorder.Item` correctly fires `onDrag`. [Issue](https://github.com/framer/motion/issues/1348)
 -   Fires `onPressStart` and `onHoverStart` **after** triggering animations.
+-   Replay keyframes when variant changes. [Issue](https://github.com/framer/motion/issues/1346)
+-   Correctly SSR first keyframe when `initial` is `true` and final keyframe when `initial` is `false`.
 
 ## [5.3.0] 2021-11-11
 

--- a/dev/examples/Animation-keyframes.tsx
+++ b/dev/examples/Animation-keyframes.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { motion } from "@framer"
+import { motion, useCycle } from "@framer"
 
 /**
  * An example of the Motion keyframes syntax.
@@ -14,11 +14,16 @@ const style = {
 }
 
 export const App = () => {
+    const [animate, cycle] = useCycle("a", "b")
     return (
         <motion.div
-            animate={{
-                width: [null, 50, 200, 100],
+            initial={false}
+            animate={animate}
+            variants={{
+                a: { x: [0, 200] },
+                b: { x: [0, 200] },
             }}
+            onClick={() => cycle()}
             transition={{
                 duration: 2,
                 easings: ["circOut", "circOut", "circOut"],

--- a/src/animation/utils/transitions.ts
+++ b/src/animation/utils/transitions.ts
@@ -12,6 +12,7 @@ import { getDefaultTransition } from "./default-transitions"
 import { warning } from "hey-listen"
 import { getAnimatableNone } from "../../render/dom/value-types/animatable-none"
 import { instantAnimationState } from "../../utils/use-instant-transition-state"
+import { resolveFinalValueInKeyframes } from "../../utils/resolve-value"
 
 type StopAnimation = { stop: () => void }
 
@@ -214,9 +215,10 @@ function getAnimation(
     }
 
     function set(): StopAnimation {
-        value.set(target)
+        const finalTarget = resolveFinalValueInKeyframes(target)
+        value.set(finalTarget)
         onComplete()
-        valueTransition?.onUpdate?.(target)
+        valueTransition?.onUpdate?.(finalTarget)
         valueTransition?.onComplete?.()
         return { stop: () => {} }
     }

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -121,14 +121,6 @@ function runTests(render: (components: any) => string) {
         )
     })
 
-    test("initial correctly sets initial keyframe to style", () => {
-        const div = render(<motion.div animate={{ x: [50, 100] }} />)
-
-        expect(div).toBe(
-            `<div style="transform:translateX(50px) translateZ(0)"></div>`
-        )
-    })
-
     test("Reorder: Renders correct element", () => {
         function Component() {
             const [state, setState] = React.useState([0])

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -121,6 +121,14 @@ function runTests(render: (components: any) => string) {
         )
     })
 
+    test("initial correctly sets initial keyframe to style", () => {
+        const div = render(<motion.div animate={{ x: [50, 100] }} />)
+
+        expect(div).toBe(
+            `<div style="transform:translateX(50px) translateZ(0)"></div>`
+        )
+    })
+
     test("Reorder: Renders correct element", () => {
         function Component() {
             const [state, setState] = React.useState([0])

--- a/src/motion/__tests__/ssr.test.tsx
+++ b/src/motion/__tests__/ssr.test.tsx
@@ -107,6 +107,20 @@ function runTests(render: (components: any) => string) {
         )
     })
 
+    test("initial correctly overrides style with keyframes and initial={false}", () => {
+        const div = render(
+            <motion.div
+                initial={false}
+                animate={{ x: [0, 100] }}
+                style={{ x: 200 }}
+            />
+        )
+
+        expect(div).toBe(
+            `<div style="transform:translateX(100px) translateZ(0)"></div>`
+        )
+    })
+
     test("Reorder: Renders correct element", () => {
         function Component() {
             const [state, setState] = React.useState([0])

--- a/src/motion/__tests__/transition-keyframes.test.tsx
+++ b/src/motion/__tests__/transition-keyframes.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "../../../jest.setup"
 import { motion, motionValue } from "../.."
 import * as React from "react"
-import { variantsHaveChanged } from "../../render/utils/animation-state"
+import { checkVariantsDidChange } from "../../render/utils/animation-state"
 
 describe("keyframes transition", () => {
     test("keyframes as target", async () => {
@@ -32,11 +32,13 @@ describe("keyframes transition", () => {
     })
 
     test("hasUpdated detects only changed keyframe arrays", async () => {
-        expect(variantsHaveChanged("1", "2")).toBe(true)
-        expect(variantsHaveChanged(["1", "2", "3"], ["1", "2", "3"])).toBe(
+        expect(checkVariantsDidChange("1", "2")).toBe(true)
+        expect(checkVariantsDidChange(["1", "2", "3"], ["1", "2", "3"])).toBe(
             false
         )
-        expect(variantsHaveChanged(["1", "2", "3"], ["1", "2", "4"])).toBe(true)
+        expect(checkVariantsDidChange(["1", "2", "3"], ["1", "2", "4"])).toBe(
+            true
+        )
     })
 
     test("keyframes with non-pixel values", async () => {

--- a/src/motion/__tests__/transition-keyframes.test.tsx
+++ b/src/motion/__tests__/transition-keyframes.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import { motion } from "../.."
+import { motion, motionValue } from "../.."
 import * as React from "react"
 import { variantsHaveChanged } from "../../render/utils/animation-state"
 
@@ -62,5 +62,54 @@ describe("keyframes transition", () => {
         })
 
         expect(promise).resolves.toHaveStyle("width: 100%;")
+    })
+
+    test("if initial={false}, take state of final keyframe", async () => {
+        const xResult = await new Promise((resolve) => {
+            const x = motionValue(0)
+            const Component = ({ animate }: any) => {
+                return (
+                    <motion.div
+                        initial={false}
+                        animate={animate}
+                        variants={{ a: { x: [0, 100] }, b: { x: [0, 100] } }}
+                        transition={{ ease: () => 0.5, duration: 10 }}
+                        style={{ x }}
+                    />
+                )
+            }
+
+            render(<Component animate="a" />)
+            setTimeout(() => resolve(x.get()), 50)
+        })
+
+        expect(xResult).toBe(100)
+    })
+
+    test("keyframes animation reruns when variants change and keyframes are the same", async () => {
+        const xResult = await new Promise((resolve) => {
+            const x = motionValue(0)
+            const Component = ({ animate }: any) => {
+                return (
+                    <motion.div
+                        initial={false}
+                        animate={animate}
+                        variants={{
+                            a: { x: [0, 100] },
+                            b: { x: [0, 100], transition: { type: false } },
+                        }}
+                        transition={{ ease: () => 0.5, duration: 10 }}
+                        style={{ x }}
+                    />
+                )
+            }
+
+            const { rerender } = render(<Component animate="a" />)
+            rerender(<Component animate="b" />)
+            rerender(<Component animate="a" />)
+            setTimeout(() => resolve(x.get()), 50)
+        })
+
+        expect(xResult).toBe(50)
     })
 })

--- a/src/motion/index.tsx
+++ b/src/motion/index.tsx
@@ -53,6 +53,7 @@ export function createMotionComponent<Props extends {}, Instance, RenderState>({
     ) {
         const layoutId = useLayoutId(props)
         props = { ...props, layoutId }
+
         /**
          * If we're rendering in a static environment, we only visually update the component
          * as a result of a React-rerender rather than interactions or animations. This

--- a/src/motion/utils/use-visual-state.ts
+++ b/src/motion/utils/use-visual-state.ts
@@ -63,19 +63,18 @@ function makeState<I, RS>(
     return state
 }
 
-export const makeUseVisualState = <I, RS>(
-    config: UseVisualStateConfig<I, RS>
-): UseVisualState<I, RS> => (
-    props: MotionProps,
-    isStatic: boolean
-): VisualState<I, RS> => {
-    const context = useContext(MotionContext)
-    const presenceContext = useContext(PresenceContext)
+export const makeUseVisualState =
+    <I, RS>(config: UseVisualStateConfig<I, RS>): UseVisualState<I, RS> =>
+    (props: MotionProps, isStatic: boolean): VisualState<I, RS> => {
+        const context = useContext(MotionContext)
+        const presenceContext = useContext(PresenceContext)
 
-    return isStatic
-        ? makeState(config, props, context, presenceContext)
-        : useConstant(() => makeState(config, props, context, presenceContext))
-}
+        return isStatic
+            ? makeState(config, props, context, presenceContext)
+            : useConstant(() =>
+                  makeState(config, props, context, presenceContext)
+              )
+    }
 
 function makeLatestValues(
     props: MotionProps,
@@ -105,8 +104,8 @@ function makeLatestValues(
         animate ??= context.animate
     }
 
-    const variantToSet =
-        blockInitialAnimation || initial === false ? animate : initial
+    const initialAnimationIsBlocked = blockInitialAnimation || initial === false
+    const variantToSet = initialAnimationIsBlocked ? animate : initial
 
     if (
         variantToSet &&
@@ -120,7 +119,20 @@ function makeLatestValues(
 
             const { transitionEnd, transition, ...target } = resolved
 
-            for (const key in target) values[key] = target[key]
+            for (const key in target) {
+                let valueTarget = target[key]
+
+                if (Array.isArray(valueTarget)) {
+                    const index = initialAnimationIsBlocked
+                        ? valueTarget.length - 1
+                        : 0
+                    valueTarget = valueTarget[index]
+                }
+
+                if (valueTarget !== null) {
+                    values[key] = valueTarget
+                }
+            }
             for (const key in transitionEnd) values[key] = transitionEnd[key]
         })
     }

--- a/src/motion/utils/use-visual-state.ts
+++ b/src/motion/utils/use-visual-state.ts
@@ -123,6 +123,10 @@ function makeLatestValues(
                 let valueTarget = target[key]
 
                 if (Array.isArray(valueTarget)) {
+                    /**
+                     * Take final keyframe if the initial animation is blocked because
+                     * we want to initialise at the end of that blocked animation.
+                     */
                     const index = initialAnimationIsBlocked
                         ? valueTarget.length - 1
                         : 0

--- a/src/render/utils/animation-state.ts
+++ b/src/render/utils/animation-state.ts
@@ -201,8 +201,12 @@ export function createAnimationState(
              * a changed value or a value that was removed in a higher priority, we set
              * this to true and add this prop to the animation list.
              */
+            const isVariantChanged = variantsHaveChanged(
+                typeState.prevProp,
+                prop
+            )
             let shouldAnimateType =
-                variantsHaveChanged(typeState.prevProp, prop) ||
+                isVariantChanged ||
                 // If we're making this variant active, we want to always make it active
                 (type === changedActiveType &&
                     typeState.isActive &&
@@ -264,7 +268,7 @@ export function createAnimationState(
                      * detect whether any value has changed. If it has, we animate it.
                      */
                     if (isKeyframesTarget(next) && isKeyframesTarget(prev)) {
-                        if (!shallowCompare(next, prev)) {
+                        if (!shallowCompare(next, prev) || isVariantChanged) {
                             markToAnimate(key)
                         } else {
                             /**

--- a/src/render/utils/animation-state.ts
+++ b/src/render/utils/animation-state.ts
@@ -201,12 +201,12 @@ export function createAnimationState(
              * a changed value or a value that was removed in a higher priority, we set
              * this to true and add this prop to the animation list.
              */
-            const isVariantChanged = variantsHaveChanged(
+            const variantDidChange = checkVariantsDidChange(
                 typeState.prevProp,
                 prop
             )
             let shouldAnimateType =
-                isVariantChanged ||
+                variantDidChange ||
                 // If we're making this variant active, we want to always make it active
                 (type === changedActiveType &&
                     typeState.isActive &&
@@ -268,7 +268,7 @@ export function createAnimationState(
                      * detect whether any value has changed. If it has, we animate it.
                      */
                     if (isKeyframesTarget(next) && isKeyframesTarget(prev)) {
-                        if (!shallowCompare(next, prev) || isVariantChanged) {
+                        if (!shallowCompare(next, prev) || variantDidChange) {
                             markToAnimate(key)
                         } else {
                             /**
@@ -394,7 +394,7 @@ export function createAnimationState(
     }
 }
 
-export function variantsHaveChanged(prev: any, next: any) {
+export function checkVariantsDidChange(prev: any, next: any) {
     if (typeof next === "string") {
         return next !== prev
     } else if (isVariantLabels(next)) {

--- a/src/render/utils/setters.ts
+++ b/src/render/utils/setters.ts
@@ -37,9 +37,11 @@ export function setTarget(
     definition: string | TargetAndTransition | TargetResolver
 ) {
     const resolved = resolveVariant(visualElement, definition)
-    let { transitionEnd = {}, transition = {}, ...target } = resolved
-        ? visualElement.makeTargetAnimatable(resolved, false)
-        : {}
+    let {
+        transitionEnd = {},
+        transition = {},
+        ...target
+    } = resolved ? visualElement.makeTargetAnimatable(resolved, false) : {}
 
     target = { ...target, ...transitionEnd }
 

--- a/src/utils/resolve-value.ts
+++ b/src/utils/resolve-value.ts
@@ -6,6 +6,6 @@ export const isCustomValue = (v: any): v is CustomValueType => {
 }
 
 export const resolveFinalValueInKeyframes = (v: ValueTarget): SingleTarget => {
-    // TODO maybe throw if v.length - 1 is placeholder token?)
+    // TODO maybe throw if v.length - 1 is placeholder token?
     return isKeyframesTarget(v) ? v[v.length - 1] || 0 : v
 }

--- a/src/utils/resolve-value.ts
+++ b/src/utils/resolve-value.ts
@@ -6,6 +6,6 @@ export const isCustomValue = (v: any): v is CustomValueType => {
 }
 
 export const resolveFinalValueInKeyframes = (v: ValueTarget): SingleTarget => {
-    // TODO maybe throw if v.length - 1 is placeholder token?
+    // TODO maybe throw if v.length - 1 is placeholder token?)
     return isKeyframesTarget(v) ? v[v.length - 1] || 0 : v
 }


### PR DESCRIPTION
This PR makes a few keyframe fixes:

1. If keyframes in two variants are the same, but the variant has changed, re-run the keyframes animation.

```jsx
<motion.div
  animate={is ? "a" : "b"}
  variants={{ a: { x: [0,100] }, b: {x: [0,100] }  }}
/>
```

Fixes https://github.com/framer/motion/issues/1346

2. If `animate` contains keyframes, set the initial value/style to the initial keyframe

```jsx
<motion.div animate={{ opacity: [0, 1] }} />
// <div style="opacity: 0"></div>
```

3. If `initial={false}` and `animate` contains keyframes, set the initial value/style to the final keyframe

```jsx
<motion.div initial={false} animate={{ opacity: [0, 1] }} />
// <div style="opacity: 1"></div>
```