### PR TITLE
Fix rotation during layout projection

### DIFF
--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -661,13 +661,6 @@ export function createProjectionNode<I>({
             )
             roundBox(layout)
 
-            console.log(
-                "snapshot",
-                calcLength(measured.y),
-                calcLength(layout.y),
-                this.options.visualElement?.getInstance().style.transform
-            )
-
             this.snapshot = {
                 measured,
                 layout,
@@ -703,12 +696,6 @@ export function createProjectionNode<I>({
             }
 
             const measured = this.measure()
-
-            console.log(
-                "layout",
-                calcLength(measured.y),
-                this.options.visualElement?.getInstance().style.transform
-            )
 
             roundBox(measured)
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -661,6 +661,13 @@ export function createProjectionNode<I>({
             )
             roundBox(layout)
 
+            console.log(
+                "snapshot",
+                calcLength(measured.y),
+                calcLength(layout.y),
+                this.options.visualElement?.getInstance().style.transform
+            )
+
             this.snapshot = {
                 measured,
                 layout,
@@ -696,6 +703,13 @@ export function createProjectionNode<I>({
             }
 
             const measured = this.measure()
+
+            console.log(
+                "layout",
+                calcLength(measured.y),
+                this.options.visualElement?.getInstance().style.transform
+            )
+
             roundBox(measured)
 
             const prevLayout = this.layout

--- a/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
+++ b/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
@@ -28,5 +28,9 @@ describe("buildProjectionTransform", () => {
         expect(buildProjectionTransform(delta, { x: 2, y: 0.5 })).toEqual(
             "translate3d(50px, 600px, 0) scale(2, 4)"
         )
+
+        expect(
+            buildProjectionTransform(delta, { x: 2, y: 0.5 }, { rotate: 45 })
+        ).toEqual("translate3d(50px, 600px, 0) scale(2, 4) rotate(45deg)")
     })
 })

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -18,6 +18,12 @@ export function buildProjectionTransform(
     const yTranslate = delta.y.translate / treeScale.y
     let transform = `translate3d(${xTranslate}px, ${yTranslate}px, 0) `
 
+    /**
+     * Scale must come before rotate otherwise the scale correction will be rotated,
+     * compounding the distortion.
+     */
+    transform += `scale(${delta.x.scale}, ${delta.y.scale}) `
+
     if (latestTransform) {
         const { rotate, rotateX, rotateY } = latestTransform
         if (rotate) transform += `rotate(${rotate}deg) `
@@ -25,7 +31,5 @@ export function buildProjectionTransform(
         if (rotateY) transform += `rotateY(${rotateY}deg) `
     }
 
-    transform += `scale(${delta.x.scale}, ${delta.y.scale})`
-
-    return transform === identityProjection ? "none" : transform
+    return transform === identityProjection ? "none" : transform.trim()
 }

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -31,5 +31,7 @@ export function buildProjectionTransform(
         if (rotateY) transform += `rotateY(${rotateY}deg) `
     }
 
-    return transform === identityProjection ? "none" : transform.trim()
+    transform = transform.trim()
+
+    return transform === identityProjection ? "none" : transform
 }


### PR DESCRIPTION
Fixes https://github.com/framer/company/issues/24876

The order of scale and rotation was previously incorrect, meaning the applied scale correction would be applied on the rotated axis rather than the screen axis.