### PR TITLE
Cancel scheduled frame when unmounting useTransform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.5.1] 2022-09-30
+
+### Fixed
+
+-   `useTransform` correctly cleans up any scheduled animation frames when it unmounts.
+
 ## [7.5.0] 2022-09-27
 
 ### Added

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion--dev",
-    "version": "7.5.0",
+    "version": "7.5.1-beta.0",
     "private": true,
     "scripts": {
         "dev": "webpack serve --config ./webpack/config.js --hot"
@@ -8,8 +8,8 @@
     "dependencies": {
         "@react-three/drei": "^7.27.3",
         "@react-three/fiber": "^8.2.2",
-        "framer-motion": "^7.5.0",
-        "framer-motion-3d": "^7.5.0",
+        "framer-motion": "^7.5.1-beta.0",
+        "framer-motion-3d": "^7.5.1-beta.0",
         "path-browserify": "^1.0.1",
         "popmotion": "11.0.5",
         "react": "^18.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.5.0",
+    "version": "7.5.1-beta.0",
     "packages": [
         "packages/*"
     ],

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion-3d",
-    "version": "7.5.0",
+    "version": "7.5.1-beta.0",
     "description": "A simple and powerful React animation library for @react-three/fiber",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",
@@ -46,7 +46,7 @@
         "postpublish": "git push --tags"
     },
     "dependencies": {
-        "framer-motion": "^7.5.0",
+        "framer-motion": "^7.5.1-beta.0",
         "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -39,7 +39,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 src/value/__tests__/use-transform.test.tsx",
         "test-server": "jest --config jest.config.ssr.json",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-projection": "yarn run collect-projection-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/projection.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "7.5.0",
+    "version": "7.5.1-beta.0",
     "description": "A simple and powerful React animation library",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -39,7 +39,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 src/value/__tests__/use-transform.test.tsx",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-projection": "yarn run collect-projection-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/projection.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/src/value/__tests__/use-motion-template.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-motion-template.test.tsx
@@ -34,16 +34,17 @@ describe("useMotionTemplate", () => {
             return <motion.div style={{ transform }} />
         }
 
-        const { container } = render(<Component />)
+        const { container, rerender } = render(<Component />)
+        rerender(<Component />)
         const { firstChild } = container
 
         return new Promise<void>((resolve) => {
-            setTimeout(() => {
+            requestAnimationFrame(() => {
                 expect(firstChild).toHaveStyle(
                     `transform: translateX(10px) translateY(2px)`
                 )
                 resolve()
-            }, 50)
+            })
         })
     })
 

--- a/packages/framer-motion/src/value/use-combine-values.ts
+++ b/packages/framer-motion/src/value/use-combine-values.ts
@@ -1,7 +1,7 @@
 import { MotionValue } from "."
 import { useMotionValue } from "./use-motion-value"
 import { useMultiOnChange } from "./use-on-change"
-import sync from "framesync"
+import sync, { cancelSync } from "framesync"
 
 export function useCombineMotionValues<R>(
     values: MotionValue[],
@@ -30,7 +30,11 @@ export function useCombineMotionValues<R>(
      * Subscribe to all motion values found within the template. Whenever any of them change,
      * schedule an update.
      */
-    useMultiOnChange(values, () => sync.update(updateValue, false, true))
+    useMultiOnChange(
+        values,
+        () => sync.update(updateValue, false, true),
+        () => cancelSync.update(updateValue)
+    )
 
     return value
 }

--- a/packages/framer-motion/src/value/use-on-change.ts
+++ b/packages/framer-motion/src/value/use-on-change.ts
@@ -11,9 +11,17 @@ export function useOnChange<T>(
     }, [callback])
 }
 
-export function useMultiOnChange(values: MotionValue[], handler: () => void) {
+export function useMultiOnChange(
+    values: MotionValue[],
+    handler: () => void,
+    clean: () => void
+) {
     useIsomorphicLayoutEffect(() => {
         const subscriptions = values.map((value) => value.onChange(handler))
-        return () => subscriptions.forEach((unsubscribe) => unsubscribe())
+
+        return () => {
+            subscriptions.forEach((unsubscribe) => unsubscribe())
+            clean()
+        }
     })
 }

--- a/packages/framer-motion/src/value/use-on-change.ts
+++ b/packages/framer-motion/src/value/use-on-change.ts
@@ -14,14 +14,14 @@ export function useOnChange<T>(
 export function useMultiOnChange(
     values: MotionValue[],
     handler: () => void,
-    clean: () => void
+    cleanup: () => void
 ) {
     useIsomorphicLayoutEffect(() => {
         const subscriptions = values.map((value) => value.onChange(handler))
 
         return () => {
             subscriptions.forEach((unsubscribe) => unsubscribe())
-            clean()
+            cleanup()
         }
     })
 }

--- a/packages/framer-motion/src/value/use-transform.ts
+++ b/packages/framer-motion/src/value/use-transform.ts
@@ -129,8 +129,6 @@ export function useTransform<I, O>(
     outputRange?: O[],
     options?: TransformOptions<O>
 ): MotionValue<O> {
-    console.log("use transformer called")
-
     const transformer =
         typeof inputRangeOrTransformer === "function"
             ? inputRangeOrTransformer

--- a/packages/framer-motion/src/value/use-transform.ts
+++ b/packages/framer-motion/src/value/use-transform.ts
@@ -129,6 +129,8 @@ export function useTransform<I, O>(
     outputRange?: O[],
     options?: TransformOptions<O>
 ): MotionValue<O> {
+    console.log("use transformer called")
+
     const transformer =
         typeof inputRangeOrTransformer === "function"
             ? inputRangeOrTransformer

--- a/yarn.lock
+++ b/yarn.lock
@@ -7909,8 +7909,8 @@ __metadata:
     cache-loader: ^1.2.5
     convert-tsconfig-paths-to-webpack-aliases: ^0.9.2
     fork-ts-checker-webpack-plugin: ^6.2.0
-    framer-motion: ^7.5.0
-    framer-motion-3d: ^7.5.0
+    framer-motion: ^7.5.1-beta.0
+    framer-motion-3d: ^7.5.1-beta.0
     path-browserify: ^1.0.1
     popmotion: 11.0.5
     react: ^18.2.0
@@ -7977,14 +7977,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion-3d@^7.5.0, framer-motion-3d@workspace:packages/framer-motion-3d":
+"framer-motion-3d@^7.5.1-beta.0, framer-motion-3d@workspace:packages/framer-motion-3d":
   version: 0.0.0-use.local
   resolution: "framer-motion-3d@workspace:packages/framer-motion-3d"
   dependencies:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^7.5.0
+    framer-motion: ^7.5.1-beta.0
     react-merge-refs: ^2.0.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
@@ -7994,7 +7994,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^7.5.0, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^7.5.1-beta.0, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:


### PR DESCRIPTION
This PR ensures that when` useTransform`'s subscription effect is cleaned up it cancels any scheduled animation frame.

 I haven't been able to capture this in a test but have verified it fixes the corresponding bug in our Slideshow component.