### PR TITLE
Fix behaviour for values removed from `animate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.5.3] 2022-10-04
+
+### Fixed
+
+-   If the initial style was derived from the `initial` prop, and that style is removed from `animate`, while **also** being removed from `initial`, it won't animate back to the originally-defined value.
+
 ## [7.5.2] 2022-10-04
 
 ### Fixed

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -73,7 +73,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "29.25 kB"
+            "maxSize": "29.35 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -93,11 +93,11 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "19.1 kB"
+            "maxSize": "19.2 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "30.35kB"
+            "maxSize": "30.45kB"
         }
     ]
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -99,6 +99,5 @@
             "path": "./dist/size-webpack-dom-max.js",
             "maxSize": "30.35kB"
         }
-    ],
-    "gitHead": "602b4683150c9031861091ce7ba8ecf7d608ec89"
+    ]
 }

--- a/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "../../../jest.setup"
 import { motion, motionValue } from "../../"
 import * as React from "react"
+import { createRef } from "react"
 
 describe("animate prop as object", () => {
     test("animates to set prop", async () => {
@@ -263,6 +264,123 @@ describe("animate prop as object", () => {
         })
         return expect(promise).resolves.toHaveStyle("z-index: 100")
     })
+
+    test("when value is removed from animate, animates back to value originally defined in initial prop", async () => {
+        return new Promise<void>((resolve) => {
+            const ref = createRef()
+
+            const props: any = {
+                ref,
+                initial: { opacity: 0 },
+                animate: { opacity: 1 },
+                transition: { type: false },
+            }
+
+            const { rerender } = render(<motion.div {...props} />)
+
+            rerender(<motion.div {...props} />)
+
+            expect(ref.current).toHaveStyle("opacity: 1")
+
+            rerender(<motion.div {...props} animate={{}} />)
+            rerender(<motion.div {...props} animate={{}} />)
+
+            expect(ref.current).toHaveStyle("opacity: 0")
+
+            resolve()
+        })
+    })
+
+    test("when value is removed from animate, animates back to value currently defined in initial prop", async () => {
+        return new Promise<void>((resolve) => {
+            const ref = createRef()
+
+            const props: any = {
+                ref,
+                initial: { opacity: 0 },
+                animate: { opacity: 1 },
+                transition: { type: false },
+            }
+
+            const { rerender } = render(<motion.div {...props} />)
+
+            rerender(<motion.div {...props} />)
+
+            expect(ref.current).toHaveStyle("opacity: 1")
+
+            rerender(
+                <motion.div
+                    {...props}
+                    initial={{ opacity: 0.5 }}
+                    animate={{}}
+                />
+            )
+            rerender(
+                <motion.div
+                    {...props}
+                    initial={{ opacity: 0.5 }}
+                    animate={{}}
+                />
+            )
+
+            expect(ref.current).toHaveStyle("opacity: 0.5")
+
+            resolve()
+        })
+    })
+
+    test("when value is removed from both animate and initial, perform no animation", async () => {
+        return new Promise<void>((resolve) => {
+            const ref = createRef()
+
+            const props: any = {
+                ref,
+                initial: { opacity: 0 },
+                animate: { opacity: 1 },
+                transition: { type: false },
+            }
+
+            const { rerender } = render(<motion.div {...props} />)
+
+            rerender(<motion.div {...props} />)
+
+            expect(ref.current).toHaveStyle("opacity: 1")
+
+            rerender(<motion.div {...props} initial={{}} animate={{}} />)
+            rerender(<motion.div {...props} initial={{}} animate={{}} />)
+
+            expect(ref.current).toHaveStyle("opacity: 1")
+
+            resolve()
+        })
+    })
+
+    test("when value is removed from animate, animate back to value read from DOM", async () => {
+        return new Promise<void>((resolve) => {
+            const ref = createRef()
+
+            const props: any = {
+                ref,
+                style: { opacity: 0.5 },
+                animate: { opacity: 1 },
+                transition: { type: false },
+            }
+
+            const { rerender } = render(<motion.div {...props} />)
+
+            rerender(<motion.div {...props} />)
+
+            expect(ref.current).toHaveStyle("opacity: 1")
+
+            rerender(<motion.div {...props} animate={{}} />)
+            rerender(<motion.div {...props} animate={{}} />)
+
+            expect(ref.current).toHaveStyle("opacity: 0.5")
+
+            resolve()
+        })
+    })
+
     test("respects repeatDelay prop", async () => {
         const promise = new Promise<number>((resolve) => {
             const x = motionValue(0)

--- a/packages/framer-motion/src/render/index.ts
+++ b/packages/framer-motion/src/render/index.ts
@@ -103,7 +103,7 @@ export const visualElement =
         }
 
         /**
-         * Create an object of the values we initially from (if initial prop present).
+         * Create an object of the values we initially animated from (if initial prop present).
          */
         const initialValues = props.initial ? { ...latestValues } : {}
 

--- a/packages/framer-motion/src/render/index.ts
+++ b/packages/framer-motion/src/render/index.ts
@@ -102,6 +102,9 @@ export const visualElement =
             ...latestValues,
         }
 
+        /**
+         * Create an object of the values we initially from (if initial prop present).
+         */
         const initialValues = props.initial ? { ...latestValues } : {}
 
         // Internal methods ========================
@@ -573,10 +576,7 @@ export const visualElement =
                     if (target !== undefined && !isMotionValue(target))
                         return target
                 }
-                console.log(
-                    initialValues[key] !== undefined &&
-                        valueFromInitial === undefined
-                )
+
                 /**
                  * If the value was initially defined on initial, but it doesn't any more,
                  * return undefined. Otherwise return the value as initially read from the DOM.


### PR DESCRIPTION
This PR fixes the behaviour of animating values when removed from `animate`.

Previously, if a value was originally animated from `initial`:
- If the value was removed from `animate`, it would animate back to the **originally read value**.
- If the value was removed from both `initial` and `animate`, it would animate back to the **originally read value**.

Now, if a value is originally animated from `initial`:
- If the value is removed from `animate`, it animates to the **current value** in `initial`.
- If the value is removed from both `initial` and `animate`, it **doesn't animate**.