### PR TITLE
`mSVG` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,12 +301,6 @@ Undocumented APIs should be considered internal and may change without warning.
 
 -   `layout="position"` now works with shared element transitions.
 
-## [7.2.1] 2022-08-23
-
-### Added
-
--   Various filesize reductions.
-
 ## [7.2.0] 2022-08-14
 
 ### Added

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -76,7 +76,7 @@
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "4.74 kB"
+            "maxSize": "3.8 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",

--- a/packages/framer-motion/rollup.config.js
+++ b/packages/framer-motion/rollup.config.js
@@ -115,7 +115,7 @@ const motion = Object.assign({}, es, {
         preserveModules: false,
         dir: undefined,
     }),
-    plugins: [...sizePlugins],
+    plugins: [...sizePlugins, visualizer()],
     external: ["react", "react-dom"],
 })
 
@@ -126,7 +126,7 @@ const m = Object.assign({}, es, {
         preserveModules: false,
         dir: undefined,
     }),
-    plugins: [...sizePlugins, visualizer()],
+    plugins: [...sizePlugins],
     external: ["react", "react-dom"],
 })
 

--- a/packages/framer-motion/rollup.config.js
+++ b/packages/framer-motion/rollup.config.js
@@ -120,19 +120,19 @@ const motion = Object.assign({}, es, {
 })
 
 const m = Object.assign({}, es, {
-    input: "lib/render/dom/motion-minimal.js",
+    input: "lib/components/m/html/index.js",
     output: Object.assign({}, es.output, {
         file: `dist/size-rollup-m.js`,
         preserveModules: false,
         dir: undefined,
     }),
-    plugins: [...sizePlugins],
+    plugins: [...sizePlugins, visualizer()],
     external: ["react", "react-dom"],
 })
 
 const domAnimation = Object.assign({}, es, {
     input: {
-        "size-rollup-dom-animation-m": "lib/render/dom/motion-minimal.js",
+        "size-rollup-dom-animation-m": "lib/components/m/html/index.js",
         "size-rollup-dom-animation": "lib/render/dom/features-animation.js",
     },
     output: {
@@ -143,13 +143,13 @@ const domAnimation = Object.assign({}, es, {
         chunkFileNames: "size-rollup-dom-animation-assets.js",
         dir: `dist`,
     },
-    plugins: [...sizePlugins, visualizer()],
+    plugins: [...sizePlugins],
     external: ["react", "react-dom"],
 })
 
 const domMax = Object.assign({}, es, {
     input: {
-        "size-rollup-dom-animation-m": "lib/render/dom/motion-minimal.js",
+        "size-rollup-dom-animation-m": "lib/components/m/html/index.js",
         "size-rollup-dom-max": "lib/render/dom/features-max.js",
     },
     output: {

--- a/packages/framer-motion/src/components/m/html/index.ts
+++ b/packages/framer-motion/src/components/m/html/index.ts
@@ -1,0 +1,8 @@
+import { createMotionProxy } from "../../../render/dom/motion-proxy"
+import { htmlMotionConfig } from "../../../render/html/config-motion"
+import { useHTMLProps } from "../../../render/html/use-props"
+import { createDomMotionConfig } from "../shared/create-config"
+
+export const m = createMotionProxy(
+    createDomMotionConfig(htmlMotionConfig, useHTMLProps) as any
+)

--- a/packages/framer-motion/src/components/m/shared/create-config.ts
+++ b/packages/framer-motion/src/components/m/shared/create-config.ts
@@ -1,0 +1,25 @@
+import { MotionComponentConfig } from "../../../motion"
+import { FeatureComponents } from "../../../motion/features/types"
+import { CustomMotionComponentConfig } from "../../../render/dom/motion-proxy"
+import { createUseRender, UseVisualProps } from "../../../render/dom/use-render"
+import { CreateVisualElement } from "../../../render/types"
+
+export function createDomMotionConfig<Instance, RenderState>(
+    baseConfig: Partial<MotionComponentConfig<Instance, RenderState>>,
+    useVisualProps: UseVisualProps
+) {
+    return <Props>(
+        Component: string | React.ComponentType<React.PropsWithChildren<Props>>,
+        { forwardMotionProps = false }: CustomMotionComponentConfig,
+        preloadedFeatures?: FeatureComponents,
+        createVisualElement?: CreateVisualElement<any>,
+        projectionNodeConstructor?: any
+    ) => ({
+        ...baseConfig,
+        preloadedFeatures,
+        useRender: createUseRender(forwardMotionProps, useVisualProps),
+        createVisualElement,
+        projectionNodeConstructor,
+        Component,
+    })
+}

--- a/packages/framer-motion/src/components/m/svg/index.ts
+++ b/packages/framer-motion/src/components/m/svg/index.ts
@@ -1,0 +1,8 @@
+import { createMotionProxy } from "../../../render/dom/motion-proxy"
+import { svgMotionConfig } from "../../../render/svg/config-motion"
+import { useSVGProps } from "../../../render/svg/use-props"
+import { createDomMotionConfig } from "../shared/create-config"
+
+export const mSVG = createMotionProxy(
+    createDomMotionConfig(svgMotionConfig, useSVGProps) as any
+)

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -2,7 +2,8 @@
  * Components
  */
 export { motion, createDomMotionComponent } from "./render/dom/motion"
-export { m } from "./render/dom/motion-minimal"
+export { m } from "./components/m/html"
+export { mSVG } from "./components/m/svg"
 export { AnimatePresence } from "./components/AnimatePresence"
 export { AnimateSharedLayout } from "./components/AnimateSharedLayout"
 export { MotionConfig } from "./components/MotionConfig"

--- a/packages/framer-motion/src/render/dom/motion-minimal.ts
+++ b/packages/framer-motion/src/render/dom/motion-minimal.ts
@@ -1,7 +1,0 @@
-import { createMotionProxy } from "./motion-proxy"
-import { createDomMotionConfig } from "./utils/create-config"
-
-/**
- * @public
- */
-export const m = createMotionProxy(createDomMotionConfig as any)

--- a/packages/framer-motion/src/render/dom/use-render.ts
+++ b/packages/framer-motion/src/render/dom/use-render.ts
@@ -1,27 +1,31 @@
 import { createElement } from "react"
-import { useHTMLProps } from "../html/use-props"
 import { filterProps } from "./utils/filter-props"
-import { isSVGComponent } from "./utils/is-svg-component"
-import { useSVGProps } from "../svg/use-props"
 import { RenderComponent } from "../../motion/features/types"
 import { HTMLRenderState } from "../html/types"
 import { SVGRenderState } from "../svg/types"
+import { MotionProps } from "../../motion/types"
+import { ResolvedValues } from "../types"
 
-export function createUseRender(forwardMotionProps = false) {
+export type UseVisualProps = (
+    props: MotionProps,
+    visualState: ResolvedValues,
+    isStatic: boolean
+) => any
+
+export type CreateUseRender = (
+    forwardMotionProps: boolean,
+    useVisualProps: UseVisualProps
+) => RenderComponent<HTMLElement | SVGElement, HTMLRenderState | SVGRenderState>
+
+export function createUseRender(
+    forwardMotionProps = false,
+    useVisualProps: UseVisualProps
+) {
     const useRender: RenderComponent<
         HTMLElement | SVGElement,
         HTMLRenderState | SVGRenderState
     > = (Component, props, projectionId, ref, { latestValues }, isStatic) => {
-        const useVisualProps = isSVGComponent(Component)
-            ? useSVGProps
-            : useHTMLProps
-
-        const visualProps = useVisualProps(
-            props,
-            latestValues,
-            isStatic,
-            Component
-        )
+        const visualProps = useVisualProps(props, latestValues, isStatic)
         const filteredProps = filterProps(
             props,
             typeof Component === "string",

--- a/packages/framer-motion/src/render/dom/utils/create-config.ts
+++ b/packages/framer-motion/src/render/dom/utils/create-config.ts
@@ -9,6 +9,8 @@ import { svgMotionConfig } from "../../svg/config-motion"
 import { htmlMotionConfig } from "../../html/config-motion"
 import { CreateVisualElement } from "../../types"
 import { CustomMotionComponentConfig } from "../motion-proxy"
+import { useSVGProps } from "../../svg/use-props"
+import { useHTMLProps } from "../../html/use-props"
 
 export function createDomMotionConfig<Props>(
     Component: string | React.ComponentType<React.PropsWithChildren<Props>>,
@@ -21,10 +23,14 @@ export function createDomMotionConfig<Props>(
         ? svgMotionConfig
         : htmlMotionConfig
 
+    const useVisualProps = isSVGComponent(Component)
+        ? useSVGProps
+        : useHTMLProps
+
     return {
         ...baseConfig,
         preloadedFeatures,
-        useRender: createUseRender(forwardMotionProps),
+        useRender: createUseRender(forwardMotionProps, useVisualProps),
         createVisualElement,
         projectionNodeConstructor,
         Component,

--- a/packages/framer-motion/webpack.size.config.js
+++ b/packages/framer-motion/webpack.size.config.js
@@ -1,7 +1,4 @@
-const tsconfig = require("./tsconfig.json")
 const path = require("path")
-const convertPathsToAliases =
-    require("convert-tsconfig-paths-to-webpack-aliases").default
 const TerserPlugin = require("terser-webpack-plugin")
 
 const tsLoader = {
@@ -14,7 +11,7 @@ module.exports = {
     entry: {
         "size-webpack-m": path.join(
             __dirname,
-            "./src/render/dom/motion-minimal.ts"
+            "./src/components/m/html/index.ts"
         ),
         "size-webpack-dom-animation": path.join(
             __dirname,


### PR DESCRIPTION
This PR splits SVG functionality out of the `m` component into its own `msvg` component, bringing the bundlesize of `m` down to 3.7kb.