### PR TITLE
Making safer process.env check

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -8,7 +8,7 @@ import {
     useContext,
 } from "react"
 import * as React from "react"
-import process from "../../utils/process"
+import { env } from "../../utils/process"
 import { AnimatePresenceProps } from "./types"
 import { useForceUpdate } from "../../utils/use-force-update"
 import { useIsMounted } from "../../utils/use-is-mounted"
@@ -75,7 +75,9 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  *
  * @public
  */
-export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<AnimatePresenceProps>> = ({
+export const AnimatePresence: React.FunctionComponent<
+    React.PropsWithChildren<AnimatePresenceProps>
+> = ({
     children,
     custom,
     initial = true,
@@ -229,7 +231,7 @@ export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<An
     })
 
     if (
-        process.env.NODE_ENV !== "production" &&
+        env !== "production" &&
         exitBeforeEnter &&
         childrenToRender.length > 1
     ) {

--- a/packages/framer-motion/src/motion/features/use-features.tsx
+++ b/packages/framer-motion/src/motion/features/use-features.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import process from "../../utils/process"
+import { env } from "../../utils/process"
 import { VisualElement } from "../../render/types"
 import { MotionProps } from "../types"
 import { FeatureBundle, FeatureDefinition } from "./types"
@@ -28,11 +28,7 @@ export function useFeatures(
      * If we're in development mode, check to make sure we're not rendering a motion component
      * as a child of LazyMotion, as this will break the file-size benefits of using it.
      */
-    if (
-        process.env.NODE_ENV !== "production" &&
-        preloadedFeatures &&
-        lazyContext.strict
-    ) {
+    if (env !== "production" && preloadedFeatures && lazyContext.strict) {
         invariant(
             false,
             "You have rendered a `motion` component within a `LazyMotion` component. This will break tree shaking. Import and render a `m` component instead."

--- a/packages/framer-motion/src/motion/features/viewport/use-viewport.ts
+++ b/packages/framer-motion/src/motion/features/viewport/use-viewport.ts
@@ -1,4 +1,4 @@
-import process from "../../../utils/process"
+import { env } from "../../../utils/process"
 import { useEffect, useRef } from "react"
 import { VisualElement } from "../../../render/types"
 import { AnimationType } from "../../../render/utils/types"
@@ -112,7 +112,7 @@ function useMissingIntersectionObserver(
     useEffect(() => {
         if (!shouldObserve || !fallback) return
 
-        if (process.env.NODE_ENV !== "production") {
+        if (env !== "production") {
             warnOnce(
                 false,
                 "IntersectionObserver not available on this device. whileInView animations will trigger on mount."

--- a/packages/framer-motion/src/utils/process.ts
+++ b/packages/framer-motion/src/utils/process.ts
@@ -1,9 +1,8 @@
 /**
  * Browser-safe usage of process
  */
-const mockProcess = { env: { NODE_ENV: "production" } }
-
-const safeProcess = typeof process === "undefined" ? mockProcess : process
-
-// eslint-disable-next-line import/no-default-export
-export default safeProcess
+const defaultEnvironment = "production"
+export const env =
+    typeof process === "undefined" || process.env === undefined
+        ? defaultEnvironment
+        : process.env.NODE_ENV || defaultEnvironment


### PR DESCRIPTION
`process` might be defined, but `env` might not be, which throws in certain environments.

Fixes https://github.com/framer/motion/issues/1544