### PR TITLE
fix typescript type for AnimatePresence component

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -88,7 +88,7 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  *
  * @public
  */
-export const AnimatePresence: React.FunctionComponent<AnimatePresenceProps> = ({
+export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<AnimatePresenceProps>> = ({
     children,
     custom,
     initial = true,

--- a/packages/framer-motion/src/components/LayoutGroup/index.tsx
+++ b/packages/framer-motion/src/components/LayoutGroup/index.tsx
@@ -24,7 +24,7 @@ const shouldInheritGroup = (inherit: InheritOption) => inherit === true
 const shouldInheritId = (inherit: InheritOption) =>
     shouldInheritGroup(inherit === true) || inherit === "id"
 
-export const LayoutGroup: React.FunctionComponent<Props> = ({
+export const LayoutGroup: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     children,
     id,
     inheritId,


### PR DESCRIPTION
After upgrading my React app to version 18 and upgrading `@types/react` to v18 I was getting errors when using the `AnimatePresence` component

```
Type '{ children: false | Element | undefined; initial: false; }' is not assignable to type 'IntrinsicAttributes & AnimatePresenceProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & AnimatePresenceProps'.

<AnimatePresence initial={false}>
```

This should fix the issue.