### PR TITLE
Fix SSR detection in Deno

### DIFF
--- a/packages/framer-motion/src/utils/is-browser.ts
+++ b/packages/framer-motion/src/utils/is-browser.ts
@@ -1,1 +1,1 @@
-export const isBrowser = typeof window !== "undefined"
+export const isBrowser = typeof document !== "undefined"

--- a/packages/framer-motion/src/utils/use-reduced-motion.ts
+++ b/packages/framer-motion/src/utils/use-reduced-motion.ts
@@ -1,5 +1,6 @@
 import { useContext, useState } from "react"
 import { MotionConfigContext } from "../context/MotionConfigContext"
+import { isBrowser } from "./is-browser"
 
 interface ReducedMotionState {
     current: boolean | null
@@ -11,7 +12,7 @@ const prefersReducedMotion: ReducedMotionState = { current: null }
 let hasDetected = false
 function initPrefersReducedMotion() {
     hasDetected = true
-    if (typeof window === "undefined") return
+    if (!isBrowser) return
 
     if (window.matchMedia) {
         const motionMediaQuery = window.matchMedia("(prefers-reduced-motion)")

--- a/packages/framer-motion/src/value/scroll/use-viewport-scroll.ts
+++ b/packages/framer-motion/src/value/scroll/use-viewport-scroll.ts
@@ -21,7 +21,6 @@ let hasListeners = false
 
 function addEventListeners() {
     hasListeners = true
-    if (typeof window === "undefined") return
 
     const updateScrollValues = createScrollUpdater(
         viewportScrollValues,


### PR DESCRIPTION
Deno provides a `window` object, which makes Framer Motion believe it's running in a browser when using Deno for SSR. They suggest checking the `document` instead:

https://github.com/denoland/deno/issues/13367

There's a few more `typeof window` checks in `dist`, centered around `window.requestAnimationFrame`. I suspect these are coming from some dependency. In my testing (SSRing www.framer.com/sites in Deno), they haven't caused any trouble, despite `window.requestAnimationFrame` being `undefined` (which means if there is some code path which triggers them, it would crash).

![image](https://user-images.githubusercontent.com/1155764/164488370-becbf2e8-d0fe-499d-afbe-ea99b6dfe255.png)
