### PR TITLE
Changes TSDoc tags for internal remarks to prevent the declaration to be considered internal

### DIFF
--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -67,7 +67,7 @@ export interface AnimationControls {
      * controls.set("hidden")
      * ```
      *
-     * @internalremarks
+     * @privateRemarks
      * We could perform a similar trick to `.start` where this can be called before mount
      * and we maintain a list of of pending actions that get applied on mount. But the
      * expectation of `set` is that it happens synchronously and this would be difficult

--- a/packages/framer-motion/src/gestures/use-pan-gesture.ts
+++ b/packages/framer-motion/src/gestures/use-pan-gesture.ts
@@ -10,7 +10,7 @@ import { FeatureProps } from "../motion/features/types"
  * @param handlers -
  * @param ref -
  *
- * @internalremarks
+ * @privateRemarks
  * Currently this sets new pan gesture functions every render. The memo route has been explored
  * in the past but ultimately we're still creating new functions every render. An optimisation
  * to explore is creating the pan gestures and loading them into a `ref`.

--- a/packages/framer-motion/src/motion/utils/valid-prop.ts
+++ b/packages/framer-motion/src/motion/utils/valid-prop.ts
@@ -3,7 +3,7 @@ import { MotionProps } from "../types"
 /**
  * A list of all valid MotionProps.
  *
- * @internalremarks
+ * @privateRemarks
  * This doesn't throw if a `MotionProp` name is missing - it should.
  */
 const validMotionProps = new Set<keyof MotionProps>([

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -158,7 +158,7 @@ export class MotionValue<V = any> {
      * }
      * ```
      *
-     * @internalremarks
+     * @privateRemarks
      *
      * We could look into a `useOnChange` hook if the above lifecycle management proves confusing.
      *


### PR DESCRIPTION
Using the [stripInternal](https://www.typescriptlang.org/tsconfig#stripInternal) to remove internal declarations means that declarations with the tag `@internal` will be removed, but this also means that if a tag starts with `internal` it will also be removed from the declarations. Therefore, when using the `@internalRemarks` tag in a declaration, it will be considered an internal declaration and will be removed.

To avoid this, I used the tag [@privateRemarks](https://tsdoc.org/pages/tags/privateremarks/) instead of `@internalRemarks`. This new tag doesn't prevent the remark from being published in the declaration, but with the previous tag(`@internalRemarks`), we weren't preventing it either.

Fixes https://github.com/framer/motion/issues/1589