### PR TITLE
Change useSpring memo dependency to json string

### DIFF
--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -55,7 +55,7 @@ export function useSpring(
 
             return value.get()
         })
-    }, Object.values(config))
+    }, [JSON.stringify(config)])
 
     useOnChange(source, (v) => value.set(parseFloat(v)))
 


### PR DESCRIPTION
useSpring will emit the error below if the number of config properties changes dynamically
```diff
- Warning: The final argument passed to useMemo changed size between renders. The order and size of this array must remain constant.
```
This also causes the config to not update properly

This PR fixes the issue