### PR TITLE
Use isomorphic layout effect in useIsMounted

### DIFF
--- a/packages/framer-motion/src/utils/use-is-mounted.ts
+++ b/packages/framer-motion/src/utils/use-is-mounted.ts
@@ -1,8 +1,9 @@
-import { useLayoutEffect, useRef } from "react"
+import { useRef } from "react"
+import { useIsomorphicLayoutEffect } from "./use-isomorphic-effect"
 
 export function useIsMounted() {
     const isMounted = useRef(false)
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         isMounted.current = true
 
         return () => {


### PR DESCRIPTION
The React 18 upgrade in #1438 introduced a new `useIsMounted` hook, that that didn't use the `useIsomorphicLayoutEffect`. This resulted in a warning rendered serverside. Fix by replacing `useLayoutEffect` with `useIsomprohicLayoutEffect`.

Fix: #578