### PR TITLE
Remove unused transforms to improve framerate up to 20%

### DIFF
--- a/dev/examples/layout-stress-translate.tsx
+++ b/dev/examples/layout-stress-translate.tsx
@@ -1,0 +1,383 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    &.expanded {
+        --offset: 100px;
+    }
+
+    .a {
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        width: var(--width);
+        height: var(--height);
+        display: flex;
+    }
+
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+    }
+
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+    }
+
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+`
+
+function Group({ children }: React.PropsWithChildren) {
+    return (
+        <motion.div layout className="a">
+            <motion.div layout className="b"></motion.div>
+            <motion.div layout className="c"></motion.div>
+            <motion.div layout className="d">
+                {children}
+            </motion.div>
+            <motion.div layout className="e"></motion.div>
+            <motion.div layout className="f">
+                <motion.div layout className="g"></motion.div>
+                <motion.div layout className="h">
+                    <motion.div layout className="i"></motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
+++ b/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
@@ -36,6 +36,27 @@ describe("buildProjectionTransform", () => {
         ).toEqual(
             "translate3d(50px, 600px, 0) scale(0.5, 2) rotate(45deg) scale(4, 2)"
         )
+
+        expect(
+            buildProjectionTransform(
+                {
+                    x: {
+                        translate: 100,
+                        scale: 0.5,
+                        origin: 0.5,
+                        originPoint: 100,
+                    },
+                    y: {
+                        translate: 300,
+                        scale: 0.5,
+                        origin: 0.5,
+                        originPoint: 100,
+                    },
+                },
+                { x: 2, y: 2 },
+                { rotate: 90 }
+            )
+        ).toEqual("translate3d(50px, 150px, 0) scale(0.5, 0.5) rotate(90deg) ")
     })
 
     it("Doesn't apply unneccessary translation", () => {

--- a/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
+++ b/packages/framer-motion/src/projection/styles/__tests__/transform.test.ts
@@ -2,11 +2,13 @@ import { buildProjectionTransform } from "../transform"
 import { createDelta } from "../../geometry/models"
 
 describe("buildProjectionTransform", () => {
-    it("Creates the expected transform for the provided arguments", () => {
+    it("Returns 'none' when no transform required", () => {
         expect(buildProjectionTransform(createDelta(), { x: 1, y: 1 })).toEqual(
             "none"
         )
+    })
 
+    it("Creates the expected transform for the provided arguments", () => {
         const delta = {
             x: {
                 translate: 100,
@@ -22,7 +24,7 @@ describe("buildProjectionTransform", () => {
             },
         }
         expect(buildProjectionTransform(delta, { x: 1, y: 1 })).toEqual(
-            "translate3d(100px, 300px, 0) scale(1, 1) scale(2, 4)"
+            "translate3d(100px, 300px, 0) scale(2, 4)"
         )
 
         expect(buildProjectionTransform(delta, { x: 2, y: 0.5 })).toEqual(
@@ -34,5 +36,47 @@ describe("buildProjectionTransform", () => {
         ).toEqual(
             "translate3d(50px, 600px, 0) scale(0.5, 2) rotate(45deg) scale(4, 2)"
         )
+    })
+
+    it("Doesn't apply unneccessary translation", () => {
+        const delta = {
+            x: {
+                translate: 0,
+                scale: 2,
+                origin: 0.5,
+                originPoint: 100,
+            },
+            y: {
+                translate: 0,
+                scale: 4,
+                origin: 0.5,
+                originPoint: 100,
+            },
+        }
+
+        expect(
+            buildProjectionTransform(delta, { x: 2, y: 4 }, { rotate: 10 })
+        ).toEqual("scale(0.5, 0.25) rotate(10deg) scale(4, 16)")
+    })
+
+    it("Doesn't apply unneccessary tree scale", () => {
+        const delta = {
+            x: {
+                translate: 100,
+                scale: 2,
+                origin: 0.5,
+                originPoint: 100,
+            },
+            y: {
+                translate: 100,
+                scale: 4,
+                origin: 0.5,
+                originPoint: 100,
+            },
+        }
+
+        expect(
+            buildProjectionTransform(delta, { x: 1, y: 1 }, { rotate: 10 })
+        ).toEqual("translate3d(100px, 100px, 0) rotate(10deg) scale(2, 4)")
     })
 })

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -24,10 +24,8 @@ export function buildProjectionTransform(
      * Apply scale correction for the tree transform.
      * This will apply scale to the screen-orientated axes.
      */
-    const treeScaleCorrectionX = 1 / treeScale.x
-    const treeScaleCorrectionY = 1 / treeScale.y
-    if (treeScaleCorrectionX !== 1 || treeScaleCorrectionY !== 1) {
-        transform += `scale(${treeScaleCorrectionX}, ${treeScaleCorrectionY}) `
+    if (treeScale.x !== 1 || treeScale.y !== 1) {
+        transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y}) `
     }
 
     if (latestTransform) {

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -1,14 +1,13 @@
 import { ResolvedValues } from "../../render/types"
 import { Delta, Point } from "../geometry/types"
 
-export const identityProjection =
-    "translate3d(0px, 0px, 0) scale(1, 1) scale(1, 1)"
-
 export function buildProjectionTransform(
     delta: Delta,
     treeScale: Point,
     latestTransform?: ResolvedValues
 ): string {
+    let transform = ""
+
     /**
      * The translations we use to calculate are always relative to the viewport coordinate space.
      * But when we apply scales, we also scale the coordinate space of an element and its children.
@@ -17,13 +16,19 @@ export function buildProjectionTransform(
      */
     const xTranslate = delta.x.translate / treeScale.x
     const yTranslate = delta.y.translate / treeScale.y
-    let transform = `translate3d(${xTranslate}px, ${yTranslate}px, 0) `
+    if (xTranslate || yTranslate) {
+        transform = `translate3d(${xTranslate}px, ${yTranslate}px, 0) `
+    }
 
     /**
      * Apply scale correction for the tree transform.
      * This will apply scale to the screen-orientated axes.
      */
-    transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y}) `
+    const treeScaleCorrectionX = 1 / treeScale.x
+    const treeScaleCorrectionY = 1 / treeScale.y
+    if (treeScaleCorrectionX !== 1 || treeScaleCorrectionY !== 1) {
+        transform += `scale(${treeScaleCorrectionX}, ${treeScaleCorrectionY}) `
+    }
 
     if (latestTransform) {
         const { rotate, rotateX, rotateY } = latestTransform
@@ -38,7 +43,9 @@ export function buildProjectionTransform(
      */
     const elementScaleX = delta.x.scale * treeScale.x
     const elementScaleY = delta.y.scale * treeScale.y
-    transform += `scale(${elementScaleX}, ${elementScaleY})`
+    if (elementScaleX !== 1 || elementScaleY !== 1) {
+        transform += `scale(${elementScaleX}, ${elementScaleY})`
+    }
 
-    return transform === identityProjection ? "none" : transform
+    return transform || "none"
 }


### PR DESCRIPTION
Currently, projection transforms are applied even when they're default values. For instance:

```
translate3d(100px, 0, 0) scale(1, 1) rotate(90deg) scale(1, 1)
```

Should be 

```
translate3d(100px, 0, 0) rotate(90deg)
```

Each of these transform commands gets turned into a `matrix` and applied as an extra step. By removing these unused/default transforms we can improve framerate up to 20%. For instance, in a translate-only stress-test, scale isn't applied and the framerate improves from ~20fps to ~26fps