### PR TITLE
fix: package.json exports paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "module": "dist/es/index.mjs",
     "exports": {
         ".": {
-            "require": "dist/cjs/index.js",
+            "require": "./dist/cjs/index.js",
             "import": "./dist/es/index.mjs",
-            "default": "dist/cjs/index.js"
+            "default": "./dist/cjs/index.js"
         },
         "./three": {
             "require": "./dist/cjs/three-entry.js",


### PR DESCRIPTION
After the release of the v5.4.2, importing Framer Motion will cause an error: `Invalid "exports" main target "dist/cjs/index.js" defined in the package config`. 
That's because all the paths defined in "exports" must be relative file URLs starting with `./`.