### PR TITLE
Adding isValidProp to MotionConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.6.0] 2022-01-12
+
+### Added
+
+-   `isValidProp` prop to `MotionConfig` that allows the injection of custom detection of valid React props.
+
 ## [5.5.8] 2022-01-12
 
 ### Fixed

--- a/src/components/MotionConfig/__tests__/index.test.tsx
+++ b/src/components/MotionConfig/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ describe("custom properties", () => {
         const Component = () => {
             return (
                 <MotionConfig isValidProp={(key) => key !== "data-foo"}>
-                    <motion.div data-foo="bar" />
+                    <motion.div data-foo="bar" data-bar="foo" />
                 </MotionConfig>
             )
         }
@@ -16,5 +16,6 @@ describe("custom properties", () => {
         const { container } = render(<Component />)
 
         expect(container.firstChild).not.toHaveAttribute("data-foo")
+        expect(container.firstChild).toHaveAttribute("data-bar")
     })
 })

--- a/src/components/MotionConfig/__tests__/index.test.tsx
+++ b/src/components/MotionConfig/__tests__/index.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "../../../../jest.setup"
+import { motion } from "../../../render/dom/motion"
+import { MotionConfig } from "../"
+import * as React from "react"
+
+describe("custom properties", () => {
+    test("renders", () => {
+        const Component = () => {
+            return (
+                <MotionConfig isValidProp={(key) => key !== "data-foo"}>
+                    <motion.div data-foo="bar" />
+                </MotionConfig>
+            )
+        }
+
+        const { container } = render(<Component />)
+
+        expect(container.firstChild).not.toHaveAttribute("data-foo")
+    })
+})

--- a/src/components/MotionConfig/index.tsx
+++ b/src/components/MotionConfig/index.tsx
@@ -1,10 +1,15 @@
 import * as React from "react"
 import { useContext, useMemo } from "react"
 import { MotionConfigContext } from "../../context/MotionConfigContext"
+import {
+    loadExternalIsValidProp,
+    IsValidProp,
+} from "../../render/dom/utils/filter-props"
 import { useConstant } from "../../utils/use-constant"
 
 export interface MotionConfigProps extends Partial<MotionConfigContext> {
     children?: React.ReactNode
+    isValidProp?: IsValidProp
 }
 
 /**
@@ -24,7 +29,13 @@ export interface MotionConfigProps extends Partial<MotionConfigContext> {
  *
  * @public
  */
-export function MotionConfig({ children, ...config }: MotionConfigProps) {
+export function MotionConfig({
+    children,
+    isValidProp,
+    ...config
+}: MotionConfigProps) {
+    isValidProp && loadExternalIsValidProp(isValidProp)
+
     /**
      * Inherit props from any parent MotionConfig components
      */

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -680,6 +680,15 @@ export function createProjectionNode<I>({
                 measured,
                 actual: this.removeElementScroll(measured),
             }
+
+            if ((this.instance as any).title)
+                console.log(
+                    (this.instance as any).title,
+                    "layout",
+                    this.layout.actual,
+                    this.layout.measured
+                )
+
             this.layoutCorrected = createBox()
             this.isLayoutDirty = false
             this.projectionDelta = undefined

--- a/src/projection/node/create-projection-node.ts
+++ b/src/projection/node/create-projection-node.ts
@@ -681,14 +681,6 @@ export function createProjectionNode<I>({
                 actual: this.removeElementScroll(measured),
             }
 
-            if ((this.instance as any).title)
-                console.log(
-                    (this.instance as any).title,
-                    "layout",
-                    this.layout.actual,
-                    this.layout.measured
-                )
-
             this.layoutCorrected = createBox()
             this.isLayoutDirty = false
             this.projectionDelta = undefined

--- a/src/render/dom/utils/filter-props.ts
+++ b/src/render/dom/utils/filter-props.ts
@@ -5,12 +5,12 @@ let shouldForward = (key: string) => !isValidMotionProp(key)
 
 export type IsValidProp = (key: string) => boolean
 
-export function loadExternalIsValidProp(emotionIsPropValid?: IsValidProp) {
-    if (!emotionIsPropValid) return
+export function loadExternalIsValidProp(isValidProp?: IsValidProp) {
+    if (!isValidProp) return
 
-    // Handle events explicitly as Emotion validates them all as true
+    // Explicitly filter our events
     shouldForward = (key: string) =>
-        key.startsWith("on") ? !isValidMotionProp(key) : emotionIsPropValid(key)
+        key.startsWith("on") ? !isValidMotionProp(key) : isValidProp(key)
 }
 
 /**


### PR DESCRIPTION
This PR adds an `isValidProp` prop to `MotionConfig` that allows the external injection of an `isValidProp` function.

Fixes https://github.com/framer/motion/issues/1406