### PR TITLE
#1514 Fix typescript type for AnimateSharedLayout

### DIFF
--- a/packages/framer-motion/src/components/AnimateSharedLayout.tsx
+++ b/packages/framer-motion/src/components/AnimateSharedLayout.tsx
@@ -3,6 +3,6 @@ import { useConstant } from "../utils/use-constant"
 import { LayoutGroup } from "./LayoutGroup"
 
 let id = 0
-export const AnimateSharedLayout: React.FunctionComponent<T> = ({ children }) => (
+export const AnimateSharedLayout: React.FC<{children: React.ReactNode}> = ({ children }) => (
     <LayoutGroup id={useConstant(() => `asl-${id++}`)}>{children}</LayoutGroup>
 )

--- a/packages/framer-motion/src/components/AnimateSharedLayout.tsx
+++ b/packages/framer-motion/src/components/AnimateSharedLayout.tsx
@@ -3,6 +3,6 @@ import { useConstant } from "../utils/use-constant"
 import { LayoutGroup } from "./LayoutGroup"
 
 let id = 0
-export const AnimateSharedLayout: React.FunctionComponent<React.PropsWithChildren> = ({ children }) => (
+export const AnimateSharedLayout: React.FunctionComponent<T> = ({ children }) => (
     <LayoutGroup id={useConstant(() => `asl-${id++}`)}>{children}</LayoutGroup>
 )

--- a/packages/framer-motion/src/components/AnimateSharedLayout.tsx
+++ b/packages/framer-motion/src/components/AnimateSharedLayout.tsx
@@ -3,6 +3,6 @@ import { useConstant } from "../utils/use-constant"
 import { LayoutGroup } from "./LayoutGroup"
 
 let id = 0
-export const AnimateSharedLayout: React.FunctionComponent = ({ children }) => (
+export const AnimateSharedLayout: React.FunctionComponent<React.PropsWithChildren> = ({ children }) => (
     <LayoutGroup id={useConstant(() => `asl-${id++}`)}>{children}</LayoutGroup>
 )


### PR DESCRIPTION
[#1514](https://github.com/framer/motion/issues/1514) After upgrading my React project without CRA to version 18.
I was getting errors when using the `AnimateSharedLayout`

```
TS2559: Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.
````