### PR TITLE
Adding isTransformDirty optimisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.6.11] 2022-11-24
+
+### Fixed
+
+-   Treat `<motion.svg />` components as HTML.
+
 ## [7.6.10] 2022-11-24
 
 ### Updated

--- a/dev/examples/layout-stress-transform-only.tsx
+++ b/dev/examples/layout-stress-transform-only.tsx
@@ -1,0 +1,398 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+/**
+ * This stress test is designed to dirty transform at the top of the tree,
+ * but only update layout at the leaves.
+ */
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    &.expanded {
+        --offset: 100px;
+    }
+
+    .a {
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        width: 100px;
+        height: 200px;
+        display: flex;
+    }
+
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: 100px;
+        height: 200px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: 100px;
+        height: 200px;
+    }
+
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: 100px;
+        height: 200px;
+
+        .i {
+            width: var(--width);
+            height: var(--height);
+            top: var(--offset);
+            left: var(--offset);
+        }
+    }
+
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: 100px;
+        height: 200px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: 100px;
+        height: 200px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: 100px;
+        height: 200px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        width: 100px;
+        height: 200px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: 100px;
+        height: 200px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+`
+
+function Group({
+    children,
+    expanded,
+}: React.PropsWithChildren<{ expanded?: boolean }>) {
+    return (
+        <motion.div layout className="a" animate={{ x: expanded ? 100 : 0 }}>
+            <motion.div layout className="b"></motion.div>
+            <motion.div layout className="c"></motion.div>
+            <motion.div layout className="d">
+                {children}
+            </motion.div>
+            <motion.div layout className="e"></motion.div>
+            <motion.div layout className="f">
+                <motion.div layout className="g"></motion.div>
+                <motion.div layout className="h">
+                    <motion.div layout className="i"></motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+                <Group expanded={expanded}>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/dev/projection/shared-transform-parents-animate-2.html
+++ b/dev/projection/shared-transform-parents-animate-2.html
@@ -70,17 +70,13 @@
 
             sync.postRender(() => {
                 aProjection.willUpdate()
-
                 const b = document.createElement("div")
                 b.id = "b"
                 scroller.appendChild(b)
-
                 const bProjection = createNode(b, scrollerProjection, {
                     layoutId: "a",
                 })
-
                 aProjection.root.didUpdate()
-
                 sync.postRender(() => {
                     matchViewportBox(a, b.getBoundingClientRect())
                     matchViewportBox(a, {

--- a/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
@@ -60,6 +60,16 @@ describe("SVG", () => {
         render(<Component />)
     })
 
+    test("doesn't calculate transformOrigin for <svg /> elements", () => {
+        const Component = () => {
+            return <motion.svg animate={{ rotate: 100 }} />
+        }
+        const { container } = render(<Component />)
+        expect(container.firstChild as Element).not.toHaveStyle(
+            "transform-origin: 0px 0px"
+        )
+    })
+
     // // https://github.com/framer/motion/issues/216
     test("doesn't throw if animating unencounterd value", () => {
         const animation = {

--- a/packages/framer-motion/src/projection/node/__tests__/node.test.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/node.test.ts
@@ -1,4 +1,6 @@
 import { createTestNode } from "./TestProjectionNode"
+import { propagateDirtyNodes } from "../create-projection-node"
+import { IProjectionNode } from "../types"
 
 describe("node", () => {
     test("If a child updates layout, and parent has scale, parent resetsTransform during measurement", () => {
@@ -184,6 +186,10 @@ describe("node", () => {
             x: { translate: 200, scale: 2, origin: 0.5, originPoint: 100 },
             y: { translate: 200, scale: 2, origin: 0.5, originPoint: 100 },
         })
+
+        propagateDirtyNodes(parent as IProjectionNode)
+        propagateDirtyNodes(child as IProjectionNode)
+        propagateDirtyNodes(grandChild as IProjectionNode)
 
         parent.resolveTargetDelta()
         child.resolveTargetDelta()

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -665,11 +665,9 @@ export function createProjectionNode<I>({
          * the next step.
          */
         updateProjection = () => {
-            const start = performance.now()
             this.nodes!.forEach(propagateDirtyNodes)
             this.nodes!.forEach(resolveTargetDelta)
             this.nodes!.forEach(calcProjection)
-            console.log(performance.now() - start)
         }
 
         /**
@@ -1095,15 +1093,16 @@ export function createProjectionNode<I>({
         hasProjected: boolean = false
 
         calcProjection() {
-            const { isProjectionDirty } = this
+            const { isProjectionDirty, isTransformDirty } = this
 
             this.isProjectionDirty = this.isTransformDirty = false
 
             if (!isProjectionDirty) return
 
             const lead = this.getLead()
-            const isShared = Boolean(lead !== this || this.resumeFrom)
-            // if (isShared && isTransformDirty) return
+            const isShared = Boolean(this.resumingFrom) || this !== lead
+
+            if (isShared && isTransformDirty) return
 
             const { layout, layoutId } = this.options
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1776,7 +1776,7 @@ function notifyLayoutUpdate(node: IProjectionNode) {
     node.options.transition = undefined
 }
 
-function propagateDirtyNodes(node: IProjectionNode) {
+export function propagateDirtyNodes(node: IProjectionNode) {
     /**
      * Propagate isProjectionDirty. Nodes are ordered by depth, so if the parent here
      * is dirty we can simply pass this forward.

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -62,6 +62,7 @@ export interface IProjectionNode<I = unknown> {
     projectionDeltaWithTransform?: Delta
     latestValues: ResolvedValues
     isLayoutDirty: boolean
+    isTransformDirty: boolean
     isProjectionDirty: boolean
     shouldResetTransform: boolean
     prevTransformTemplateValue: string | undefined

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -419,7 +419,7 @@ export abstract class VisualElement<
                     sync.update(this.notifyUpdate, false, true)
 
                 if (valueIsTransform && this.projection) {
-                    this.projection.isProjectionDirty = true
+                    this.projection.isTransformDirty = true
                 }
             }
         )

--- a/packages/framer-motion/src/render/svg/lowercase-elements.ts
+++ b/packages/framer-motion/src/render/svg/lowercase-elements.ts
@@ -21,7 +21,6 @@ export const lowercaseSVGElements = [
     "polyline",
     "rect",
     "stop",
-    "svg",
     "switch",
     "symbol",
     "text",


### PR DESCRIPTION
This PR specifies between when a projection is dirty and when a transform is dirty. Ancestor transforms only matter for shared element transitions.

In the included stress test this leads to a **75% per-frame JS reduction**. As with previous optimisations, in the real world there is no lower or upper bound to this cost saving, it depends on the tree.