### PR TITLE
Fix AnimatePresence won't unmount fastly changing content

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { useId, useMemo } from "react"
+import { ComponentKey } from "."
 import {
     PresenceContext,
     PresenceContextProps,
@@ -11,11 +12,12 @@ import { PopChild } from "./PopChild"
 interface PresenceChildProps {
     children: React.ReactElement
     isPresent: boolean
-    onExitComplete?: () => void
+    onExitComplete?: (key: ComponentKey) => void
     initial?: false | VariantLabels
     custom?: any
     presenceAffectsLayout: boolean
     mode: "sync" | "popLayout" | "wait"
+    childKey: ComponentKey
 }
 
 export const PresenceChild = ({
@@ -26,6 +28,7 @@ export const PresenceChild = ({
     custom,
     presenceAffectsLayout,
     mode,
+    childKey,
 }: PresenceChildProps) => {
     const presenceChildren = useConstant(newChildrenMap)
     const id = useId()
@@ -43,7 +46,7 @@ export const PresenceChild = ({
                     if (!isComplete) return // can stop searching when any is incomplete
                 }
 
-                onExitComplete?.()
+                onExitComplete?.(childKey)
             },
             register: (childId: string) => {
                 presenceChildren.set(childId, false)
@@ -67,7 +70,7 @@ export const PresenceChild = ({
      * component immediately.
      */
     React.useEffect(() => {
-        !isPresent && !presenceChildren.size && onExitComplete?.()
+        !isPresent && !presenceChildren.size && onExitComplete?.(childKey)
     }, [isPresent])
 
     if (mode === "popLayout") {

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -286,7 +286,6 @@ export const AnimatePresence: React.FunctionComponent<
     //   [F]       [F]
     //   [B]       [B]        [B]     <--- preservingKey
     //             [3]        [3]     <--- presentChunk - 3
-    //   [B]                          <--- targetChunk - 2
     //   [C]       [C]        [C]     <--- preservingKey
 
     childrenToRender = []

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -285,14 +285,14 @@ export const AnimatePresence: React.FunctionComponent<
     //
     //  init ->  animate -> Exit Complete
     //
-    //             [1]        [1]     <--- presentChunk - 1
+    //             [1]        [1]     <--- targetChunk - 1
     //   [A]       [A]        [A]     <--- preservingKey
-    //             [2]        [2]     <--- presentChunk - 2
     //   [D]       [D]
-    //   [E]       [E]                <--- targetChunk - 1
+    //   [E]       [E]                <--- presentChunk - 1
     //   [F]       [F]
+    //             [2]        [2]     <--- targetChunk - 2
     //   [B]       [B]        [B]     <--- preservingKey
-    //             [3]        [3]     <--- presentChunk - 3
+    //             [3]        [3]     <--- targetChunk - 3
     //   [C]       [C]        [C]     <--- preservingKey
 
     childrenToRender = []

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -131,9 +131,8 @@ export const AnimatePresence: React.FunctionComponent<
     const filteredChildren = onlyElements(children)
     let childrenToRender = filteredChildren
 
-    const exiting = useRef(new Set<ComponentKey>()).current
     const exitingChildren = useRef(
-        new Map<ComponentKey, ReactElement<any>>()
+        new Map<ComponentKey, ReactElement<any> | undefined>()
     ).current
 
     // Keep a living record of the children we're actually rendering so we
@@ -159,7 +158,6 @@ export const AnimatePresence: React.FunctionComponent<
     useUnmountEffect(() => {
         isInitialRender.current = true
         allChildren.clear()
-        exiting.clear()
         exitingChildren.clear()
     })
 
@@ -195,11 +193,10 @@ export const AnimatePresence: React.FunctionComponent<
         const key = presentKeys[i]
 
         if (targetKeys.indexOf(key) === -1) {
-            exiting.add(key)
+            exitingChildren.set(key, undefined)
         } else {
-            exiting.delete(key)
-            exitingChildren.delete(key)
             preservingKeys.push(key)
+            exitingChildren.delete(key)
         }
     }
 
@@ -217,7 +214,6 @@ export const AnimatePresence: React.FunctionComponent<
 
             const onExit = () => {
                 allChildren.delete(key)
-                exiting.delete(key)
                 exitingChildren.delete(key)
 
                 // Remove this child from the present children
@@ -227,7 +223,7 @@ export const AnimatePresence: React.FunctionComponent<
                 presentChildren.current.splice(removeIndex, 1)
 
                 // Defer re-rendering until all exiting children have indeed left
-                if (!exiting.size) {
+                if (!exitingChildren.size) {
                     presentChildren.current = filteredChildren
 
                     if (isMounted.current === false) return

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -131,7 +131,6 @@ export const AnimatePresence: React.FunctionComponent<
     const filteredChildren = onlyElements(children)
     let childrenToRender = filteredChildren
 
-    // Keep a living record of the children we're actually rendering so we
     const exitingChildren = useRef(
         new Map<ComponentKey, ReactElement<any>>()
     ).current

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -269,25 +269,26 @@ export const AnimatePresence: React.FunctionComponent<
     // insert the chunk where the change occurred in the previous location.
     //
     // presentChildren  ->  children
-    //     [1]                 [A]
-    //     [A]                 [D]
-    //     [2]                 [E]
-    //     [B]                 [F]
-    //     [3]                 [B]
+    //     [A]                 [1]
+    //     [D]                 [A]
+    //     [E]                 [2]
+    //     [F]                 [B]
+    //     [B]                 [3]
     //     [C]                 [C]
     //
-    // init -> animate -> Exit Complete
+    //  init ->  animate -> Exit Complete
     //
-    // [1]        [1]                <--- presentChunk - 1
-    // [A]        [A]         [A]    <--- preservingKey
-    // [2]        [2]                <--- presentChunk - 2
-    //            [D]         [D]
-    //            [E]         [E]    <--- targetChunk - 1
-    //            [F]         [F]
-    // [B]        [B]         [B]    <--- preservingKey
-    // [3]        [3]                <--- presentChunk - 3
-    //                        [B]    <--- targetChunk - 2
-    // [C]        [C]         [C]    <--- preservingKey
+    //             [1]        [1]     <--- presentChunk - 1
+    //   [A]       [A]        [A]     <--- preservingKey
+    //             [2]        [2]     <--- presentChunk - 2
+    //   [D]       [D]
+    //   [E]       [E]                <--- targetChunk - 1
+    //   [F]       [F]
+    //   [B]       [B]        [B]     <--- preservingKey
+    //             [3]        [3]     <--- presentChunk - 3
+    //   [B]                          <--- targetChunk - 2
+    //   [C]       [C]        [C]     <--- preservingKey
+
     childrenToRender = []
     Array.from({ length: preservingKeys.length + 1 }).forEach((_, i) => {
         const key = preservingKeys[i]

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -105,7 +105,7 @@ export const AnimatePresence: React.FunctionComponent<
     const filteredChildren = onlyElements(children)
     let childrenToRender = filteredChildren
 
-    const exiting = new Set<ComponentKey>()
+    const exiting = useRef(new Set<ComponentKey>()).current
 
     // Keep a living record of the children we're actually rendering so we
     // can diff to figure out which are entering and exiting


### PR DESCRIPTION
## Description

`exiting` object is not enclosed for `useRef()` as shown below

```tsx
-   const exiting = new Set<ComponentKey>()
+   const exiting = useRef(new Set<ComponentKey>()).current
```

Because the object `exiting` is a new object each time it is re-rendered, the `onExit` event validates the `Defer re-rendering untill all exiting child have indented left` incorrectly.

```tsx
const onExit = () => {
    allChildren.delete(key)
    exiting.delete(key)

    // Remove this child from the present children
    const removeIndex = presentChildren.current.findIndex(
        (presentChild) => presentChild.key === key
    )
    presentChildren.current.splice(removeIndex, 1)

    // Defer re-rendering until all exiting children have indeed left
    if (!exiting.size) {
        presentChildren.current = filteredChildren

        if (isMounted.current === false) return

        forceRender()
        onExitComplete && onExitComplete()
    }
}
```

---

###### 2022-06-11 update

A bug occurred because the `onExit` function is newly defined each time when a fastly outgoing elements unmount instantly.

To solve this problem, solved it by memoizing `exitingChild`.

```tsx
// If the component was exiting, reuse the previous component to preserve state
let extingChild = exitingChildren.get(key)
if (extingChild) return extingChild

const onExit = () => {
    ...
}

extingChild = (
    <PresenceChild
        key={key}
        isPresent={false}
        onExitComplete={onExit}
        custom={custom}
        presenceAffectsLayout={presenceAffectsLayout}
    >
        {child}
    </PresenceChild>
)
exitingChildren.set(key, extingChild)
return extingChild
```

But when I solved this problem, I saw a different problem.

The rendering array will have a strange change position.

Generally, if a change is made from `["A", "D", "E", "F", "B", "C"]` to `["1", "A", "2", "B", "3", "C"]` during animation, 
it is expected to be `["1" ,"A" ,"D" ,"E" ,"F" ,"2" ,"B" ,"3" ,"C"]`

It does not work as intended and is output in the form `["1", "D", "E", "F", "A", "2", "B", "3", "C"]`.

```tsx
// unnatural position
const insertionIndex = presentKeys.indexOf(key)

const onExit = () => {
  ...
}

// If the current array is smaller than "insertionIndex", it will not be inserted in the intended location
childrenToRender.splice(
    insertionIndex,
    0,
    <PresenceChild
      ...
    </PresenceChild>
)
```

If a change occurs in the rendering array, insert the chunk where the change occurred in the previous location.

```
 presentChildren  ->  children
     [A]                 [1]
     [D]                 [A]
     [E]                 [2]
     [F]                 [B]
     [B]                 [3]
     [C]                 [C]

  init ->  animate -> Exit Complete

             [1]        [1]     <--- targetChunk - 1
   [A]       [A]        [A]     <--- preservingKey
   [D]       [D]
   [E]       [E]                <--- presentChunk - 1
   [F]       [F]
             [2]        [2]     <--- targetChunk - 2
   [B]       [B]        [B]     <--- preservingKey
             [3]        [3]     <--- targetChunk - 3
   [C]       [C]        [C]     <--- preservingKey
```

## Demo

<details>
<summary><h5>original</h5></summary>

https://user-images.githubusercontent.com/48559454/173114437-7111d473-8626-404e-b2a3-d0bb7ea10125.mov

</details>

##### fixed:

https://user-images.githubusercontent.com/48559454/173112041-f4996ce6-be01-4b11-989f-1fa74952a9e6.mov


<details>
<summary><h5>original</h5></summary>

https://user-images.githubusercontent.com/48559454/173114631-cab937ef-da5f-463a-954f-583d8097691c.mov

</details>

##### fixed:

https://user-images.githubusercontent.com/48559454/173112065-e8eafab0-90d7-4155-918a-c1d8082aed98.mov


- #907
original: https://codesandbox.io/s/animatepresence-quick-key-change-bug-zggbr?file=/src/HoverText.js
fixed: https://codesandbox.io/s/animatepresence-quick-key-change-bug-forked-od8snl?file=/package.json

- #1439
original: https://codesandbox.io/s/serene-poincare-q45cs?file=/src/Loader.js
fixed: https://codesandbox.io/s/silly-burnell-6ocfg4?file=/package.json

- #1534
original: https://codesandbox.io/s/adoring-rubin-hsxcfh?file=/src/App.ts
fixed: https://codesandbox.io/s/young-snowflake-5z3cem?file=/package.json


fixed: #907 
fixed: #1439
fixed: #1534