### PR TITLE
Publish APIs that are used internally in Framer

### DIFF
--- a/packages/framer-motion-3d/src/utils/use-time.ts
+++ b/packages/framer-motion-3d/src/utils/use-time.ts
@@ -4,7 +4,7 @@ import { useContext } from "react"
 
 export function useTime() {
     const time = useMotionValue(0)
-    const isStatic = useContext(MotionConfigContext)["isStatic"] // Internal API
+    const { isStatic } = useContext(MotionConfigContext)
 
     !isStatic && useFrame((state) => time.set(state.clock.getElapsedTime()))
 

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -56,10 +56,8 @@ export interface AnimatePresenceProps {
     exitBeforeEnter?: boolean
 
     /**
-     * Used in Framer to flag that sibling children *shouldn't* re-render as a result of a
+     * Internal. Used in Framer to flag that sibling children *shouldn't* re-render as a result of a
      * child being removed.
-     *
-     * @internal
      */
     presenceAffectsLayout?: boolean
 }

--- a/packages/framer-motion/src/context/MotionConfigContext.tsx
+++ b/packages/framer-motion/src/context/MotionConfigContext.tsx
@@ -7,15 +7,13 @@ import { Transition } from "../types"
  */
 export interface MotionConfigContext {
     /**
-     * @internal
+     * Internal, exported only for usage in Framer
      */
     transformPagePoint: TransformPoint
 
     /**
-     * Determines whether this is a static context ie the Framer canvas. If so,
+     * Internal. Determines whether this is a static context ie the Framer canvas. If so,
      * it'll disable all dynamic functionality.
-     *
-     * @internal
      */
     isStatic: boolean
 

--- a/packages/framer-motion/src/context/SwitchLayoutGroupContext.ts
+++ b/packages/framer-motion/src/context/SwitchLayoutGroupContext.ts
@@ -23,7 +23,7 @@ export type InitialPromotionConfig = {
 }
 
 /**
- * @internal
+ * Internal, exported only for usage in Framer
  */
 export const SwitchLayoutGroupContext = createContext<SwitchLayoutGroupContext>(
     {}

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -319,6 +319,8 @@ export interface MotionProps
     ): string
 
     /**
+     * Internal.
+     *
      * This allows values to be transformed before being animated or set as styles.
      *
      * For instance, this allows custom values in Framer Library like `size` to be converted into `width` and `height`.
@@ -329,8 +331,6 @@ export interface MotionProps
      * - Extract `CustomValueType` as a separate user-defined type (delete `CustomValueType` and animate a `Color` - does this throw a type error?).
      *
      * @param values -
-     *
-     * @internal
      */
     transformValues?<V extends ResolvedValues>(values: V): V
 }


### PR DESCRIPTION
These are 5 things were marked as `@internal`, but are used in Framer.

I think it’s better to export these instead of the Framer application using internal types.