### PR TITLE
Fixing drag to reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Undocumented APIs should be considered internal and may change without warning.
 -   `react@18`
 -   `react-three-fiber@8`
 
+### Fixed
+
+-   Drag to reorder items no longer jumping in React 18.
+
 ## [6.5.2] 2022-07-27
 
 ### Fixed

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -61,6 +61,5 @@
         "@react-three/fiber": "^8.2.2",
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1"
-    },
-    "gitHead": "809942a0e5d65d5773fe483f4b96f548ee9ae69b"
+    }
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -97,6 +97,5 @@
             "path": "./dist/size-webpack-dom-max.js",
             "maxSize": "32.4 kB"
         }
-    ],
-    "gitHead": "809942a0e5d65d5773fe483f4b96f548ee9ae69b"
+    ]
 }

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -71,7 +71,9 @@ export function ReorderGroup<V>(
     }: Props<V> & HTMLMotionProps<any> & React.PropsWithChildren<{}>,
     externalRef?: React.Ref<any>
 ) {
-    const Component = useConstant(() => motion(as)) as FunctionComponent<React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>>
+    const Component = useConstant(() => motion(as)) as FunctionComponent<
+        React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
+    >
 
     const order: ItemData<V>[] = []
     const isReordering = useRef(false)

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -57,7 +57,9 @@ export function ReorderItem<V>(
     }: Props<V> & HTMLMotionProps<any> & React.PropsWithChildren<{}>,
     externalRef?: React.Ref<any>
 ) {
-    const Component = useConstant(() => motion(as)) as FunctionComponent<React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>>
+    const Component = useConstant(() => motion(as)) as FunctionComponent<
+        React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
+    >
 
     const context = useContext(ReorderContext)
     const point = {

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -562,27 +562,30 @@ export class VisualElementDragControls {
          * If the element's layout changes, calculate the delta and apply that to
          * the drag gesture's origin point.
          */
-        projection!.addEventListener("didUpdate", (({
-            delta,
-            hasLayoutChanged,
-        }: LayoutUpdateData) => {
-            if (this.isDragging && hasLayoutChanged) {
-                eachAxis((axis) => {
-                    const motionValue = this.getAxisMotionValue(axis)
-                    if (!motionValue) return
+        const stopLayoutUpdateListener = projection!.addEventListener(
+            "didUpdate",
+            (({ delta, hasLayoutChanged }: LayoutUpdateData) => {
+                if (this.isDragging && hasLayoutChanged) {
+                    eachAxis((axis) => {
+                        const motionValue = this.getAxisMotionValue(axis)
+                        if (!motionValue) return
 
-                    this.originPoint[axis] += delta[axis].translate
-                    motionValue.set(motionValue.get() + delta[axis].translate)
-                })
+                        this.originPoint[axis] += delta[axis].translate
+                        motionValue.set(
+                            motionValue.get() + delta[axis].translate
+                        )
+                    })
 
-                this.visualElement.syncRender()
-            }
-        }) as any)
+                    this.visualElement.syncRender()
+                }
+            }) as any
+        )
 
         return () => {
             stopResizeListener()
             stopPointerListener()
             stopMeasureLayoutListener()
+            stopLayoutUpdateListener?.()
         }
     }
 


### PR DESCRIPTION
Bundling this into the `7.0.0` release as e2e tests don't actually pass without this fix. The solution here was to ensure that if the didUpdate event listener was double-applied (as it is in StrictMode) then it unsubscribes correctly first.

Closes https://github.com/framer/motion/issues/1518