### PR TITLE
Only animateChanges from useEffect, so react animateChanges cannot go ahead of about-to-change react properties.

### DIFF
--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -20,6 +20,7 @@ export function useVisualElement<Instance, RenderState>(
     const parent = useVisualElementContext()
     const presenceContext = useContext(PresenceContext)
     const shouldReduceMotion = useReducedMotionConfig()
+    const [_, forceRender] = React.useState(1)
 
     const visualElementRef: MutableRefObject<VisualElement | undefined> =
         useRef(undefined)
@@ -38,6 +39,9 @@ export function useVisualElement<Instance, RenderState>(
             blockInitialAnimation: presenceContext?.initial === false,
             shouldReduceMotion,
         })
+        visualElementRef.current.forceRender = () => {
+            forceRender((s) => s + 1)
+        }
     }
 
     const visualElement = visualElementRef.current

--- a/packages/framer-motion/src/render/index.ts
+++ b/packages/framer-motion/src/render/index.ts
@@ -436,6 +436,11 @@ export const visualElement =
             },
 
             /**
+             * Force react to render.
+             */
+            forceRender(): void {},
+
+            /**
              * Schedule a render on the next animation frame.
              */
             scheduleRender() {

--- a/packages/framer-motion/src/render/types.ts
+++ b/packages/framer-motion/src/render/types.ts
@@ -63,6 +63,7 @@ export interface VisualElement<Instance = any, RenderState = any>
     getStaticValue(key: string): number | string | undefined
     setStaticValue(key: string, value: number | string): void
     getLatestValues(): ResolvedValues
+    forceRender(): void
     scheduleRender(): void
 
     makeTargetAnimatable(

--- a/packages/framer-motion/src/render/utils/animation-state.ts
+++ b/packages/framer-motion/src/render/utils/animation-state.ts
@@ -384,7 +384,16 @@ export function createAnimationState(
 
         state[type].isActive = isActive
 
-        return animateChanges(options, type)
+        // If called with extra options, we assume our caller is in a use effect and we animate the
+        // changes directly.
+        if (options) {
+            return animateChanges(options, type)
+        }
+
+        // The normal case, we just changed some animation state, we must make sure react will
+        // schedule our visual element and we animate from useEffect.
+        visualElement?.forceRender()
+        return Promise.resolve()
     }
 
     return {


### PR DESCRIPTION
Fixes this scenario:
```html
<!DOCTYPE html>
<script src="../../dev/webpack/react.development.js"></script>
<script src="../../dev/webpack/react-dom.development.js"></script>
<script src="dist/framer-motion.dev.js"></script>
<main id="main">ERROR</main>
<script>
    const _jsx = React.createElement
    const motion = Motion.motion

    const Component = function () {
        const [isHover, setIsHover] = React.useState(false)
        const [isPressed, setIsPressed] = React.useState(false)
        const [variant, setVariant] = React.useState("AWicccZ5Z")

        const variants = [variant]
        if (isHover) variants.push(variant + "-hover")

        //! Uncommenting the next line makes it work.
        // if (isPressed) variants.push(variant + "-pressed")

        return _jsx(motion.div,
            {
                animate: variants,
                onHoverStart: () => setIsHover(true),
                onHoverEnd: () => setIsHover(false),
                //! Commenting out the onTap* handlers also makes it work.
                onTapStart: () => setIsPressed(true),
                onTap: () => setIsPressed(false),
                onTapCancel: () => setIsPressed(false)
            }
            , _jsx(motion.div,
                {
                    onTap: () => setVariant("zYfTjnAAK"),
                    style: {
                        width: 300,
                        height: 300,
                        "backgroundColor": "rgb(153, 238, 255)",
                    },
                    variants: {
                        "zYfTjnAAK": {
                            "backgroundColor": "rgb(250, 121, 0)"
                        },
                    },
                },
                _jsx(motion.div,
                    {
                        style: {
                            width: 100,
                            height: 100,
                            "backgroundColor": "rgb(153, 238, 255)",
                        },
                        variants: {
                            // This state lingers too long.
                            "AWicccZ5Z-hover": {
                                "backgroundColor": "rgb(54, 185, 211)"
                            },
                            "zYfTjnAAK": {
                                "backgroundColor": "rgb(250, 121, 0)"
                            },
                            "zYfTjnAAK-hover": {
                                "backgroundColor": "rgb(200, 100, 0)"
                            },
                        },
                    })
            )
        )
    }

    ReactDOM.render(_jsx(Component), document.getElementById("main"))
</script>
```