### PR TITLE
Missing parens in `useTransform` example

### DIFF
--- a/packages/framer-motion/src/value/use-transform.ts
+++ b/packages/framer-motion/src/value/use-transform.ts
@@ -99,7 +99,7 @@ export function useTransform<I, O>(
  * export const MyComponent = () => {
  *   const x = useMotionValue(0)
  *   const y = useMotionValue(0)
- *   const z = useTransform([x, y], [latestX, latestY] => latestX * latestY)
+ *   const z = useTransform([x, y], ([latestX, latestY]) => latestX * latestY)
  *
  *   return <motion.div style={{ x, y, z }} />
  * }


### PR DESCRIPTION
The arrow function is malformed here. Even though there is technically only one argument, the array destructuring requires parentheses.

<img width="885" alt="Screen Shot 2022-06-03 at 11 40 56 AM" src="https://user-images.githubusercontent.com/4009209/171896270-c916a787-e8d9-4ee7-8580-67d66cf806ce.png">

I also want to point out that this example doesn't play well with TypeScript and requires to either cast the arguments passed to the arrow function or use (undocumented?) generics with the `useTransform` function.

<img width="882" alt="Screen Shot 2022-06-03 at 11 45 06 AM" src="https://user-images.githubusercontent.com/4009209/171900006-e961fe25-e03b-49ac-9963-9e7be1bd4505.png">

<img width="766" alt="Screen Shot 2022-06-03 at 11 45 43 AM" src="https://user-images.githubusercontent.com/4009209/171900113-9f2bc94a-431f-4e11-ac4c-fef5f1e126dd.png">

Is this a type bug? The argument type is determined correctly when a single value is passed.

<img width="470" alt="Screen Shot 2022-06-03 at 11 44 30 AM" src="https://user-images.githubusercontent.com/4009209/171899837-78ba06b4-6cf9-412b-981b-584c13505918.png">

