### PR TITLE
Crossfade border-radius of "%" and "px" units

### DIFF
--- a/src/projection/animation/__tests__/mix-values.test.ts
+++ b/src/projection/animation/__tests__/mix-values.test.ts
@@ -71,4 +71,30 @@ describe("mixValues", () => {
 
         expect(output).toEqual({ borderTopLeftRadius: "10%" })
     })
+
+    test("doesn't mix % with px", () => {
+        const output = {}
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: "10px" },
+            { borderTopLeftRadius: "20%" },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: "20%" })
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: "20%" },
+            { borderTopLeftRadius: "10px" },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: "10px" })
+    })
 })

--- a/src/projection/animation/__tests__/mix-values.test.ts
+++ b/src/projection/animation/__tests__/mix-values.test.ts
@@ -1,0 +1,74 @@
+import { mixValues } from "../mix-values"
+
+describe("mixValues", () => {
+    test("mixes borderRadius numbers", () => {
+        const output = {}
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: 10 },
+            { borderTopLeftRadius: 20 },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: 15 })
+    })
+
+    test("mixes borderRadius px", () => {
+        const output = {}
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: "10px" },
+            { borderTopLeftRadius: "20px" },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: 15 })
+    })
+
+    test("mixes borderRadius percentage", () => {
+        const output = {}
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: "10%" },
+            { borderTopLeftRadius: "20%" },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: "15%" })
+    })
+
+    test("mixes borderRadius percentage with 0", () => {
+        const output = {}
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: 0 },
+            { borderTopLeftRadius: "20%" },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: "10%" })
+
+        mixValues(
+            output,
+            { borderTopLeftRadius: "20%" },
+            { borderTopLeftRadius: 0 },
+            0.5,
+            false,
+            false
+        )
+
+        expect(output).toEqual({ borderTopLeftRadius: "10%" })
+    })
+})

--- a/src/projection/animation/mix-values.ts
+++ b/src/projection/animation/mix-values.ts
@@ -1,9 +1,13 @@
 import { circOut, linear, mix, progress as calcProgress } from "popmotion"
+import { percent } from "style-value-types"
 import { ResolvedValues } from "../../render/types"
 import { EasingFunction } from "../../types"
 
 const borders = ["TopLeft", "TopRight", "BottomLeft", "BottomRight"]
 const numBorders = borders.length
+
+const asNumber = (value: string | number) =>
+    typeof value === "string" ? parseFloat(value) : value
 
 export function mixValues(
     target: ResolvedValues,
@@ -47,17 +51,13 @@ export function mixValues(
         followRadius ||= 0
         leadRadius ||= 0
 
-        /**
-         * Currently we're only crossfading between numerical border radius.
-         * It would be possible to crossfade between percentages for a little
-         * extra bundle size.
-         */
-        if (
-            typeof followRadius === "number" &&
-            typeof leadRadius === "number"
-        ) {
-            const radius = Math.max(mix(followRadius, leadRadius, progress), 0)
-            target[borderLabel] = radius
+        target[borderLabel] = Math.max(
+            mix(asNumber(followRadius), asNumber(leadRadius), progress),
+            0
+        )
+
+        if (percent.test(leadRadius) || percent.test(followRadius)) {
+            target[borderLabel] += "%"
         }
     }
 

--- a/src/projection/animation/mix-values.ts
+++ b/src/projection/animation/mix-values.ts
@@ -1,5 +1,5 @@
 import { circOut, linear, mix, progress as calcProgress } from "popmotion"
-import { percent } from "style-value-types"
+import { percent, px } from "style-value-types"
 import { ResolvedValues } from "../../render/types"
 import { EasingFunction } from "../../types"
 
@@ -8,6 +8,9 @@ const numBorders = borders.length
 
 const asNumber = (value: string | number) =>
     typeof value === "string" ? parseFloat(value) : value
+
+const isPx = (value: string | number) =>
+    typeof value === "number" || px.test(value)
 
 export function mixValues(
     target: ResolvedValues,
@@ -51,13 +54,22 @@ export function mixValues(
         followRadius ||= 0
         leadRadius ||= 0
 
-        target[borderLabel] = Math.max(
-            mix(asNumber(followRadius), asNumber(leadRadius), progress),
-            0
-        )
+        const canMix =
+            followRadius === 0 ||
+            leadRadius === 0 ||
+            isPx(followRadius) === isPx(leadRadius)
 
-        if (percent.test(leadRadius) || percent.test(followRadius)) {
-            target[borderLabel] += "%"
+        if (canMix) {
+            target[borderLabel] = Math.max(
+                mix(asNumber(followRadius), asNumber(leadRadius), progress),
+                0
+            )
+
+            if (percent.test(leadRadius) || percent.test(followRadius)) {
+                target[borderLabel] += "%"
+            }
+        } else {
+            target[borderLabel] = leadRadius
         }
     }
 

--- a/src/projection/styles/scale-border-radius.ts
+++ b/src/projection/styles/scale-border-radius.ts
@@ -17,6 +17,7 @@ export function pixelsToPercent(pixels: number, axis: Axis): number {
 export const correctBorderRadius: ScaleCorrectorDefinition = {
     correct: (latest, node) => {
         if (!node.target) return latest
+
         /**
          * If latest is a string, if it's a percentage we can return immediately as it's
          * going to be stretched appropriately. Otherwise, if it's a pixel, convert it to a number.


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/1413
