### PR TITLE
Adding "preserve-ratio" layout setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.3.0] 2022-06-09
+
+### Added
+
+-   `layout="preserve-ratio"` performs a position-only transition if the aspect ratio has changed.
+
+### Fixed
+
+-   `layout="position"` now works with shared element transitions.
+
 ## [7.2.1] 2022-08-23
 
 ### Added

--- a/dev/tests/layout-shared-crossfade-a-ab.tsx
+++ b/dev/tests/layout-shared-crossfade-a-ab.tsx
@@ -9,6 +9,7 @@ const transition = {
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
+    const size = params.get("size") || false
     const [state, setState] = React.useState(false)
 
     return (
@@ -26,7 +27,7 @@ export const App = () => {
                     id="b"
                     layoutId="box"
                     layout={type}
-                    style={b}
+                    style={size ? aLarge : b}
                     transition={transition}
                     onClick={() => setState(!state)}
                 />
@@ -54,4 +55,12 @@ const b = {
     left: 200,
     width: 300,
     height: 300,
+}
+
+const aLarge = {
+    ...box,
+    top: 100,
+    left: 200,
+    width: 300,
+    height: 600,
 }

--- a/dev/tests/layout-shared-crossfade-a-ab.tsx
+++ b/dev/tests/layout-shared-crossfade-a-ab.tsx
@@ -25,6 +25,7 @@ export const App = () => {
                 <motion.div
                     id="b"
                     layoutId="box"
+                    layout={type}
                     style={b}
                     transition={transition}
                     onClick={() => setState(!state)}

--- a/packages/framer-motion/cypress/integration/layout-shared.ts
+++ b/packages/framer-motion/cypress/integration/layout-shared.ts
@@ -584,26 +584,78 @@ describe("Shared layout: A -> AB -> A crossfade transition", () => {
                     height: 300,
                 })
             })
-        // .trigger("click")
-        // .wait(50)
-        // .get("#a")
-        // .should(([$box]: any) => {
-        //     expectBbox($box, {
-        //         top: 50,
-        //         left: 100,
-        //         width: 100,
-        //         height: 200,
-        //     })
-        // })
-        // .get("#b")
-        // .should(([$box]: any) => {
-        //     expectBbox($box, {
-        //         top: 50,
-        //         left: 100,
-        //         width: 100,
-        //         height: 200,
-        //     })
-        // })
+    })
+
+    it(`It correctly animates layout="preserve-aspect" as "position" animations if aspect ratios are different`, () => {
+        cy.visit("?test=layout-shared-crossfade-a-ab&type=preserve-aspect")
+            .wait(50)
+            .get("#a")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 0,
+                    left: 0,
+                    width: 100,
+                    height: 200,
+                })
+            })
+            .trigger("click")
+            .wait(50)
+            .get("#a")
+            .should(([$box]: any) => {
+                expect(parseFloat($box.style.opacity) || 1).to.equal(1)
+                expectBbox($box, {
+                    top: 50,
+                    left: 100,
+                    width: 100,
+                    height: 200,
+                })
+            })
+            .get("#b")
+            .should(([$box]: any) => {
+                expect(parseFloat($box.style.opacity) || 1).to.equal(1)
+                expectBbox($box, {
+                    top: 50,
+                    left: 100,
+                    width: 300,
+                    height: 300,
+                })
+            })
+    })
+
+    it(`It correctly animates layout="preserve-aspect" as normal layout animations if both aspect ratios are the same`, () => {
+        cy.visit(
+            "?test=layout-shared-crossfade-a-ab&type=preserve-aspect&size=same"
+        )
+            .wait(50)
+            .get("#a")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 0,
+                    left: 0,
+                    width: 100,
+                    height: 200,
+                })
+            })
+            .trigger("click")
+            .wait(50)
+            .get("#a")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 50,
+                    left: 100,
+                    width: 200,
+                    height: 400,
+                })
+            })
+            .get("#b")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 50,
+                    left: 100,
+                    width: 200,
+                    height: 400,
+                })
+            })
     })
 
     it("Correctly fires layout={true} animations after an instant transition", () => {

--- a/packages/framer-motion/cypress/integration/layout-shared.ts
+++ b/packages/framer-motion/cypress/integration/layout-shared.ts
@@ -552,7 +552,7 @@ describe("Shared layout: A -> AB -> A crossfade transition", () => {
         // })
     })
 
-    it.skip(`It correctly fires layout="position" animations`, () => {
+    it(`It correctly fires layout="position" animations`, () => {
         cy.visit("?test=layout-shared-crossfade-a-ab&type=position")
             .wait(50)
             .get("#a")
@@ -571,26 +571,6 @@ describe("Shared layout: A -> AB -> A crossfade transition", () => {
                 expectBbox($box, {
                     top: 50,
                     left: 100,
-                    width: 300,
-                    height: 300,
-                })
-            })
-            .get("#b")
-            .should(([$box]: any) => {
-                expectBbox($box, {
-                    top: 50,
-                    left: 100,
-                    width: 300,
-                    height: 300,
-                })
-            })
-            .trigger("click")
-            .wait(50)
-            .get("#a")
-            .should(([$box]: any) => {
-                expectBbox($box, {
-                    top: 50,
-                    left: 100,
                     width: 100,
                     height: 200,
                 })
@@ -600,10 +580,30 @@ describe("Shared layout: A -> AB -> A crossfade transition", () => {
                 expectBbox($box, {
                     top: 50,
                     left: 100,
-                    width: 100,
-                    height: 200,
+                    width: 300,
+                    height: 300,
                 })
             })
+        // .trigger("click")
+        // .wait(50)
+        // .get("#a")
+        // .should(([$box]: any) => {
+        //     expectBbox($box, {
+        //         top: 50,
+        //         left: 100,
+        //         width: 100,
+        //         height: 200,
+        //     })
+        // })
+        // .get("#b")
+        // .should(([$box]: any) => {
+        //     expectBbox($box, {
+        //         top: 50,
+        //         left: 100,
+        //         width: 100,
+        //         height: 200,
+        //     })
+        // })
     })
 
     it("Correctly fires layout={true} animations after an instant transition", () => {

--- a/packages/framer-motion/src/motion/features/layout/types.ts
+++ b/packages/framer-motion/src/motion/features/layout/types.ts
@@ -26,9 +26,12 @@ export interface LayoutProps {
      * If `layout` is set to `"size"`, the position of the component will change instantly and
      * only its size will animate.
      *
+     * If `layout` is set to `"preserve-aspect"`, the component will animate size & position if
+     * the aspect ratio remains the same between renders, and just position if the ratio changes.
+     *
      * @public
      */
-    layout?: boolean | "position" | "size"
+    layout?: boolean | "position" | "size" | "preserve-aspect"
 
     /**
      * Enable shared layout transitions between different components with the same `layoutId`.

--- a/packages/framer-motion/src/projection/geometry/utils.ts
+++ b/packages/framer-motion/src/projection/geometry/utils.ts
@@ -1,3 +1,5 @@
+import { distance } from "popmotion"
+import { calcLength } from "./delta-calc"
 import { AxisDelta, Box, Delta } from "./types"
 
 function isAxisDeltaZero(delta: AxisDelta) {
@@ -15,4 +17,12 @@ export function boxEquals(a: Box, b: Box) {
         a.y.min === b.y.min &&
         a.y.max === b.y.max
     )
+}
+
+export function aspectRatio(box: Box): number {
+    return calcLength(box.x) / calcLength(box.y)
+}
+
+export function isCloseTo(a: number, b: number, max = 0.01) {
+    return distance(a, b) <= max
 }

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -21,7 +21,12 @@ import { createBox, createDelta } from "../geometry/models"
 import { transformBox, translateAxis } from "../geometry/delta-apply"
 import { Axis, AxisDelta, Box, Delta, Point } from "../geometry/types"
 import { getValueTransition } from "../../animation/utils/transitions"
-import { boxEquals, isDeltaZero } from "../geometry/utils"
+import {
+    aspectRatio,
+    boxEquals,
+    isCloseTo,
+    isDeltaZero,
+} from "../geometry/utils"
 import { NodeStack } from "../shared/stack"
 import { scaleCorrectors } from "../styles/scale-correction"
 import { buildProjectionTransform } from "../styles/transform"
@@ -1258,7 +1263,16 @@ export function createProjectionNode<I>({
              * then instead of projecting into the lead box we instead want to calculate
              * a new target that aligns the two boxes but maintains the layout shape.
              */
-            if (this.options.layout === "position" && this !== lead) {
+            if (
+                this !== lead &&
+                this.layout &&
+                layout &&
+                shouldAnimatePositionOnly(
+                    this.options.animationType,
+                    this.layout.actual,
+                    layout.actual
+                )
+            ) {
                 target = this.target || createBox()
 
                 const xLength = calcLength(this.layout!.actual.x)
@@ -1565,9 +1579,11 @@ function notifyLayoutUpdate(node: IProjectionNode) {
         node.hasListeners("didUpdate")
     ) {
         const { actual: layout, measured: measuredLayout } = node.layout
+        const { animationType } = node.options
+
         // TODO Maybe we want to also resize the layout snapshot so we don't trigger
         // animations for instance if layout="size" and an element has only changed position
-        if (node.options.animationType === "size") {
+        if (animationType === "size") {
             eachAxis((axis) => {
                 const axisSnapshot = snapshot.isShared
                     ? snapshot.measured[axis]
@@ -1576,7 +1592,9 @@ function notifyLayoutUpdate(node: IProjectionNode) {
                 axisSnapshot.min = layout[axis].min
                 axisSnapshot.max = axisSnapshot.min + length
             })
-        } else if (node.options.animationType === "position") {
+        } else if (
+            shouldAnimatePositionOnly(animationType, snapshot.layout, layout)
+        ) {
             eachAxis((axis) => {
                 const axisSnapshot = snapshot.isShared
                     ? snapshot.measured[axis]
@@ -1750,4 +1768,16 @@ function roundAxis(axis: Axis): void {
 function roundBox(box: Box): void {
     roundAxis(box.x)
     roundAxis(box.y)
+}
+
+function shouldAnimatePositionOnly(
+    animationType: string | undefined,
+    snapshot: Box,
+    layout: Box
+) {
+    return (
+        animationType === "position" ||
+        (animationType === "preserve-aspect" &&
+            !isCloseTo(aspectRatio(snapshot), aspectRatio(layout)))
+    )
 }

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -152,7 +152,7 @@ export interface ProjectionNodeOptions {
     alwaysMeasureLayout?: boolean
     scheduleRender?: VoidFunction
     onExitComplete?: VoidFunction
-    animationType?: "size" | "position" | "both"
+    animationType?: "size" | "position" | "both" | "preserve-aspect"
     layoutId?: string
     layout?: boolean | string
     visualElement?: VisualElement


### PR DESCRIPTION
This PR adds "preserve-ratio" as a `layout` setting. This option will animating both size and position when the aspect ratio matches, and position-only when it doesn't.

Thoughts on name? `prefer-ratio` ?