### PR TITLE
Fix layout animations in position: fixed

### DIFF
--- a/dev/projection/single-element-page-scroll-overlay.html
+++ b/dev/projection/single-element-page-scroll-overlay.html
@@ -1,0 +1,68 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #overlay {
+                position: fixed;
+                inset: 0;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="overlay">
+            <div id="box"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const overlay = document.getElementById("overlay")
+            const overlayProjection = createNode(overlay, undefined, {
+                layoutScroll: "root",
+                layout: false,
+            })
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(box, overlayProjection)
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            const scrollOffset = [50, 100]
+            window.scrollTo(...scrollOffset)
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, { top: 0, left: 0, bottom: 100, right: 100 })
+        </script>
+    </body>
+</html>

--- a/dev/projection/single-element-page-scroll-overlay.html
+++ b/dev/projection/single-element-page-scroll-overlay.html
@@ -46,7 +46,7 @@
 
             const overlay = document.getElementById("overlay")
             const overlayProjection = createNode(overlay, undefined, {
-                layoutScroll: "root",
+                layoutScroll: true,
                 layout: false,
             })
 

--- a/packages/framer-motion/src/projection/node/DocumentProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/DocumentProjectionNode.ts
@@ -10,4 +10,5 @@ export const DocumentProjectionNode = createProjectionNode<Window>({
         x: document.documentElement.scrollLeft || document.body.scrollLeft,
         y: document.documentElement.scrollTop || document.body.scrollTop,
     }),
+    checkIsScrollRoot: () => true,
 })

--- a/packages/framer-motion/src/projection/node/HTMLProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/HTMLProjectionNode.ts
@@ -23,4 +23,6 @@ export const HTMLProjectionNode = createProjectionNode<HTMLElement>({
     resetTransform: (instance, value) => {
         instance.style.transform = value ?? "none"
     },
+    checkIsScrollRoot: (instance) =>
+        Boolean(window.getComputedStyle(instance).position === "fixed"),
 })

--- a/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
@@ -23,6 +23,7 @@ export const TestProjectionNode = createProjectionNode<TestInstance>({
         return rootNode
     },
     resetTransform: (instance) => instance.resetTransform?.(),
+    checkIsScrollRoot: () => false,
 })
 
 let id = 0

--- a/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
@@ -6,6 +6,7 @@ let rootNode: IProjectionNode
 
 export const TestRootNode = createProjectionNode<{}>({
     measureScroll: (_instance) => ({ x: 0, y: 0 }),
+    checkIsScrollRoot: () => true,
 })
 
 interface TestInstance {

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -50,6 +50,7 @@ export interface IProjectionNode<I = unknown> {
     targetDelta?: Delta
     targetWithTransforms?: Box
     scroll?: Point
+    isScrollRoot?: boolean
     treeScale?: Point
     projectionDelta?: Delta
     latestValues: ResolvedValues
@@ -141,6 +142,7 @@ export interface ProjectionNodeConfig<I> {
         notifyResize: VoidFunction
     ) => VoidFunction
     measureScroll: (instance: I) => Point
+    checkIsScrollRoot: (instance: I) => boolean
     resetTransform?: (instance: I, value?: string) => void
 }
 


### PR DESCRIPTION
As per https://github.com/framer/motion/issues/1535, layout animations break in `position: fixed` and `scroll` elements.

This PR makes it possible to tag `position: fixed` elements with the `layoutScroll` prop. Elements with the `layoutScroll` prop are now checked to see if they are also `position: fixed`. If so, all parent scrolls will be disregarded.

I haven't applied to `sticky` for now as more research is needed to see if we can determine when the element is in sticky mode vs inline.