### PR TITLE
Add isMotionComponent and unwrapMotionComponent

### DIFF
--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -73,7 +73,11 @@ export {
     DragControls,
 } from "./gestures/drag/use-drag-controls"
 export { useDomEvent } from "./events/use-dom-event"
-export { createMotionComponent } from "./motion"
+export {
+    createMotionComponent,
+    isMotionComponent,
+    unwrapMotionComponent,
+} from "./motion"
 export { visualElement } from "./render"
 export { VisualElement } from "./render/types"
 export { addScaleCorrector } from "./projection/styles/scale-correction"

--- a/packages/framer-motion/src/motion/__tests__/motion-component.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/motion-component.test.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { isMotionComponent, motion, unwrapMotionComponent } from "../.."
+
+function CustomComp() {
+    return <div />
+}
+
+describe("isMotionComponent", () => {
+    it("returns true for motion components", () => {
+        expect(isMotionComponent(motion.div)).toBe(true)
+        expect(isMotionComponent(motion(CustomComp))).toBe(true)
+    })
+
+    it("returns false for other components", () => {
+        expect(isMotionComponent("div")).toBe(false)
+        expect(isMotionComponent(CustomComp)).toBe(false)
+    })
+})
+
+describe("unwrapMotionComponent", () => {
+    it("returns the wrapped component for motion components", () => {
+        expect(unwrapMotionComponent(motion.div)).toBe("div")
+        expect(unwrapMotionComponent(motion(CustomComp))).toBe(CustomComp)
+    })
+
+    it("returns undefined for other components", () => {
+        expect(unwrapMotionComponent("div")).toBe(undefined)
+        expect(unwrapMotionComponent(CustomComp)).toBe(undefined)
+    })
+})


### PR DESCRIPTION
This will add two new utility functions to framer-motion:

**1. isMotionComponent**

Checks if a React component is a motion component.

```jsx
isMotionComponent(motion.div) → true
isMotionComponent(motion(CustomComp)) → true
isMotionComponent("div") → false
isMotionComponent(CustomComp) → false
```

**2. unwrapMotionComponent**

Returns the wrapped component from a motion component or undefined if it's not a motion component.

```jsx
unwrapMotionComponent(motion.div) → "div"
unwrapMotionComponent(motion(CustomComp)) → CustomComp
unwrapMotionComponent("div") → undefined
unwrapMotionComponent(CustomComp) → undefined
```
