### PR TITLE
Split scale correction and element resize scales

### DIFF
--- a/dev/projection/shared-promote-new-mix-rotate-scale-correction.html
+++ b/dev/projection/shared-promote-new-mix-rotate-scale-correction.html
@@ -1,0 +1,117 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #container-a {
+                position: relative;
+                width: 300px;
+                height: 300px;
+            }
+
+            #box-a {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #container-b {
+                position: relative;
+                width: 300px;
+                height: 600px;
+            }
+
+            #box-b {
+                position: absolute;
+                top: 100px;
+                left: 100px;
+                width: 200px;
+                height: 300px;
+                background-color: #09f;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="container-a"><div id="box-a"></div></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode } = window.Animate
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                matchBorderRadius,
+                matchRotate,
+            } = window.Assert
+
+            const container = document.getElementById("container-a")
+            const containerProjection = createNode(container, undefined, {
+                layoutId: "container",
+            })
+
+            const box = document.getElementById("box-a")
+            const boxProjection = createNode(box, containerProjection, {
+                layoutId: "box",
+            })
+
+            containerProjection.willUpdate()
+            boxProjection.willUpdate()
+
+            const newContainer = document.createElement("div")
+            newContainer.id = "container-b"
+            document.body.appendChild(newContainer)
+            const newContainerProjection = createNode(newContainer, undefined, {
+                layoutId: "container",
+            })
+
+            const newBox = document.createElement("div")
+            newBox.id = "box-b"
+            newContainer.appendChild(newBox)
+            const newBoxProjection = createNode(
+                newBox,
+                newContainerProjection,
+                { layoutId: "box" }
+            )
+
+            boxProjection.setValue("opacity", 0.8)
+            newBoxProjection.setValue("borderRadius", 20)
+            newBoxProjection.setValue("rotate", 40)
+
+            newBoxProjection.root.didUpdate()
+
+            sync.postRender(() => {
+                const bbox = newBox.getBoundingClientRect()
+                matchViewportBox(box, bbox)
+                matchVisibility(box, "visible")
+                matchVisibility(newBox, "visible")
+                matchOpacity(box, 0.8)
+                matchOpacity(newBox, 1)
+                matchRotate(box, 20)
+                matchRotate(newBox, 20)
+
+                matchBorderRadius(box, "6.66667% / 5%")
+                matchBorderRadius(newBox, "6.66667% / 5%")
+            })
+        </script>
+    </body>
+</html>

--- a/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
+++ b/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
@@ -22,15 +22,17 @@ describe("buildProjectionTransform", () => {
             },
         }
         expect(buildProjectionTransform(delta, { x: 1, y: 1 })).toEqual(
-            "translate3d(100px, 300px, 0) scale(2, 4)"
+            "translate3d(100px, 300px, 0) scale(1, 1) scale(2, 4)"
         )
 
         expect(buildProjectionTransform(delta, { x: 2, y: 0.5 })).toEqual(
-            "translate3d(50px, 600px, 0) scale(2, 4)"
+            "translate3d(50px, 600px, 0) scale(0.5, 2) scale(4, 2)"
         )
 
         expect(
             buildProjectionTransform(delta, { x: 2, y: 0.5 }, { rotate: 45 })
-        ).toEqual("translate3d(50px, 600px, 0) rotate(45deg) scale(2, 4)")
+        ).toEqual(
+            "translate3d(50px, 600px, 0) scale(0.5, 2) rotate(45deg) scale(4, 2)"
+        )
     })
 })

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -18,6 +18,11 @@ export function buildProjectionTransform(
     const yTranslate = delta.y.translate / treeScale.y
     let transform = `translate3d(${xTranslate}px, ${yTranslate}px, 0) `
 
+    /**
+     * Apply scale correction for the tree. This will apply scale to the screen-orientated axes.
+     */
+    transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y})`
+
     if (latestTransform) {
         const { rotate, rotateX, rotateY } = latestTransform
         if (rotate) transform += `rotate(${rotate}deg) `
@@ -25,7 +30,13 @@ export function buildProjectionTransform(
         if (rotateY) transform += `rotateY(${rotateY}deg) `
     }
 
-    transform += `scale(${delta.x.scale}, ${delta.y.scale})`
+    /**
+     * Apply scale to match the size of the element to the size we want it.
+     * This will apply scale to the element-orientated axes.
+     */
+    const elementScaleX = delta.x.scale * treeScale.x
+    const elementScaleY = delta.y.scale * treeScale.y
+    transform += `scale(${elementScaleX}, ${elementScaleY})`
 
     return transform === identityProjection ? "none" : transform
 }

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -1,7 +1,8 @@
 import { ResolvedValues } from "../../render/types"
 import { Delta, Point } from "../geometry/types"
 
-export const identityProjection = "translate3d(0px, 0px, 0) scale(1, 1)"
+export const identityProjection =
+    "translate3d(0px, 0px, 0) scale(1, 1) scale(1, 1)"
 
 export function buildProjectionTransform(
     delta: Delta,
@@ -19,9 +20,10 @@ export function buildProjectionTransform(
     let transform = `translate3d(${xTranslate}px, ${yTranslate}px, 0) `
 
     /**
-     * Apply scale correction for the tree. This will apply scale to the screen-orientated axes.
+     * Apply scale correction for the tree transform.
+     * This will apply scale to the screen-orientated axes.
      */
-    transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y})`
+    transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y}) `
 
     if (latestTransform) {
         const { rotate, rotateX, rotateY } = latestTransform


### PR DESCRIPTION
The last PR had a problem where it induced a skew to elements as the tree scale correction and element resize scales need to happen on pre and post rotated axes. This PR splits them out