### PR TITLE
Making `resetRotation` 2x faster when no rotations applied

### DIFF
--- a/dev/examples/layout-stress.tsx
+++ b/dev/examples/layout-stress.tsx
@@ -1,0 +1,385 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    &.expanded {
+        --width: 500px;
+        --height: 500px;
+        --offset: 100px;
+    }
+
+    .a {
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        width: var(--width);
+        height: var(--height);
+        display: flex;
+    }
+
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: var(--offset);
+        height: var(--offset);
+    }
+
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: var(--offset);
+        height: var(--offset);
+    }
+
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+`
+
+function Group({ children }: React.PropsWithChildren) {
+    return (
+        <motion.div layout className="a">
+            <motion.div layout className="b"></motion.div>
+            <motion.div layout className="c"></motion.div>
+            <motion.div layout className="d">
+                {children}
+            </motion.div>
+            <motion.div layout className="e"></motion.div>
+            <motion.div layout className="f">
+                <motion.div layout className="g"></motion.div>
+                <motion.div layout className="h">
+                    <motion.div layout className="i"></motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -773,7 +773,7 @@ export function createProjectionNode<I>({
 
             const box = visualElement.measureViewportBox()
 
-            // // Remove viewport scroll to give page-relative coordinates
+            // Remove viewport scroll to give page-relative coordinates
             const { scroll } = this.root
             if (scroll) {
                 translateAxis(box.x, scroll.x)

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1438,8 +1438,7 @@ export function createProjectionNode<I>({
 
             // Check the rotate value of all axes and reset to 0
             for (let i = 0; i < transformAxes.length; i++) {
-                const axis = transformAxes[i]
-                const key = "rotate" + axis
+                const key = "rotate" + transformAxes[i]
 
                 // Record the rotation and then temporarily set it to 0
                 resetValues[key] = latestValues[key]

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1442,7 +1442,7 @@ export function createProjectionNode<I>({
                 const key = "rotate" + axis
 
                 // Record the rotation and then temporarily set it to 0
-                resetValues[key] = visualElement.getStaticValue(key)
+                resetValues[key] = latestValues[key]
                 visualElement.setStaticValue(key, 0)
             }
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1441,7 +1441,7 @@ export function createProjectionNode<I>({
                 const key = "rotate" + transformAxes[i]
 
                 // Record the rotation and then temporarily set it to 0
-                if (latestValues[key] !== undefined) {
+                if (latestValues[key]) {
                     resetValues[key] = latestValues[key]
                     visualElement.setStaticValue(key, 0)
                 }

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1441,8 +1441,10 @@ export function createProjectionNode<I>({
                 const key = "rotate" + transformAxes[i]
 
                 // Record the rotation and then temporarily set it to 0
-                resetValues[key] = latestValues[key]
-                visualElement.setStaticValue(key, 0)
+                if (latestValues[key] !== undefined) {
+                    resetValues[key] = latestValues[key]
+                    visualElement.setStaticValue(key, 0)
+                }
             }
 
             // Force a render of this element to apply the transform with all rotations


### PR DESCRIPTION
Before a layout animation we check the tree for any rotations and suspend them so we can get an accurate read from `getBoundingClientRect`. It's not ideal as it introduces an extra (batched) DOM write, but otherwise the bounding box is unsalvageable. 

99% of the time there will be no rotations. By unrolling the initial check we speed this function up to 2x.