### PR TITLE
Restore scroll position after measuring height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.3.8] 2022-06-03
+
+### Fixed
+
+-   Restore scroll position after measuring `height` when doing unit conversion animation.
+
 ## [6.3.7] 2022-06-03
 
 ### Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
-  "version": "6.3.7",
-  "packages": [
-    "packages/*"
-  ],
-  "npmClient": "yarn",
-  "useWorkspaces": true
+    "version": "6.3.7",
+    "packages": ["packages/*"],
+    "npmClient": "yarn",
+    "useWorkspaces": true
 }

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -84,6 +84,5 @@
         "typescript": "^4.2.3",
         "webpack": "^5.27.2",
         "yarn-deduplicate": "^1.1.1"
-    },
-    "gitHead": "f5a706800f4b0cc9d3b3af3d11c985ec96997921"
+    }
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -76,7 +76,7 @@
     "bundlesize": [
         {
             "path": "./dist/framer-motion.js",
-            "maxSize": "35.65 kB"
+            "maxSize": "35.7 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -96,7 +96,7 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "19.55 kB"
+            "maxSize": "19.6 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -102,6 +102,5 @@
             "path": "./dist/size-webpack-dom-max.js",
             "maxSize": "31.5 kB"
         }
-    ],
-    "gitHead": "f5a706800f4b0cc9d3b3af3d11c985ec96997921"
+    ]
 }

--- a/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
@@ -261,6 +261,11 @@ const checkAndConvertChangedValueTypes = (
     })
 
     if (changedValueTypeKeys.length) {
+        const scrollY =
+            changedValueTypeKeys.indexOf("height") >= 0
+                ? window.pageYOffset
+                : null
+
         const convertedTarget = convertChangedValueTypes(
             target,
             visualElement,
@@ -276,6 +281,9 @@ const checkAndConvertChangedValueTypes = (
 
         // Reapply original values
         visualElement.syncRender()
+
+        // Restore scroll position
+        if (scrollY !== null) window.scrollTo({ top: scrollY })
 
         return { target: convertedTarget, transitionEnd }
     } else {


### PR DESCRIPTION
When animating between different `height` units like `0` and `auto` we do some DOM measurements that might change the page height in such a way that scroll position resets to `0`. This PR measures and restores the scroll position.

We could do the same with `width` but this is the first time this has come up even with y scroll so it's probably not neccessary.

Fixes https://github.com/framer/motion/issues/1540