### PR TITLE
Replace placeholder with actual v7 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
-## [7.0.0] 2022-08-xx
+## [7.0.0] 2022-08-02
 
 ### Updated
 


### PR DESCRIPTION
Not sure if there is some thought behind having the placeholder, but I'm guessing it's not intended.