### PR TITLE
Adding `frameTimestamp` to measurements

### DIFF
--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1,4 +1,4 @@
-import sync, { cancelSync, flushSync, Process } from "framesync"
+import sync, { cancelSync, flushSync, getFrameData, Process } from "framesync"
 import { mix } from "popmotion"
 import {
     animate,
@@ -54,6 +54,11 @@ const transformAxes = ["", "X", "Y", "Z"]
  * which has a noticeable difference in spring animations
  */
 const animationTarget = 1000
+
+/**
+ * A mutable state containing the latest animation frame timestamp.
+ */
+const frameData = getFrameData()
 
 let id = 0
 
@@ -754,6 +759,7 @@ export function createProjectionNode<I>({
             roundBox(layoutBox)
 
             return {
+                frameTimestamp: frameData.timestamp,
                 measuredBox: pageBox,
                 layoutBox,
                 latestValues: {},

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -9,6 +9,7 @@ import { MotionStyle } from "../../motion/types"
 import type { VisualElement } from "../../render/VisualElement"
 
 export interface Measurements {
+    frameTimestamp: number
     measuredBox: Box
     layoutBox: Box
     latestValues: ResolvedValues


### PR DESCRIPTION
This PR adds a `frameTimestamp` field to `Measurements`.

This will enable us to more reliably avoid double measurements within a given animation frame and more reliably understand the freshness of data when attempting to resolve relative bounding boxes.