### PR TITLE
Adding frame-locked delay function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.6.0] 2022-10-17
+
+### Added
+
+-   `delay()`: An alternative to `window.setTimeout()` that is locked to the animation framerate.
+
 ## [7.5.4] 2022-10-17
 
 ### Fixed

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -82,6 +82,7 @@ export { addScaleCorrector } from "./projection/styles/scale-correction"
 export { useInstantTransition } from "./utils/use-instant-transition"
 export { useInstantLayoutTransition } from "./projection/use-instant-layout-transition"
 export { useResetProjection } from "./projection/use-reset-projection"
+export * from "./utils/delay"
 
 /**
  * Contexts

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -372,7 +372,7 @@ export function createProjectionNode<I>({
                     this.root.updateBlockedByResize = true
 
                     cancelDelay && cancelDelay()
-                    delay(resizeUnblockUpdate, 250)
+                    cancelDelay = delay(resizeUnblockUpdate, 250)
 
                     if (globalProjectionState.hasAnimatedSinceResize) {
                         globalProjectionState.hasAnimatedSinceResize = false

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -46,6 +46,7 @@ import { Transition } from "../../types"
 import { resolveMotionValue } from "../../value/utils/resolve-motion-value"
 import { MotionStyle } from "../../motion/types"
 import { globalProjectionState } from "./state"
+import { delay } from "../../utils/delay"
 
 const transformAxes = ["", "X", "Y", "Z"]
 
@@ -362,7 +363,7 @@ export function createProjectionNode<I>({
             }
 
             if (attachResizeListener) {
-                let unblockTimeout: number
+                let cancelDelay: VoidFunction
 
                 const resizeUnblockUpdate = () =>
                     (this.root.updateBlockedByResize = false)
@@ -370,8 +371,8 @@ export function createProjectionNode<I>({
                 attachResizeListener(instance, () => {
                     this.root.updateBlockedByResize = true
 
-                    clearTimeout(unblockTimeout)
-                    unblockTimeout = window.setTimeout(resizeUnblockUpdate, 250)
+                    cancelDelay && cancelDelay()
+                    delay(resizeUnblockUpdate, 250)
 
                     if (globalProjectionState.hasAnimatedSinceResize) {
                         globalProjectionState.hasAnimatedSinceResize = false

--- a/packages/framer-motion/src/utils/__tests__/delay.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/delay.test.ts
@@ -1,0 +1,39 @@
+import { delay } from "../delay"
+
+describe("delay", () => {
+    test("resolves after provided duration", async () => {
+        const startTime = performance.now()
+
+        return new Promise<void>((resolve) => {
+            delay(() => {
+                const elapsed = performance.now() - startTime
+                expect(elapsed > 50 && elapsed < 80).toBe(true)
+                resolve()
+            }, 50)
+        })
+    })
+
+    test("provides overshoot duration", async () => {
+        return new Promise<void>((resolve) => {
+            delay((overshoot) => {
+                expect(overshoot).toBeLessThan(20)
+                expect(overshoot).toBeGreaterThan(0)
+                resolve()
+            }, 50)
+        })
+    })
+
+    test("callback doesn't fire if cancelled", async () => {
+        const callback = jest.fn()
+
+        const cancelDelay = delay(callback, 10)
+
+        return new Promise<void>((resolve) => {
+            cancelDelay()
+            setTimeout(() => {
+                expect(callback).not.toBeCalled()
+                resolve()
+            }, 50)
+        })
+    })
+})

--- a/packages/framer-motion/src/utils/delay.ts
+++ b/packages/framer-motion/src/utils/delay.ts
@@ -1,0 +1,19 @@
+import sync, { cancelSync, FrameData } from "framesync"
+
+export type DelayedFunction = (overshoot: number) => void
+
+export function delay(callback: DelayedFunction, timeout: number) {
+    const start = performance.now()
+
+    const checkElapsed = ({ timestamp }: FrameData) => {
+        const elapsed = timestamp - start
+        if (elapsed >= timeout) {
+            cancelSync.read(checkElapsed)
+            callback(elapsed - timeout)
+        }
+    }
+
+    sync.read(checkElapsed, true)
+
+    return () => cancelSync.read(checkElapsed)
+}


### PR DESCRIPTION
This is a framerate-locked `delay` function that can avoid the use of `setTimeout`.