### PR TITLE
Fixing jumping boxes when switching relative projection parent

### DIFF
--- a/dev/projection/animate-relative-skip-parent.html
+++ b/dev/projection/animate-relative-skip-parent.html
@@ -1,0 +1,107 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                position: relative;
+                width: 200px;
+                height: 200px;
+                padding: 50px;
+                background-color: #00cc88;
+            }
+
+            #mid {
+                width: 100px;
+                height: 100px;
+                background-color: white;
+                display: flex;
+                align-items: flex-start;
+                justify-content: flex-start;
+                position: absolute;
+                top: 50px;
+                left: 50px;
+            }
+
+            #parent.b {
+                width: 500px;
+                height: 500px;
+            }
+
+            .b #mid {
+                justify-content: flex-end;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent">
+            <div id="mid"><div id="child"></div></div>
+        </div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            /**
+             * This file tests whether, if the middle box finishes its animation correctly,
+             * does the child correctly use the middle box instead of the parent box
+             * as its relative parent.
+             */
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const mid = document.getElementById("mid")
+            const child = document.getElementById("child")
+
+            const childOrigin = child.getBoundingClientRect()
+
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 2 } // { duration: 200, ease: relativeEase() }
+            )
+            const midProjection = createNode(
+                mid,
+                parentProjection,
+                {},
+                { duration: 2, delay: 1 } // { duration: 200, ease: relativeEase() }
+            )
+            const childProjection = createNode(
+                child,
+                midProjection,
+                {},
+                { duration: 2, delay: 1 } // { duration: 0 }
+            )
+
+            parentProjection.willUpdate()
+            midProjection.willUpdate()
+            childProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            // sync.postRender(() => {
+            //     sync.postRender(() => {
+            //         matchViewportBox(child, childOrigin)
+            //     })
+            // })
+        </script>
+    </body>
+</html>

--- a/dev/projection/animate-relative-skip-parent.html
+++ b/dev/projection/animate-relative-skip-parent.html
@@ -73,20 +73,20 @@
             const parentProjection = createNode(
                 parent,
                 undefined,
-                {},
-                { duration: 2 } // { duration: 200, ease: relativeEase() }
+                { layoutScroll: true },
+                { duration: 0.01 }
             )
             const midProjection = createNode(
                 mid,
                 parentProjection,
                 {},
-                { duration: 2, delay: 1 } // { duration: 200, ease: relativeEase() }
+                { duration: 0.01, delay: 0 }
             )
             const childProjection = createNode(
                 child,
                 midProjection,
                 {},
-                { duration: 2, delay: 1 } // { duration: 0 }
+                { duration: 10, delay: 0.1 } // { duration: 0 }
             )
 
             parentProjection.willUpdate()
@@ -97,11 +97,17 @@
 
             parentProjection.root.didUpdate()
 
-            // sync.postRender(() => {
-            //     sync.postRender(() => {
-            //         matchViewportBox(child, childOrigin)
-            //     })
-            // })
+            setTimeout(() => {
+                parentProjection.willUpdate()
+                midProjection.willUpdate()
+                childProjection.willUpdate()
+                parent.classList.remove("b")
+                parentProjection.root.didUpdate()
+
+                sync.postRender(() => {
+                    matchViewportBox(child, childOrigin, 0.5)
+                })
+            }, 150)
         </script>
     </body>
 </html>

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -433,6 +433,10 @@ export function createProjectionNode<I>({
                         const hasOnlyRelativeTargetChanged =
                             !hasLayoutChanged && hasRelativeTargetChanged
 
+                        if (visualElement.getInstance().id === "mid") {
+                            console.log(hasLayoutChanged, targetChanged)
+                        }
+
                         if (
                             this.resumeFrom?.instance ||
                             hasOnlyRelativeTargetChanged ||
@@ -474,6 +478,7 @@ export function createProjectionNode<I>({
                                 !hasLayoutChanged &&
                                 this.animationProgress === 0
                             ) {
+                                console.log("finishing animation")
                                 finishAnimation(this)
                             }
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -433,10 +433,6 @@ export function createProjectionNode<I>({
                         const hasOnlyRelativeTargetChanged =
                             !hasLayoutChanged && hasRelativeTargetChanged
 
-                        if (visualElement.getInstance().id === "mid") {
-                            console.log(hasLayoutChanged, targetChanged)
-                        }
-
                         if (
                             this.resumeFrom?.instance ||
                             hasOnlyRelativeTargetChanged ||
@@ -478,7 +474,6 @@ export function createProjectionNode<I>({
                                 !hasLayoutChanged &&
                                 this.animationProgress === 0
                             ) {
-                                console.log("finishing animation")
                                 finishAnimation(this)
                             }
 
@@ -973,7 +968,6 @@ export function createProjectionNode<I>({
             /**
              * If we've been told to attempt to resolve a relative target, do so.
              */
-
             if (this.attemptToResolveRelativeTarget) {
                 this.attemptToResolveRelativeTarget = false
                 this.relativeParent = this.getClosestProjectingParent()

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -905,16 +905,19 @@ export function createProjectionNode<I>({
             // TODO If this is unsuccessful this currently happens every frame
             if (!this.targetDelta && !this.relativeTarget) {
                 // TODO: This is a semi-repetition of further down this function, make DRY
-                this.relativeParent = this.getClosestProjectingParent()
-                if (this.relativeParent && this.relativeParent.layout) {
+                const relativeParent = this.getClosestProjectingParent()
+                if (relativeParent && relativeParent.layout) {
+                    this.relativeParent = relativeParent
                     this.relativeTarget = createBox()
                     this.relativeTargetOrigin = createBox()
                     calcRelativePosition(
                         this.relativeTargetOrigin,
                         this.layout.actual,
-                        this.relativeParent.layout.actual
+                        relativeParent.layout.actual
                     )
                     copyBoxInto(this.relativeTarget, this.relativeTargetOrigin)
+                } else {
+                    this.relativeParent = this.relativeTarget = undefined
                 }
             }
 
@@ -970,24 +973,27 @@ export function createProjectionNode<I>({
              */
             if (this.attemptToResolveRelativeTarget) {
                 this.attemptToResolveRelativeTarget = false
-                this.relativeParent = this.getClosestProjectingParent()
+                const relativeParent = this.getClosestProjectingParent()
 
                 if (
-                    this.relativeParent &&
-                    Boolean(this.relativeParent.resumingFrom) ===
+                    relativeParent &&
+                    Boolean(relativeParent.resumingFrom) ===
                         Boolean(this.resumingFrom) &&
-                    !this.relativeParent.options.layoutScroll &&
-                    this.relativeParent.target
+                    !relativeParent.options.layoutScroll &&
+                    relativeParent.target
                 ) {
+                    this.relativeParent = relativeParent
                     this.relativeTarget = createBox()
                     this.relativeTargetOrigin = createBox()
 
                     calcRelativePosition(
                         this.relativeTargetOrigin,
                         this.target,
-                        this.relativeParent.target
+                        relativeParent.target
                     )
                     copyBoxInto(this.relativeTarget, this.relativeTargetOrigin)
+                } else {
+                    this.relativeParent = this.relativeTarget = undefined
                 }
             }
         }
@@ -1626,15 +1632,15 @@ function notifyLayoutUpdate(node: IProjectionNode) {
         let hasRelativeTargetChanged = false
 
         if (!node.resumeFrom) {
-            node.relativeParent = node.getClosestProjectingParent()
+            const relativeParent = node.getClosestProjectingParent()
 
             /**
              * If the relativeParent is itself resuming from a different element then
              * the relative snapshot is not relavent
              */
-            if (node.relativeParent && !node.relativeParent.resumeFrom) {
+            if (relativeParent && !relativeParent.resumeFrom) {
                 const { snapshot: parentSnapshot, layout: parentLayout } =
-                    node.relativeParent
+                    relativeParent
 
                 if (parentSnapshot && parentLayout) {
                     const relativeSnapshot = createBox()


### PR DESCRIPTION
There was code that could potentially reassign a relative projection parent without cleaning up outdated relative projection targets.

Contributes towards https://github.com/framer/company/issues/26070