### PR TITLE
Fix exports map for TypeScript

### DIFF
--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -6,11 +6,9 @@
     "module": "dist/es/index.mjs",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "require": "./dist/cjs/index.js",
-            "import": {
-                "types": "./dist/index.d.ts",
-                "default": "./dist/es/index.mjs"
-            },
+            "import": "./dist/es/index.mjs",
             "default": "./dist/cjs/index.js"
         },
         "./package.json": "./package.json"

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -6,11 +6,9 @@
     "module": "dist/es/index.mjs",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "require": "./dist/cjs/index.js",
-            "import": {
-                "types": "./dist/index.d.ts",
-                "default": "./dist/es/index.mjs"
-            },
+            "import": "./dist/es/index.mjs",
             "default": "./dist/cjs/index.js"
         },
         "./package.json": "./package.json"


### PR DESCRIPTION
* Rewrite the `exports` map in `package.json` so that the `types` key is available for both `require` and `import`. Otherwise TypeScript will ignore the types when looking for CJS types.