### PR TITLE
Add `position` to `Measurements`

### DIFF
--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -41,6 +41,7 @@ import {
     Measurements,
     ScrollMeasurements,
     Phase,
+    Position,
 } from "./types"
 import { FlatTree } from "../../render/utils/flat-tree"
 import { Transition } from "../../types"
@@ -774,12 +775,20 @@ export function createProjectionNode<I>({
 
             roundBox(layoutBox)
 
+            const positionStyle =
+                this.options.visualElement?.readValue("position")
+            const position: Position =
+                positionStyle === "fixed" || positionStyle === "sticky"
+                    ? positionStyle
+                    : "static"
+
             return {
                 animationId: this.root.animationId,
                 measuredBox: pageBox,
                 layoutBox,
                 latestValues: {},
                 source: this.id,
+                position,
             }
         }
 

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -8,12 +8,15 @@ import { InitialPromotionConfig } from "../../context/SwitchLayoutGroupContext"
 import { MotionStyle } from "../../motion/types"
 import type { VisualElement } from "../../render/VisualElement"
 
+export type Position = "static" | "sticky" | "fixed"
+
 export interface Measurements {
     animationId: number
     measuredBox: Box
     layoutBox: Box
     latestValues: ResolvedValues
     source: number
+    position: Position
 }
 
 export type Phase = "snapshot" | "measure"


### PR DESCRIPTION
This PR adds `position` to `Measurements`. We only need to know whether an element is `fixed`, `sticky`, or other (treated as `static`). In future PRs this will be used to treat the three layout types seperately.