### PR TITLE
Remove unnecessary log codes

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -21,25 +21,12 @@ type ComponentKey = string | number
 
 const getChildKey = (child: ReactElement<any>): ComponentKey => child.key || ""
 
-const isDev = process.env.NODE_ENV !== "production"
-
 function updateChildLookup(
     children: ReactElement<any>[],
     allChildren: Map<ComponentKey, ReactElement<any>>
 ) {
-    const seenChildren = isDev ? new Set<ComponentKey>() : null
-
     children.forEach((child) => {
         const key = getChildKey(child)
-
-        if (isDev && seenChildren && seenChildren.has(key)) {
-            console.warn(
-                `Children of AnimatePresence require unique keys. "${key}" is a duplicate.`
-            )
-
-            seenChildren.add(key)
-        }
-
         allChildren.set(key, child)
     })
 }


### PR DESCRIPTION
### Remove unnecessary log codes

`packages/framer-motion/src/components/AnimatePresence/index.tsx`

Remove duplicate key alert in function `updateChildLookup`

#### reason

If you look at the original code, the logic `seenChildren.add(key)` is `if(isDev &&seenChildren.has(key))`, so it never works logically.

Also, even if you correct the behavior as originally intended, as shown in the code below, 'react-devtools' already warns you, so you don't need it.

```tsx
function updateChildLookup(
    children: ReactElement<any>[],
    allChildren: Map<ComponentKey, ReactElement<any>>
) {
    const seenChildren = isDev ? new Set<ComponentKey>() : null

    children.forEach((child) => {
        const key = getChildKey(child)

        if (isDev && seenChildren) {
            if (seenChildren.has(key)) {
                console.warn(
                    `Children of AnimatePresence require unique keys. "${key}" is a duplicate.`
                )
            } else {
                seenChildren.add(key)
            }
        }

        allChildren.set(key, child)
    })
}
```

![image](https://user-images.githubusercontent.com/48559454/166707912-f5dace2f-ef2c-4cd3-aee6-b2143547750c.png)

