### PR TITLE
Prevent scroll measurements more than once per frame pre/post render

### DIFF
--- a/dev/examples/layout-stress-scroll.tsx
+++ b/dev/examples/layout-stress-scroll.tsx
@@ -1,0 +1,394 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    &.expanded {
+        --offset: 100px;
+    }
+
+    .a-scroll {
+        overflow: scroll;
+        width: calc(var(--width) / 2);
+    }
+
+    .a {
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        width: var(--width);
+        height: var(--height);
+        display: flex;
+    }
+
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+    }
+
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+    }
+
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+`
+
+function Group({ children }: React.PropsWithChildren) {
+    return (
+        <motion.div
+            layoutScroll
+            className="a-scroll"
+            style={{ overflow: "scroll" }}
+        >
+            <motion.div layout className="a">
+                <motion.div layout className="b"></motion.div>
+                <motion.div layout className="c"></motion.div>
+                <motion.div layout className="d">
+                    {children}
+                </motion.div>
+                <motion.div layout className="e"></motion.div>
+                <motion.div layout className="f">
+                    <motion.div layout className="g"></motion.div>
+                    <motion.div layout className="h">
+                        <motion.div layout className="i"></motion.div>
+                    </motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/dev/examples/layout-stress-transform.tsx
+++ b/dev/examples/layout-stress-transform.tsx
@@ -1,0 +1,383 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    &.expanded {
+        --offset: 100px;
+    }
+
+    .a {
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        width: var(--width);
+        height: var(--height);
+        display: flex;
+    }
+
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+    }
+
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+    }
+
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: var(--width);
+        height: var(--height);
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+`
+
+function Group({ children }: React.PropsWithChildren) {
+    return (
+        <motion.div layout className="a" style={{ x: 100 }}>
+            <motion.div layout className="b"></motion.div>
+            <motion.div layout className="c"></motion.div>
+            <motion.div layout className="d" style={{ scale: 1.1 }}>
+                {children}
+            </motion.div>
+            <motion.div layout className="e"></motion.div>
+            <motion.div layout className="f">
+                <motion.div layout className="g"></motion.div>
+                <motion.div layout className="h">
+                    <motion.div layout className="i"></motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -97,7 +97,10 @@ export function applyTreeDeltas(
             node.scroll &&
             node !== node.root
         ) {
-            transformBox(box, { x: -node.scroll.x, y: -node.scroll.y })
+            transformBox(box, {
+                x: -node.scroll.offset.x,
+                y: -node.scroll.offset.y,
+            })
         }
 
         if (delta) {

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -84,6 +84,9 @@ export function createProjectionNode<I>({
          */
         elementId: number | undefined
 
+        /**
+         * An id that represents a unique session instigated by startUpdate.
+         */
         animationId: number = 0
 
         /**

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -9,16 +9,18 @@ import { MotionStyle } from "../../motion/types"
 import type { VisualElement } from "../../render/VisualElement"
 
 export interface Measurements {
-    frameTimestamp: number
+    animationId: number
     measuredBox: Box
     layoutBox: Box
     latestValues: ResolvedValues
     source: number
 }
 
+export type Phase = "snapshot" | "measure"
+
 export interface ScrollMeasurements {
-    frameTimestamp: number
-    isLockedToFrame: boolean
+    animationId: number
+    phase: Phase
     isRoot: boolean
     offset: Point
 }
@@ -35,6 +37,7 @@ export type LayoutEvents =
 export interface IProjectionNode<I = unknown> {
     id: number
     elementId: number | undefined
+    animationId: number
     parent?: IProjectionNode
     relativeParent?: IProjectionNode
     root?: IProjectionNode
@@ -76,7 +79,7 @@ export interface IProjectionNode<I = unknown> {
     updateLayout(): void
     updateSnapshot(): void
     clearSnapshot(): void
-    updateScroll(lockToFrame?: boolean): void
+    updateScroll(phase?: Phase): void
     scheduleUpdateProjection(): void
     scheduleCheckAfterUnmount(): void
     checkUpdateFailed(): void

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -16,6 +16,13 @@ export interface Measurements {
     source: number
 }
 
+export interface ScrollMeasurements {
+    frameTimestamp: number
+    isLockedToFrame: boolean
+    isRoot: boolean
+    offset: Point
+}
+
 export type LayoutEvents =
     | "willUpdate"
     | "didUpdate"
@@ -46,8 +53,7 @@ export interface IProjectionNode<I = unknown> {
     relativeTarget?: Box
     targetDelta?: Delta
     targetWithTransforms?: Box
-    scroll?: Point
-    isScrollRoot?: boolean
+    scroll?: ScrollMeasurements
     treeScale?: Point
     projectionDelta?: Delta
     projectionDeltaWithTransform?: Delta
@@ -70,7 +76,7 @@ export interface IProjectionNode<I = unknown> {
     updateLayout(): void
     updateSnapshot(): void
     clearSnapshot(): void
-    updateScroll(): void
+    updateScroll(lockToFrame?: boolean): void
     scheduleUpdateProjection(): void
     scheduleCheckAfterUnmount(): void
     checkUpdateFailed(): void

--- a/packages/framer-motion/src/projection/utils/measure.ts
+++ b/packages/framer-motion/src/projection/utils/measure.ts
@@ -24,8 +24,8 @@ export function measurePageBox(
     const { scroll } = rootProjectionNode
 
     if (scroll) {
-        translateAxis(viewportBox.x, scroll.x)
-        translateAxis(viewportBox.y, scroll.y)
+        translateAxis(viewportBox.x, scroll.offset.x)
+        translateAxis(viewportBox.y, scroll.offset.y)
     }
 
     return viewportBox


### PR DESCRIPTION
Currently if a node is a child of a scrollable element it'll naively trigger a scroll measurement. If there's multiple children they'll all trigger a scroll measurement. Even though the presumption is that the browser does some caching around these returned values (layout thrashing), in the included stress test there's a 30% speed increase in preparing the layout animation with this change.

This PR also changes the use of `frameTimestamp` to an `animationId`. It's rare but in Framer we've had instances where there seems to be many different renders in the same frame. By changing to an `animationId` that gets incremented during `startUpdate` we make sure these are all handled independently.