### PR TITLE
Tests for `position: sticky` layout animations

### DIFF
--- a/dev/projection/collect-projection-tests.js
+++ b/dev/projection/collect-projection-tests.js
@@ -3,7 +3,7 @@ const path = require("path")
 
 const files = fs
     .readdirSync(__dirname)
-    .filter((f) => path.extname(f) === ".html")
+    .filter((f) => path.extname(f) === ".html" && !f.includes(".skip."))
 
 fs.writeFile(
     "../../packages/framer-motion/cypress/fixtures/projection-tests.json",

--- a/dev/projection/sticky-child-scroll-change-offset.skip.html
+++ b/dev/projection/sticky-child-scroll-change-offset.skip.html
@@ -1,0 +1,88 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #size {
+                height: 100px;
+            }
+
+            #overlay {
+                background-color: black;
+                position: sticky;
+                top: 0px;
+                height: 200px;
+                width: 200px;
+            }
+
+            #overlay.b #box {
+                position: relative;
+                left: 300px;
+                top: 300px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="size"></div>
+        <div id="overlay">
+            <div id="box"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const overlay = document.getElementById("overlay")
+            const overlayProjection = createNode(overlay, undefined, {
+                layoutScroll: true,
+            })
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(
+                box,
+                overlayProjection
+                // undefined,
+                // { duration: 2 }
+            )
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            overlay.classList.add("b")
+
+            const scrollOffset = [50, 150]
+            window.scrollTo(...scrollOffset)
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, { top: 0, left: -50, bottom: 100, right: 50 })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-child-scroll-change.skip.html
+++ b/dev/projection/sticky-child-scroll-change.skip.html
@@ -1,0 +1,86 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #size {
+                height: 100px;
+            }
+
+            #overlay {
+                background-color: black;
+                position: sticky;
+                top: 0px;
+                height: 200px;
+                width: 200px;
+            }
+
+            #overlay.b #box {
+                position: relative;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="size"></div>
+        <div id="overlay">
+            <div id="box"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const overlay = document.getElementById("overlay")
+            const overlayProjection = createNode(overlay, undefined, {
+                layoutScroll: true,
+            })
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(
+                box,
+                overlayProjection
+                // undefined,
+                // { duration: 2 }
+            )
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            overlay.classList.add("b")
+
+            const scrollOffset = [50, 150]
+            window.scrollTo(...scrollOffset)
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, { top: 0, left: -50, bottom: 100, right: 50 })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-child.html
+++ b/dev/projection/sticky-child.html
@@ -1,0 +1,86 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #size {
+                height: 100px;
+            }
+
+            #overlay {
+                background-color: black;
+                position: sticky;
+                top: 0px;
+                height: 200px;
+                width: 200px;
+            }
+
+            #overlay.b #box {
+                position: relative;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="size"></div>
+        <div id="overlay">
+            <div id="box"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const overlay = document.getElementById("overlay")
+            const overlayProjection = createNode(overlay, undefined, {
+                layoutScroll: true,
+            })
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(
+                box,
+                overlayProjection
+                // undefined,
+                // { duration: 2 }
+            )
+
+            const scrollOffset = [50, 150]
+            window.scrollTo(...scrollOffset)
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            overlay.classList.add("b")
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, { top: 0, left: -50, bottom: 100, right: 50 })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-element-scroll-child.skip.html
+++ b/dev/projection/sticky-element-scroll-child.skip.html
@@ -1,0 +1,109 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            #scroller {
+                width: 200px;
+                height: 200px;
+                overflow: scroll;
+                margin-left: 100px;
+            }
+
+            #sticky {
+                position: sticky;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 50px;
+                background: #0088ff;
+                display: flex;
+                justify-content: flex-start;
+            }
+
+            #sticky.b {
+                justify-content: flex-end;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background: #00cc88;
+            }
+
+            #content {
+                width: 100%;
+                height: 400px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div id="scroller">
+            <div id="sticky">
+                <div id="child"></div>
+            </div>
+            <div id="content"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const scroller = document.getElementById("scroller")
+            const scrollerProjection = createNode(scroller, undefined, {
+                layoutScroll: true,
+            })
+
+            const sticky = document.getElementById("sticky")
+            const stickyProjection = createNode(sticky, scrollerProjection)
+
+            const child = document.getElementById("child")
+            const childProjection = createNode(child, stickyProjection)
+
+            const childOrigin = child.getBoundingClientRect()
+
+            stickyProjection.willUpdate()
+            childProjection.willUpdate()
+
+            scroller.scrollTo(0, 100)
+            sticky.classList.add("b")
+
+            stickyProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(child, childOrigin)
+            }, 50)
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-element-scroll-shared-child.html
+++ b/dev/projection/sticky-element-scroll-shared-child.html
@@ -1,0 +1,114 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            #scroller {
+                width: 200px;
+                height: 200px;
+                overflow: scroll;
+                margin-left: 100px;
+            }
+
+            #sticky {
+                position: sticky;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 50px;
+                background: #0088ff;
+                display: flex;
+                justify-content: space-between;
+            }
+
+            .child {
+                width: 50px;
+                height: 50px;
+                background: #00cc88;
+            }
+
+            #content {
+                width: 100%;
+                height: 400px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div id="scroller">
+            <div id="sticky">
+                <div class="child"></div>
+            </div>
+            <div id="content"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const scroller = document.getElementById("scroller")
+            const scrollerProjection = createNode(scroller, undefined, {
+                layoutScroll: true,
+            })
+
+            const sticky = document.getElementById("sticky")
+            const stickyProjection = createNode(sticky, scrollerProjection)
+
+            const child = document.querySelector(".child")
+            const childProjection = createNode(child, stickyProjection, {
+                layoutId: "child",
+            })
+
+            const childOrigin = child.getBoundingClientRect()
+
+            stickyProjection.willUpdate()
+            childProjection.willUpdate()
+
+            const newChild = document.createElement("div")
+            newChild.classList.add("child")
+            sticky.appendChild(newChild)
+            const newChildProjection = createNode(newChild, stickyProjection, {
+                layoutId: "child",
+            })
+
+            scroller.scrollTo(0, 100)
+
+            stickyProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(child, childOrigin)
+                matchViewportBox(newChild, childOrigin)
+            }, 50)
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-element-scroll.skip.html
+++ b/dev/projection/sticky-element-scroll.skip.html
@@ -1,0 +1,100 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            #scroller {
+                width: 200px;
+                height: 200px;
+                overflow: scroll;
+                margin-left: 100px;
+            }
+
+            #sticky {
+                position: sticky;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 50px;
+                background: #0088ff;
+                display: flex;
+                align-items: flex-start;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background: #00cc88;
+            }
+
+            #content {
+                width: 100%;
+                height: 400px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div id="scroller">
+            <div id="sticky">
+                <div id="child"></div>
+            </div>
+            <div id="content"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const scroller = document.getElementById("scroller")
+            const scrollerProjection = createNode(scroller, undefined, {
+                layoutScroll: true,
+            })
+
+            const sticky = document.getElementById("sticky")
+            const stickyProjection = createNode(sticky, scrollerProjection)
+
+            const stickyOrigin = sticky.getBoundingClientRect()
+
+            stickyProjection.willUpdate()
+
+            scroller.scrollTo(0, 100)
+
+            stickyProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(sticky, stickyOrigin)
+            }, 50)
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-scroll-change-no-stick.html
+++ b/dev/projection/sticky-scroll-change-no-stick.html
@@ -1,0 +1,69 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+                position: sticky;
+                top: 0px;
+            }
+
+            #size {
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="size"></div>
+        <div id="box"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(box, undefined, {
+                layoutScroll: true,
+            })
+
+            requestAnimationFrame(() => {
+                boxProjection.willUpdate()
+
+                const scrollOffset = [50, 50]
+                window.scrollTo(...scrollOffset)
+
+                boxProjection.root.didUpdate()
+
+                matchViewportBox(box, {
+                    top: 50,
+                    left: -50,
+                    bottom: 150,
+                    right: 50,
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-scroll-change-with-stick.html
+++ b/dev/projection/sticky-scroll-change-with-stick.html
@@ -1,0 +1,69 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+                position: sticky;
+                top: 0px;
+            }
+
+            #size {
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="size"></div>
+        <div id="box"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(box, undefined, {
+                layoutScroll: true,
+            })
+
+            requestAnimationFrame(() => {
+                boxProjection.willUpdate()
+
+                const scrollOffset = [50, 150]
+                window.scrollTo(...scrollOffset)
+
+                boxProjection.root.didUpdate()
+
+                matchViewportBox(box, {
+                    top: 0,
+                    left: -50,
+                    bottom: 100,
+                    right: 50,
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-scroll-no-layout-change-stick.skip.html
+++ b/dev/projection/sticky-scroll-no-layout-change-stick.skip.html
@@ -1,0 +1,73 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #overlay {
+                position: sticky;
+                top: 0px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="overlay">
+            <div id="box"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const overlay = document.getElementById("overlay")
+            const overlayProjection = createNode(overlay, undefined, {
+                layoutScroll: true,
+                layout: false,
+            })
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(
+                box,
+                overlayProjection
+                // undefined,
+                // { duration: 2 }
+            )
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            const scrollOffset = [50, 100]
+            window.scrollTo(...scrollOffset)
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, { top: 0, left: -50, bottom: 100, right: 50 })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-scroll-no-layout-change.html
+++ b/dev/projection/sticky-scroll-no-layout-change.html
@@ -1,0 +1,84 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #position {
+                height: 300px;
+            }
+
+            #overlay {
+                position: sticky;
+                top: 0px;
+                left: 0px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div id="overlay">
+            <div id="box"></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+
+            const overlay = document.getElementById("overlay")
+            const overlayProjection = createNode(overlay, undefined, {
+                layoutScroll: true,
+                layout: false,
+            })
+
+            const box = document.getElementById("box")
+            const boxProjection = createNode(
+                box,
+                overlayProjection
+                // undefined,
+                // { duration: 1 }
+            )
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            const scrollOffset = [50, 100]
+            window.scrollTo(...scrollOffset)
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, {
+                top: 200,
+                left: -50,
+                bottom: 300,
+                right: 50,
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-shared-to-fixed-page-scroll-no-stick.html
+++ b/dev/projection/sticky-shared-to-fixed-page-scroll-no-stick.html
@@ -1,0 +1,89 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            .sticky {
+                position: sticky;
+                top: 100px;
+                width: 100%;
+                height: 200px;
+                background: #0088ff;
+            }
+
+            .fixed {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 300px;
+                height: 300px;
+                background: #0088ff;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div class="sticky"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const sticky = document.querySelector(".sticky")
+            const stickyProjection = createNode(sticky, undefined, {
+                layoutId: "sticky",
+            })
+
+            const stickyOrigin = sticky.getBoundingClientRect()
+
+            stickyProjection.willUpdate()
+
+            const scrollOffset = [50, 50]
+            window.scrollTo(...scrollOffset)
+
+            const fixed = document.createElement("div")
+            fixed.classList.add("fixed")
+            document.body.appendChild(fixed)
+            const fixedProjection = createNode(fixed, undefined, {
+                layoutId: "sticky",
+            })
+
+            fixedProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(sticky, addPageScroll(stickyOrigin, 50, 50))
+                matchViewportBox(fixed, addPageScroll(stickyOrigin, 50, 50))
+            }, 50)
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-shared-to-fixed-page-scroll-stick.html
+++ b/dev/projection/sticky-shared-to-fixed-page-scroll-stick.html
@@ -1,0 +1,89 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            .sticky {
+                position: sticky;
+                top: 100px;
+                width: 100%;
+                height: 200px;
+                background: #0088ff;
+            }
+
+            .fixed {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 300px;
+                height: 300px;
+                background: #0088ff;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div class="sticky"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const sticky = document.querySelector(".sticky")
+            const stickyProjection = createNode(sticky, undefined, {
+                layoutId: "sticky",
+            })
+
+            const stickyOrigin = sticky.getBoundingClientRect()
+
+            stickyProjection.willUpdate()
+
+            const scrollOffset = [50, 300]
+            window.scrollTo(...scrollOffset)
+
+            const fixed = document.createElement("div")
+            fixed.classList.add("fixed")
+            document.body.appendChild(fixed)
+            const fixedProjection = createNode(fixed, undefined, {
+                layoutId: "sticky",
+            })
+
+            fixedProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(sticky, addPageScroll(stickyOrigin, 50, 300))
+                matchViewportBox(fixed, addPageScroll(stickyOrigin, 50, 300))
+            }, 50)
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-to-fixed-page-scroll.skip.html
+++ b/dev/projection/sticky-to-fixed-page-scroll.skip.html
@@ -1,0 +1,80 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            .sticky {
+                position: sticky;
+                top: 100px;
+                width: 100%;
+                height: 200px;
+                background: #0088ff;
+            }
+
+            .sticky.b {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 300px;
+                height: 300px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div class="sticky"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const sticky = document.querySelector(".sticky")
+            const stickyProjection = createNode(sticky, undefined)
+
+            stickyProjection.willUpdate()
+
+            const scrollOffset = [50, 150]
+            window.scrollTo(...scrollOffset)
+
+            const stickyOrigin = sticky.getBoundingClientRect()
+
+            sticky.classList.add("b")
+
+            stickyProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(sticky, stickyOrigin)
+            }, 50)
+        </script>
+    </body>
+</html>

--- a/dev/projection/sticky-to-fixed.html
+++ b/dev/projection/sticky-to-fixed.html
@@ -1,0 +1,77 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #position {
+                width: 1px;
+                height: 200px;
+            }
+
+            .sticky {
+                position: sticky;
+                top: 100px;
+                width: 100%;
+                height: 200px;
+                background: #0088ff;
+            }
+
+            .sticky.b {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 300px;
+                height: 300px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="position"></div>
+        <div class="sticky"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const {
+                matchViewportBox,
+                matchVisibility,
+                matchOpacity,
+                addPageScroll,
+            } = window.Assert
+
+            const sticky = document.querySelector(".sticky")
+            const stickyProjection = createNode(sticky, undefined)
+
+            const stickyOrigin = sticky.getBoundingClientRect()
+
+            stickyProjection.willUpdate()
+
+            sticky.classList.add("b")
+
+            stickyProjection.root.didUpdate()
+
+            setTimeout(() => {
+                matchViewportBox(sticky, stickyOrigin)
+            }, 50)
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Failing tests are currently skipped via `.skip`