### PR TITLE
Pop exiting elements from the document flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.2.0] 2022-08-14
+
+### Added
+
+-   `popLayout` option for `AnimatePresence` that "pops" exiting elements from the document layout flow, allowing sibling `layout` elements to animate to their new layout as soon as exiting starts.
+
 ## [7.1.2] 2022-08-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ### Deprecated
 
--   `exitBeforeEnter` - replace with `mode="deferEnter"`.
+-   `exitBeforeEnter` - replace with `mode="wait"`.
 
 ## [7.1.2] 2022-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ### Added
 
--   `popLayout` option for `AnimatePresence` that "pops" exiting elements from the document layout flow, allowing sibling `layout` elements to animate to their new layout as soon as exiting starts.
+-   `AnimatePresence`'s new `mode="popLayout"` prop will "pop" exiting elements from the document layout flow, allowing sibling `layout` elements to animate to their new layout as soon as exiting starts.
+
+### Deprecated
+
+-   `exitBeforeEnter` - replace with `mode="deferEnter"`.
 
 ## [7.1.2] 2022-08-16
 

--- a/dev/examples/AnimatePresence-notifications-list-pop.tsx
+++ b/dev/examples/AnimatePresence-notifications-list-pop.tsx
@@ -2,11 +2,6 @@ import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 
-/**
- * An example of pairing AnimatePresence with layout animations to create a notifications list
- * that correctly animate into their new positions as others are added/removed.
- */
-
 const Notification = React.forwardRef(function (
     { id, notifications, setNotifications, style },
     ref
@@ -40,7 +35,7 @@ export const App = () => {
     return (
         <div className="container">
             <ul>
-                <AnimatePresence pop initial={false}>
+                <AnimatePresence popLayout initial={false}>
                     {notifications.map((id) => (
                         <Notification
                             id={id}

--- a/dev/examples/AnimatePresence-notifications-list-pop.tsx
+++ b/dev/examples/AnimatePresence-notifications-list-pop.tsx
@@ -35,7 +35,7 @@ export const App = () => {
     return (
         <div className="container">
             <ul>
-                <AnimatePresence popLayout initial={false}>
+                <AnimatePresence mode="popLayout" initial={false}>
                     {notifications.map((id) => (
                         <Notification
                             id={id}

--- a/dev/examples/AnimatePresence-notifications-list-pop.tsx
+++ b/dev/examples/AnimatePresence-notifications-list-pop.tsx
@@ -1,0 +1,136 @@
+import * as React from "react"
+import { useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+
+/**
+ * An example of pairing AnimatePresence with layout animations to create a notifications list
+ * that correctly animate into their new positions as others are added/removed.
+ */
+
+const Notification = React.forwardRef(function (
+    { id, notifications, setNotifications, style },
+    ref
+) {
+    return (
+        <motion.li
+            id={id}
+            layout
+            drag="x"
+            ref={ref}
+            dragConstraints={{ left: 0, right: 0 }}
+            initial={{ opacity: 0, y: 50, scale: 0 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{
+                opacity: 0,
+                scale: 0.5,
+                transition: { duration: 0.2 },
+            }}
+            onDrag={(e, { offset }) => {
+                offset.x > 50 && setNotifications(remove(notifications, id))
+            }}
+            onClick={() => setNotifications(remove(notifications, id))}
+            style={style}
+        />
+    )
+})
+
+export const App = () => {
+    const [notifications, setNotifications] = useState([0])
+
+    return (
+        <div className="container">
+            <ul>
+                <AnimatePresence pop initial={false}>
+                    {notifications.map((id) => (
+                        <Notification
+                            id={id}
+                            key={id}
+                            notifications={notifications}
+                            setNotifications={setNotifications}
+                        />
+                    ))}
+                </AnimatePresence>
+            </ul>
+            <button onClick={() => setNotifications(add(notifications))}>
+                +
+            </button>
+            <style>{styles}</style>
+        </div>
+    )
+}
+
+const remove = (arr: number[], item: number) => {
+    const itemIndex = arr.findIndex((i) => i === item)
+
+    const newArr = [...arr]
+    newArr.splice(itemIndex, 1)
+    return newArr
+}
+
+let newIndex = 0
+const add = (arr: number[]) => {
+    newIndex++
+    return [...arr, newIndex]
+}
+
+const styles = `
+body {
+    width: 100vw;
+    height: 100vh;
+    background: linear-gradient(180deg, #ff008c 0%, rgb(211, 9, 225) 100%);
+    overflow: hidden;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  * {
+    box-sizing: border-box;
+  }
+  
+  .container {
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    flex-direction: column;
+  }
+
+  button {
+      position: fixed;
+      bottom: 10px;
+      left: 10px;
+      border-radius: 50%;
+      width: 50px;
+      height: 50px;
+      border: none;
+      background: white;
+      font-size: 48px;
+  }
+  
+  ul,
+  li {
+    padding: 0;
+    margin: 0;
+  }
+  
+  ul {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    top: 0;
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    justify-content: flex-end;
+  }
+  
+  li {
+    width: 300px;
+    background: white;
+    margin: 10px;
+    flex: 0 0 100px;
+    border-radius: 20px;
+  }
+  `

--- a/dev/tests/animate-presence-pop.tsx
+++ b/dev/tests/animate-presence-pop.tsx
@@ -1,0 +1,45 @@
+import { AnimatePresence, motion } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.section`
+    position: relative;
+    top: 100px;
+    left: 100px;
+
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+`
+
+export const App = () => {
+    const [state, setState] = useState(true)
+
+    return (
+        <Container onClick={() => setState(!state)}>
+            <AnimatePresence pop>
+                {state ? (
+                    <motion.div
+                        key="a"
+                        id="a"
+                        animate={{
+                            opacity: 1,
+                            transition: { duration: 0.001 },
+                        }}
+                        exit={{ opacity: 0, transition: { duration: 10 } }}
+                        layout
+                    />
+                ) : null}
+                <motion.div
+                    key="b"
+                    id="b"
+                    layout
+                    transition={{ ease: () => 1 }}
+                />
+            </AnimatePresence>
+        </Container>
+    )
+}

--- a/dev/tests/animate-presence-pop.tsx
+++ b/dev/tests/animate-presence-pop.tsx
@@ -5,8 +5,7 @@ import styled from "styled-components"
 
 const Container = styled.section`
     position: relative;
-    top: 100px;
-    left: 100px;
+    padding: 100px;
 
     div {
         width: 100px;
@@ -17,27 +16,40 @@ const Container = styled.section`
 
 export const App = () => {
     const [state, setState] = useState(true)
+    const params = new URLSearchParams(window.location.search)
+    const position = params.get("position") || ("static" as any)
+    const itemStyle =
+        position === "relative" ? { position, top: 100, left: 100 } : {}
 
     return (
         <Container onClick={() => setState(!state)}>
             <AnimatePresence popLayout>
+                <motion.div
+                    key="a"
+                    id="a"
+                    layout
+                    transition={{ ease: () => 1 }}
+                    style={{ ...itemStyle }}
+                />
                 {state ? (
                     <motion.div
-                        key="a"
-                        id="a"
+                        key="b"
+                        id="b"
                         animate={{
                             opacity: 1,
                             transition: { duration: 0.001 },
                         }}
                         exit={{ opacity: 0, transition: { duration: 10 } }}
                         layout
+                        style={{ ...itemStyle, backgroundColor: "green" }}
                     />
                 ) : null}
                 <motion.div
-                    key="b"
-                    id="b"
+                    key="c"
+                    id="c"
                     layout
                     transition={{ ease: () => 1 }}
+                    style={{ ...itemStyle, backgroundColor: "blue" }}
                 />
             </AnimatePresence>
         </Container>

--- a/dev/tests/animate-presence-pop.tsx
+++ b/dev/tests/animate-presence-pop.tsx
@@ -25,7 +25,7 @@ export const App = () => {
 
     return (
         <Container onClick={() => setState(!state)}>
-            <AnimatePresence popLayout>
+            <AnimatePresence mode="popLayout">
                 <motion.div
                     key="a"
                     id="a"

--- a/dev/tests/animate-presence-pop.tsx
+++ b/dev/tests/animate-presence-pop.tsx
@@ -20,7 +20,7 @@ export const App = () => {
 
     return (
         <Container onClick={() => setState(!state)}>
-            <AnimatePresence pop>
+            <AnimatePresence popLayout>
                 {state ? (
                     <motion.div
                         key="a"

--- a/dev/tests/animate-presence-pop.tsx
+++ b/dev/tests/animate-presence-pop.tsx
@@ -5,6 +5,8 @@ import styled from "styled-components"
 
 const Container = styled.section`
     position: relative;
+    display: flex;
+    flex-direction: column;
     padding: 100px;
 
     div {

--- a/dev/tests/drag-tabs.tsx
+++ b/dev/tests/drag-tabs.tsx
@@ -76,7 +76,7 @@ export function App() {
                     </LayoutGroup>
                 </nav>
                 <main>
-                    <AnimatePresence exitBeforeEnter initial={false}>
+                    <AnimatePresence mode="wait" initial={false}>
                         <motion.div
                             id={`${
                                 selectedTab ? selectedTab.label : "empty"

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
     "version": "7.1.2",
-    "packages": [
-        "packages/*"
-    ],
+    "packages": ["packages/*"],
     "npmClient": "yarn",
     "useWorkspaces": true
 }

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -47,8 +47,7 @@
     },
     "dependencies": {
         "framer-motion": "^7.1.2",
-        "react-merge-refs": "^2.0.1",
-        "tslib": "2.4.0"
+        "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {
         "@react-three/fiber": "^8.2.2",

--- a/packages/framer-motion/cypress/integration/animate-presence-pop.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-pop.ts
@@ -17,16 +17,36 @@ describe("AnimatePresence popLayout", () => {
     it("correctly pops exiting elements out of the DOM", () => {
         cy.visit("?test=animate-presence-pop")
             .wait(50)
-            .get("#a")
+            .get("#b")
             .should(([$a]: any) => {
                 expectBbox($a, {
-                    top: 100,
+                    top: 200,
                     left: 100,
                     width: 100,
                     height: 100,
                 })
             })
+            .get("#c")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 300,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .trigger("click", 60, 60, { force: true })
+            .wait(100)
             .get("#b")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 200,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .get("#c")
             .should(([$a]: any) => {
                 expectBbox($a, {
                     top: 200,
@@ -37,40 +57,83 @@ describe("AnimatePresence popLayout", () => {
             })
             .trigger("click", 60, 60, { force: true })
             .wait(100)
-            .get("#a")
+            .get("#b")
             .should(([$a]: any) => {
                 expectBbox($a, {
-                    top: 100,
+                    top: 200,
                     left: 100,
                     width: 100,
                     height: 100,
                 })
             })
+            .get("#c")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 300,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+    })
+
+    it("correctly pops exiting elements out of the DOM when they already have an explicit top/left", () => {
+        cy.visit("?test=animate-presence-pop&position=relative")
+            .wait(50)
             .get("#b")
             .should(([$a]: any) => {
                 expectBbox($a, {
-                    top: 100,
-                    left: 100,
+                    top: 300,
+                    left: 200,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .get("#c")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 400,
+                    left: 200,
                     width: 100,
                     height: 100,
                 })
             })
             .trigger("click", 60, 60, { force: true })
             .wait(100)
-            .get("#a")
+            .get("#b")
             .should(([$a]: any) => {
                 expectBbox($a, {
-                    top: 100,
-                    left: 100,
+                    top: 300,
+                    left: 200,
                     width: 100,
                     height: 100,
                 })
             })
+            .get("#c")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 300,
+                    left: 200,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .trigger("click", 60, 60, { force: true })
+            .wait(100)
             .get("#b")
             .should(([$a]: any) => {
                 expectBbox($a, {
-                    top: 200,
-                    left: 100,
+                    top: 300,
+                    left: 200,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .get("#c")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 400,
+                    left: 200,
                     width: 100,
                     height: 100,
                 })

--- a/packages/framer-motion/cypress/integration/animate-presence-pop.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-pop.ts
@@ -13,7 +13,7 @@ function expectBbox(element: HTMLElement, expectedBbox: Partial<BoundingBox>) {
     expectedBbox.height && expect(bbox.height).to.equal(expectedBbox.height)
 }
 
-describe("AnimatePresence pop", () => {
+describe("AnimatePresence popLayout", () => {
     it("correctly pops exiting elements out of the DOM", () => {
         cy.visit("?test=animate-presence-pop")
             .wait(50)

--- a/packages/framer-motion/cypress/integration/animate-presence-pop.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-pop.ts
@@ -1,0 +1,79 @@
+interface BoundingBox {
+    top: number
+    left: number
+    width: number
+    height: number
+}
+
+function expectBbox(element: HTMLElement, expectedBbox: Partial<BoundingBox>) {
+    const bbox = element.getBoundingClientRect()
+    expect(bbox.left).to.equal(expectedBbox.left)
+    expect(bbox.top).to.equal(expectedBbox.top)
+    expectedBbox.width && expect(bbox.width).to.equal(expectedBbox.width)
+    expectedBbox.height && expect(bbox.height).to.equal(expectedBbox.height)
+}
+
+describe("AnimatePresence pop", () => {
+    it("correctly pops exiting elements out of the DOM", () => {
+        cy.visit("?test=animate-presence-pop")
+            .wait(50)
+            .get("#a")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 100,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .get("#b")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 200,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .trigger("click", 60, 60, { force: true })
+            .wait(100)
+            .get("#a")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 100,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .get("#b")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 100,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .trigger("click", 60, 60, { force: true })
+            .wait(100)
+            .get("#a")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 100,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .get("#b")
+            .should(([$a]: any) => {
+                expectBbox($a, {
+                    top: 200,
+                    left: 100,
+                    width: 100,
+                    height: 100,
+                })
+            })
+    })
+})

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -16,6 +16,10 @@ interface MeasureProps extends Props {
     sizeRef: React.RefObject<Size>
 }
 
+/**
+ * Measurement functionality has to be within a separate component
+ * to leverage snapshot lifecycle.
+ */
 class PopChildMeasure extends React.Component<MeasureProps> {
     getSnapshotBeforeUpdate(prevProps: MeasureProps) {
         if (prevProps.isPresent && !this.props.isPresent) {
@@ -40,6 +44,15 @@ export function PopChild({ children, isPresent }: Props) {
     const ref = useRef<HTMLElement>(null)
     const size = useRef({ width: 0, height: 0 })
 
+    /**
+     * We create and inject a style block so we can apply this explicit
+     * sizing in a non-destructive manner by just deleting the style block.
+     *
+     * We can't apply the size via render as the measurement happens
+     * in getSnapshotBeforeUpdate (post-render), likewise if we apply the
+     * styles directly on the DOM node, we might be overwriting
+     * styles set via the style prop.
+     */
     useInsertionEffect(() => {
         const { width, height } = size.current
         if (isPresent || !ref.current || !width || !height) return

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -89,8 +89,7 @@ export function PopChild({ children, isPresent }: Props) {
 
         const style = document.createElement("style")
         document.head.appendChild(style)
-        style.appendChild(
-            document.createTextNode(`
+        style.sheet?.insertRule(`
           [data-motion-pop-id="${id}"] {
             position: absolute !important;
             width: ${width}px !important;
@@ -99,7 +98,6 @@ export function PopChild({ children, isPresent }: Props) {
             left: ${left} !important;
           }
         `)
-        )
 
         return () => {
             document.head.removeChild(style)

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -32,6 +32,9 @@ class PopChildMeasure extends React.Component<MeasureProps> {
         return null
     }
 
+    /**
+     * Required with getSnapshotBeforeUpdate to stop React complaining.
+     */
     componentDidUpdate() {}
 
     render() {
@@ -48,7 +51,7 @@ export function PopChild({ children, isPresent }: Props) {
      * We create and inject a style block so we can apply this explicit
      * sizing in a non-destructive manner by just deleting the style block.
      *
-     * We can't apply the size via render as the measurement happens
+     * We can't apply size via render as the measurement happens
      * in getSnapshotBeforeUpdate (post-render), likewise if we apply the
      * styles directly on the DOM node, we might be overwriting
      * styles set via the style prop.

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import { useRef, useInsertionEffect, useId } from "react"
+
+interface Size {
+    width: number
+    height: number
+}
+
+interface Props {
+    children: React.ReactElement
+    isPresent: boolean
+}
+
+interface MeasureProps extends Props {
+    childRef: React.RefObject<HTMLElement>
+    sizeRef: React.RefObject<Size>
+}
+
+class PopChildMeasure extends React.Component<MeasureProps> {
+    getSnapshotBeforeUpdate(prevProps: MeasureProps) {
+        if (prevProps.isPresent && !this.props.isPresent) {
+            const element = this.props.childRef.current
+            const size = this.props.sizeRef.current
+            size!.height = element?.offsetHeight || 0
+            size!.width = element?.offsetWidth || 0
+        }
+
+        return null
+    }
+
+    componentDidUpdate() {}
+
+    render() {
+        return this.props.children
+    }
+}
+
+export function PopChild({ children, isPresent }: Props) {
+    const id = useId()
+    const ref = useRef<HTMLElement>(null)
+    const size = useRef({ width: 0, height: 0 })
+
+    useInsertionEffect(() => {
+        const { width, height } = size.current
+        if (isPresent || !ref.current || !width || !height) return
+
+        ref.current.dataset.motionPopId = id
+
+        const style = document.createElement("style")
+        document.head.appendChild(style)
+        style.appendChild(
+            document.createTextNode(`
+          [data-motion-pop-id="${id}"] {
+            position: absolute !important;
+            width: ${width}px !important;
+            height: ${height}px !important;
+          }
+        `)
+        )
+
+        return () => {
+            document.head.removeChild(style)
+        }
+    }, [isPresent])
+
+    return (
+        <PopChildMeasure isPresent={isPresent} childRef={ref} sizeRef={size}>
+            {React.cloneElement(children, { ref })}
+        </PopChildMeasure>
+    )
+}

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -4,8 +4,8 @@ import { useRef, useInsertionEffect, useId } from "react"
 interface Size {
     width: number
     height: number
-    top: `${number}px` | "auto"
-    left: `${number}px` | "auto"
+    top: number
+    left: number
 }
 
 interface Props {
@@ -26,27 +26,11 @@ class PopChildMeasure extends React.Component<MeasureProps> {
     getSnapshotBeforeUpdate(prevProps: MeasureProps) {
         const element = this.props.childRef.current
         if (element && prevProps.isPresent && !this.props.isPresent) {
-            const { position } = getComputedStyle(element)
             const size = this.props.sizeRef.current!
             size.height = element.offsetHeight || 0
             size.width = element.offsetWidth || 0
-            size.top = size.left = "auto"
-
-            /**
-             * If this element is position: relative and the parent has
-             * padding, we need to explicitly set a top and/or left.
-             */
-            if (position === "relative" && element.offsetParent) {
-                const { paddingTop, paddingLeft } = getComputedStyle(
-                    element.offsetParent
-                )
-                if (parseFloat(paddingTop)) {
-                    size.top = `${element.offsetTop}px`
-                }
-                if (parseFloat(paddingLeft)) {
-                    size.left = `${element.offsetLeft}px`
-                }
-            }
+            size.top = element.offsetTop
+            size.left = element.offsetLeft
         }
 
         return null
@@ -68,8 +52,8 @@ export function PopChild({ children, isPresent }: Props) {
     const size = useRef<Size>({
         width: 0,
         height: 0,
-        top: "auto",
-        left: "auto",
+        top: 0,
+        left: 0,
     })
 
     /**
@@ -94,8 +78,8 @@ export function PopChild({ children, isPresent }: Props) {
             position: absolute !important;
             width: ${width}px !important;
             height: ${height}px !important;
-            top: ${top} !important;
-            left: ${left} !important;
+            top: ${top}px !important;
+            left: ${left}px !important;
           }
         `)
 

--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -6,14 +6,16 @@ import {
 } from "../../context/PresenceContext"
 import { VariantLabels } from "../../motion/types"
 import { useConstant } from "../../utils/use-constant"
+import { PopChild } from "./PopChild"
 
 interface PresenceChildProps {
-    children: React.ReactElement<any>
+    children: React.ReactElement
     isPresent: boolean
     onExitComplete?: () => void
     initial?: false | VariantLabels
     custom?: any
     presenceAffectsLayout: boolean
+    pop: boolean
 }
 
 export const PresenceChild = ({
@@ -23,6 +25,7 @@ export const PresenceChild = ({
     onExitComplete,
     custom,
     presenceAffectsLayout,
+    pop,
 }: PresenceChildProps) => {
     const presenceChildren = useConstant(newChildrenMap)
     const id = useId()
@@ -66,6 +69,10 @@ export const PresenceChild = ({
     React.useEffect(() => {
         !isPresent && !presenceChildren.size && onExitComplete?.()
     }, [isPresent])
+
+    if (pop) {
+        children = <PopChild isPresent={isPresent}>{children}</PopChild>
+    }
 
     return (
         <PresenceContext.Provider value={context}>

--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -15,7 +15,7 @@ interface PresenceChildProps {
     initial?: false | VariantLabels
     custom?: any
     presenceAffectsLayout: boolean
-    popLayout: boolean
+    mode: "sync" | "popLayout" | "wait"
 }
 
 export const PresenceChild = ({
@@ -25,7 +25,7 @@ export const PresenceChild = ({
     onExitComplete,
     custom,
     presenceAffectsLayout,
-    popLayout,
+    mode,
 }: PresenceChildProps) => {
     const presenceChildren = useConstant(newChildrenMap)
     const id = useId()
@@ -70,7 +70,7 @@ export const PresenceChild = ({
         !isPresent && !presenceChildren.size && onExitComplete?.()
     }, [isPresent])
 
-    if (popLayout) {
+    if (mode === "popLayout") {
         children = <PopChild isPresent={isPresent}>{children}</PopChild>
     }
 

--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -15,7 +15,7 @@ interface PresenceChildProps {
     initial?: false | VariantLabels
     custom?: any
     presenceAffectsLayout: boolean
-    pop: boolean
+    popLayout: boolean
 }
 
 export const PresenceChild = ({
@@ -25,7 +25,7 @@ export const PresenceChild = ({
     onExitComplete,
     custom,
     presenceAffectsLayout,
-    pop,
+    popLayout,
 }: PresenceChildProps) => {
     const presenceChildren = useConstant(newChildrenMap)
     const id = useId()
@@ -70,7 +70,7 @@ export const PresenceChild = ({
         !isPresent && !presenceChildren.size && onExitComplete?.()
     }, [isPresent])
 
-    if (pop) {
+    if (popLayout) {
         children = <PopChild isPresent={isPresent}>{children}</PopChild>
     }
 

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -317,11 +317,11 @@ describe("AnimatePresence", () => {
         return await expect(promise).resolves.toBe(3)
     })
 
-    test("Only renders one child at a time if exitBeforeEnter={true}", async () => {
+    test("Only renders one child at a time if mode === 'wait'", async () => {
         const promise = new Promise<number>((resolve) => {
             const Component = ({ i }: { i: number }) => {
                 return (
-                    <AnimatePresence exitBeforeEnter>
+                    <AnimatePresence mode="wait">
                         <motion.div
                             key={i}
                             animate={{ opacity: 1 }}
@@ -352,7 +352,7 @@ describe("AnimatePresence", () => {
         const promise = new Promise<HTMLElement>((resolve) => {
             const Component = ({ i }: { i: number }) => {
                 return (
-                    <AnimatePresence exitBeforeEnter>
+                    <AnimatePresence mode="wait">
                         <motion.div
                             key={i}
                             data-testid={i}

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -75,13 +75,16 @@ function onlyElements(children: ReactNode): ReactElement<any>[] {
  *
  * @public
  */
-export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<AnimatePresenceProps>> = ({
+export const AnimatePresence: React.FunctionComponent<
+    React.PropsWithChildren<AnimatePresenceProps>
+> = ({
     children,
     custom,
     initial = true,
     onExitComplete,
     exitBeforeEnter,
     presenceAffectsLayout = true,
+    pop = false,
 }) => {
     // We want to force a re-render once all exiting animations have finished. We
     // either use a local forceRender function, or one from a parent context if it exists.
@@ -132,6 +135,7 @@ export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<An
                         isPresent
                         initial={initial ? undefined : false}
                         presenceAffectsLayout={presenceAffectsLayout}
+                        pop={pop}
                     >
                         {child}
                     </PresenceChild>
@@ -205,6 +209,7 @@ export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<An
                 onExitComplete={onExit}
                 custom={custom}
                 presenceAffectsLayout={presenceAffectsLayout}
+                pop={pop}
             >
                 {child}
             </PresenceChild>
@@ -222,6 +227,7 @@ export const AnimatePresence: React.FunctionComponent<React.PropsWithChildren<An
                 key={getChildKey(child)}
                 isPresent
                 presenceAffectsLayout={presenceAffectsLayout}
+                pop={pop}
             >
                 {child}
             </PresenceChild>

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -84,7 +84,7 @@ export const AnimatePresence: React.FunctionComponent<
     onExitComplete,
     exitBeforeEnter,
     presenceAffectsLayout = true,
-    popLayout = false,
+    mode = "sync",
 }) => {
     // We want to force a re-render once all exiting animations have finished. We
     // either use a local forceRender function, or one from a parent context if it exists.
@@ -135,7 +135,7 @@ export const AnimatePresence: React.FunctionComponent<
                         isPresent
                         initial={initial ? undefined : false}
                         presenceAffectsLayout={presenceAffectsLayout}
-                        popLayout={popLayout}
+                        mode={mode}
                     >
                         {child}
                     </PresenceChild>
@@ -164,7 +164,7 @@ export const AnimatePresence: React.FunctionComponent<
 
     // If we currently have exiting children, and we're deferring rendering incoming children
     // until after all current children have exiting, empty the childrenToRender array
-    if (exitBeforeEnter && exiting.size) {
+    if (mode === "wait" && exiting.size) {
         childrenToRender = []
     }
 
@@ -209,7 +209,7 @@ export const AnimatePresence: React.FunctionComponent<
                 onExitComplete={onExit}
                 custom={custom}
                 presenceAffectsLayout={presenceAffectsLayout}
-                popLayout={popLayout}
+                mode={mode}
             >
                 {child}
             </PresenceChild>
@@ -227,7 +227,7 @@ export const AnimatePresence: React.FunctionComponent<
                 key={getChildKey(child)}
                 isPresent
                 presenceAffectsLayout={presenceAffectsLayout}
-                popLayout={popLayout}
+                mode={mode}
             >
                 {child}
             </PresenceChild>

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -84,7 +84,7 @@ export const AnimatePresence: React.FunctionComponent<
     onExitComplete,
     exitBeforeEnter,
     presenceAffectsLayout = true,
-    pop = false,
+    popLayout = false,
 }) => {
     // We want to force a re-render once all exiting animations have finished. We
     // either use a local forceRender function, or one from a parent context if it exists.
@@ -135,7 +135,7 @@ export const AnimatePresence: React.FunctionComponent<
                         isPresent
                         initial={initial ? undefined : false}
                         presenceAffectsLayout={presenceAffectsLayout}
-                        pop={pop}
+                        popLayout={popLayout}
                     >
                         {child}
                     </PresenceChild>
@@ -209,7 +209,7 @@ export const AnimatePresence: React.FunctionComponent<
                 onExitComplete={onExit}
                 custom={custom}
                 presenceAffectsLayout={presenceAffectsLayout}
-                pop={pop}
+                popLayout={popLayout}
             >
                 {child}
             </PresenceChild>
@@ -227,7 +227,7 @@ export const AnimatePresence: React.FunctionComponent<
                 key={getChildKey(child)}
                 isPresent
                 presenceAffectsLayout={presenceAffectsLayout}
-                pop={pop}
+                popLayout={popLayout}
             >
                 {child}
             </PresenceChild>

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -16,6 +16,7 @@ import { PresenceChild } from "./PresenceChild"
 import { LayoutGroupContext } from "../../context/LayoutGroupContext"
 import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
 import { useUnmountEffect } from "../../utils/use-unmount-effect"
+import { warnOnce } from "../../utils/warn-once"
 
 type ComponentKey = string | number
 
@@ -86,6 +87,12 @@ export const AnimatePresence: React.FunctionComponent<
     presenceAffectsLayout = true,
     mode = "sync",
 }) => {
+    // Support deprecated exitBeforeEnter prop
+    if (exitBeforeEnter) {
+        mode = "wait"
+        warnOnce(false, "Replace exitBeforeEnter with mode='wait'")
+    }
+
     // We want to force a re-render once all exiting animations have finished. We
     // either use a local forceRender function, or one from a parent context if it exists.
     let [forceRender] = useForceUpdate()
@@ -236,11 +243,11 @@ export const AnimatePresence: React.FunctionComponent<
 
     if (
         env !== "production" &&
-        exitBeforeEnter &&
+        mode === "wait" &&
         childrenToRender.length > 1
     ) {
         console.warn(
-            `You're attempting to animate multiple children within AnimatePresence, but its exitBeforeEnter prop is set to true. This will lead to odd visual behaviour.`
+            `You're attempting to animate multiple children within AnimatePresence, but its mode is set to "wait". This will lead to odd visual behaviour.`
         )
     }
 

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -53,7 +53,7 @@ export interface AnimatePresenceProps {
      *
      * @deprecated
      *
-     * Replace with `mode="popLayout"`
+     * Replace with `mode="wait"`
      */
     exitBeforeEnter?: boolean
 

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -61,7 +61,7 @@ export interface AnimatePresenceProps {
      *
      * @public
      */
-    pop?: boolean
+    popLayout?: boolean
 
     /**
      * Internal. Used in Framer to flag that sibling children *shouldn't* re-render as a result of a

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -51,9 +51,17 @@ export interface AnimatePresenceProps {
      * )
      * ```
      *
-     * @beta
+     * @public
      */
     exitBeforeEnter?: boolean
+
+    /**
+     * If set to `true`, top-level `exit` components will be "popped" out of the DOM layout,
+     * so surrounding elements can animate to their new layout immediately.
+     *
+     * @public
+     */
+    pop?: boolean
 
     /**
      * Internal. Used in Framer to flag that sibling children *shouldn't* re-render as a result of a

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -51,17 +51,24 @@ export interface AnimatePresenceProps {
      * )
      * ```
      *
-     * @public
+     * @deprecated
+     *
+     * Replace with `mode="popLayout"`
      */
     exitBeforeEnter?: boolean
 
     /**
-     * If set to `true`, top-level `exit` components will be "popped" out of the DOM layout,
-     * so surrounding elements can animate to their new layout immediately.
+     * Determines how to handle entering and exiting elements.
+     *
+     * - `"sync"`: Default. Elements animate in and out as soon as they're added/removed.
+     * - `"popLayout"`: Exiting elements are "popped" from the page layout, allowing sibling
+     *      elements to immediately occupy their new layouts.
+     * - `"wait"`: Only renders one component at a time. Wait for the exiting component to animate out
+     *      before animating the next component in.
      *
      * @public
      */
-    popLayout?: boolean
+    mode?: "sync" | "popLayout" | "wait"
 
     /**
      * Internal. Used in Framer to flag that sibling children *shouldn't* re-render as a result of a

--- a/yarn.lock
+++ b/yarn.lock
@@ -7993,7 +7993,6 @@ __metadata:
     "@rollup/plugin-commonjs": ^22.0.1
     framer-motion: ^7.1.2
     react-merge-refs: ^2.0.1
-    tslib: 2.4.0
   peerDependencies:
     "@react-three/fiber": ^8.2.2
     react: ">=18.0"


### PR DESCRIPTION
This PR adds a `mode` prop to `AnimatePresence`.

When `mode="popLayout"` is enabled, exiting elements will be "popped" from the layout. This allows surrounding `layout` elements to immediately animate into the space previously occupied by the exiting element, rather than waiting for it to animate out completely.

`exitBeforeEnter` becomes deprecated and replaced with `mode="wait"`

Fixes https://github.com/framer/motion/issues/296