### PR TITLE
Fix blocked animations

### DIFF
--- a/dev/examples/variants-race.tsx
+++ b/dev/examples/variants-race.tsx
@@ -1,0 +1,61 @@
+import * as React from "react"
+import { useState } from "react"
+import { motion } from "framer-motion"
+
+export const App = function () {
+    const [isHover, setIsHover] = useState(false)
+    const [isPressed, setIsPressed] = useState(false)
+    const [variant, setVariant] = useState("a")
+
+    const variants = [variant]
+    if (isHover) variants.push(variant + "-hover")
+
+    //! Uncommenting the next line makes it work.
+    // if (isPressed) variants.push(variant + "-pressed")
+    console.log(variants)
+    return (
+        <motion.div
+            animate={variants}
+            onHoverStart={() => setIsHover(true)}
+            onHoverEnd={() => setIsHover(false)}
+            // onTapStart={() => setIsPressed(true)}
+            // onTap={() => setIsPressed(false)}
+            onTapCancel={() => setIsPressed(false)}
+        >
+            <motion.div
+                onTap={() => setVariant("b")}
+                style={{
+                    width: 300,
+                    height: 300,
+                    backgroundColor: "rgba(255,255,0)",
+                }}
+                variants={{
+                    b: {
+                        backgroundColor: "rgba(0,255,255)",
+                    },
+                }}
+            >
+                <motion.div
+                    id="inner"
+                    style={{
+                        width: 100,
+                        height: 100,
+                        backgroundColor: "rgba(255,255,0)",
+                    }}
+                    variants={{
+                        // This state lingers too long.
+                        "a-hover": {
+                            backgroundColor: "rgba(150,150,0)",
+                        },
+                        b: {
+                            backgroundColor: "rgba(0,255,255)",
+                        },
+                        "b-hover": {
+                            backgroundColor: "rgb(0, 150,150)",
+                        },
+                    }}
+                />
+            </motion.div>
+        </motion.div>
+    )
+}

--- a/packages/framer-motion/src/render/utils/__tests__/animation-state.test.ts
+++ b/packages/framer-motion/src/render/utils/__tests__/animation-state.test.ts
@@ -656,77 +656,41 @@ describe("Animation state - Set active", () => {
         let animate = mockAnimate(state)
         state.setActive(AnimationType.Hover, true)
         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
 
         // Set hover to false
         animate = mockAnimate(state)
         state.setActive(AnimationType.Hover, false)
         expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
 
         // Set hover to true
         animate = mockAnimate(state)
         state.setActive(AnimationType.Hover, true)
         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
 
         // Set hover to false
         animate = mockAnimate(state)
         state.setActive(AnimationType.Hover, false)
         expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
 
         // Set hover to true
         animate = mockAnimate(state)
         state.setActive(AnimationType.Hover, true)
         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
 
         // Set press to true
         animate = mockAnimate(state)
         state.setActive(AnimationType.Tap, true)
         expect(animate).toBeCalledWith([{ opacity: 0.8 }])
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(
-            state.getState()[AnimationType.Hover].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(state.getState()[AnimationType.Tap].protectedKeys).toEqual({})
 
         // Set hover to false
         animate = mockAnimate(state)
         state.setActive(AnimationType.Hover, false)
-        expect(
-            state.getState()[AnimationType.Animate].protectedKeys
-        ).toHaveProperty("opacity")
-        expect(
-            state.getState()[AnimationType.Tap].protectedKeys
-        ).toHaveProperty("opacity")
         expect(animate).not.toBeCalled()
 
         // Set press to false
         animate = mockAnimate(state)
         state.setActive(AnimationType.Tap, false)
         expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
     })
 
     test("Change active variant where no variants are defined", () => {

--- a/packages/framer-motion/src/render/utils/animation-state.ts
+++ b/packages/framer-motion/src/render/utils/animation-state.ts
@@ -384,7 +384,14 @@ export function createAnimationState(
 
         state[type].isActive = isActive
 
-        return animateChanges(options, type)
+        const animations = animateChanges(options, type)
+
+        // Remove this and create failing test
+        for (const key in state) {
+            state[key].protectedKeys = {}
+        }
+
+        return animations
     }
 
     return {

--- a/packages/framer-motion/src/render/utils/animation-state.ts
+++ b/packages/framer-motion/src/render/utils/animation-state.ts
@@ -386,7 +386,6 @@ export function createAnimationState(
 
         const animations = animateChanges(options, type)
 
-        // Remove this and create failing test
         for (const key in state) {
             state[key].protectedKeys = {}
         }


### PR DESCRIPTION
Closes https://github.com/framer/motion/pull/1451

This clears protectedKeys after animations triggered by `setActive`, ie gestures like `whileHover` etc. This removes the race condition of trying to animate a tree via state immediately after doing so with a gesture.