### PR TITLE
Treat `<motion.svg />` components as HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [7.6.11] 2022-11-24
+
+### Fixed
+
+-   Treat `<motion.svg />` components as HTML.
+
 ## [7.6.10] 2022-11-24
 
 ### Updated

--- a/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
@@ -60,6 +60,16 @@ describe("SVG", () => {
         render(<Component />)
     })
 
+    test("doesn't calculate transformOrigin for <svg /> elements", () => {
+        const Component = () => {
+            return <motion.svg animate={{ rotate: 100 }} />
+        }
+        const { container } = render(<Component />)
+        expect(container.firstChild as Element).not.toHaveStyle(
+            "transform-origin: 0px 0px"
+        )
+    })
+
     // // https://github.com/framer/motion/issues/216
     test("doesn't throw if animating unencounterd value", () => {
         const animation = {

--- a/packages/framer-motion/src/render/svg/lowercase-elements.ts
+++ b/packages/framer-motion/src/render/svg/lowercase-elements.ts
@@ -21,7 +21,6 @@ export const lowercaseSVGElements = [
     "polyline",
     "rect",
     "stop",
-    "svg",
     "switch",
     "symbol",
     "text",


### PR DESCRIPTION
For our purposes, `svg` elements are the same as HTML elements, rather than SVG elements.