### PR TITLE
Setting scale threshold

### DIFF
--- a/dev/examples/layout-stress-scale-correction.tsx
+++ b/dev/examples/layout-stress-scale-correction.tsx
@@ -94,12 +94,11 @@ const Container = styled.div`
 function Group({ children }: React.PropsWithChildren) {
     return (
         <motion.div layout className="a">
-            <motion.div layout className="b"></motion.div>
-            <motion.div layout className="c"></motion.div>
             <motion.div layout className="d">
+                <motion.div layout className="b"></motion.div>
+                <motion.div layout className="c"></motion.div>
                 {children}
             </motion.div>
-            <motion.div layout className="e"></motion.div>
             <motion.div layout className="f">
                 <motion.div layout className="g"></motion.div>
                 <motion.div layout className="h">

--- a/dev/examples/layout-stress-scale-correction.tsx
+++ b/dev/examples/layout-stress-scale-correction.tsx
@@ -1,0 +1,380 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    &.expanded {
+        --width: 500px;
+        --height: 500px;
+        --offset: 100px;
+    }
+
+    .a {
+        width: var(--width);
+        height: var(--height);
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        display: flex;
+
+        .a {
+            width: 100px;
+            height: 100px;
+        }
+    }
+
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+    }
+
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: 100px;
+        height: 100px;
+    }
+
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: 100px;
+        height: 100px;
+    }
+
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 100px;
+        left: 100px;
+    }
+
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+    }
+
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+    }
+
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        position: absolute;
+    }
+
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: var(--offset);
+        left: var(--offset);
+    }
+`
+
+function Group({ children }: React.PropsWithChildren) {
+    return (
+        <motion.div layout className="a">
+            <motion.div layout className="b"></motion.div>
+            <motion.div layout className="c"></motion.div>
+            <motion.div layout className="d">
+                {children}
+            </motion.div>
+            <motion.div layout className="e"></motion.div>
+            <motion.div layout className="f">
+                <motion.div layout className="g"></motion.div>
+                <motion.div layout className="h">
+                    <motion.div layout className="i"></motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -121,11 +121,12 @@ export function applyTreeDeltas(
      * Snap tree scale back to 1 if it's within a non-perceivable threshold.
      * This will help reduce useless scales getting rendered.
      */
-    // treeScale.x = snapToDefault(treeScale.x)
-    // treeScale.y = snapToDefault(treeScale.y)
+    treeScale.x = snapToDefault(treeScale.x)
+    treeScale.y = snapToDefault(treeScale.y)
 }
 
 function snapToDefault(scale: number): number {
+    if (Number.isInteger(scale)) return scale
     return scale > 1.0000000000001 || scale < 0.999999999999 ? scale : 1
 }
 

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -116,6 +116,17 @@ export function applyTreeDeltas(
             transformBox(box, node.latestValues)
         }
     }
+
+    /**
+     * Snap tree scale back to 1 if it's within a non-perceivable threshold.
+     * This will help reduce useless scales getting rendered.
+     */
+    // treeScale.x = snapToDefault(treeScale.x)
+    // treeScale.y = snapToDefault(treeScale.y)
+}
+
+function snapToDefault(scale: number): number {
+    return scale > 1.0000000000001 || scale < 0.999999999999 ? scale : 1
 }
 
 export function translateAxis(axis: Axis, distance: number) {

--- a/packages/framer-motion/src/projection/geometry/delta-calc.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-calc.ts
@@ -7,7 +7,7 @@ export function calcLength(axis: Axis) {
 }
 
 export function isNear(value: number, target = 0, maxDistance = 0.01): boolean {
-    return Math.abs(value - target) < maxDistance
+    return Math.abs(value - target) <= maxDistance
 }
 
 export function calcAxisDelta(

--- a/packages/framer-motion/src/projection/geometry/delta-calc.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-calc.ts
@@ -1,4 +1,4 @@
-import { distance, mix } from "popmotion"
+import { mix } from "popmotion"
 import { ResolvedValues } from "../../render/types"
 import { Axis, AxisDelta, Box, Delta } from "./types"
 
@@ -7,7 +7,7 @@ export function calcLength(axis: Axis) {
 }
 
 export function isNear(value: number, target = 0, maxDistance = 0.01): boolean {
-    return distance(value, target) < maxDistance
+    return Math.abs(value - target) < maxDistance
 }
 
 export function calcAxisDelta(

--- a/packages/framer-motion/src/projection/geometry/utils.ts
+++ b/packages/framer-motion/src/projection/geometry/utils.ts
@@ -1,4 +1,3 @@
-import { distance } from "popmotion"
 import { calcLength } from "./delta-calc"
 import { AxisDelta, Box, Delta } from "./types"
 
@@ -24,5 +23,5 @@ export function aspectRatio(box: Box): number {
 }
 
 export function isCloseTo(a: number, b: number, max = 0.1) {
-    return distance(a, b) <= max
+    return Math.abs(a - b) <= max
 }

--- a/packages/framer-motion/src/projection/geometry/utils.ts
+++ b/packages/framer-motion/src/projection/geometry/utils.ts
@@ -21,7 +21,3 @@ export function boxEquals(a: Box, b: Box) {
 export function aspectRatio(box: Box): number {
     return calcLength(box.x) / calcLength(box.y)
 }
-
-export function isCloseTo(a: number, b: number, max = 0.1) {
-    return Math.abs(a - b) <= max
-}

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -15,18 +15,14 @@ import {
     calcLength,
     calcRelativeBox,
     calcRelativePosition,
+    isNear,
 } from "../geometry/delta-calc"
 import { removeBoxTransforms } from "../geometry/delta-remove"
 import { createBox, createDelta } from "../geometry/models"
 import { transformBox, translateAxis } from "../geometry/delta-apply"
 import { Axis, AxisDelta, Box, Delta, Point } from "../geometry/types"
 import { getValueTransition } from "../../animation/utils/transitions"
-import {
-    aspectRatio,
-    boxEquals,
-    isCloseTo,
-    isDeltaZero,
-} from "../geometry/utils"
+import { aspectRatio, boxEquals, isDeltaZero } from "../geometry/utils"
 import { NodeStack } from "../shared/stack"
 import { scaleCorrectors } from "../styles/scale-correction"
 import { buildProjectionTransform } from "../styles/transform"
@@ -667,7 +663,9 @@ export function createProjectionNode<I>({
         updateProjection = () => {
             this.nodes!.forEach(propagateDirtyNodes)
             this.nodes!.forEach(resolveTargetDelta)
+            const start = performance.now()
             this.nodes!.forEach(calcProjection)
+            console.log(performance.now() - start)
         }
 
         /**
@@ -1901,6 +1899,6 @@ function shouldAnimatePositionOnly(
     return (
         animationType === "position" ||
         (animationType === "preserve-aspect" &&
-            !isCloseTo(aspectRatio(snapshot), aspectRatio(layout), 0.2))
+            !isNear(aspectRatio(snapshot), aspectRatio(layout), 0.2))
     )
 }

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -663,9 +663,7 @@ export function createProjectionNode<I>({
         updateProjection = () => {
             this.nodes!.forEach(propagateDirtyNodes)
             this.nodes!.forEach(resolveTargetDelta)
-            const start = performance.now()
             this.nodes!.forEach(calcProjection)
-            console.log(performance.now() - start)
         }
 
         /**

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -1,8 +1,5 @@
 import { ResolvedValues } from "../../render/types"
 import { Delta, Point } from "../geometry/types"
-import { isCloseTo } from "../geometry/utils"
-
-const scaleThreshold = 0.0000000001
 
 export function buildProjectionTransform(
     delta: Delta,
@@ -27,10 +24,7 @@ export function buildProjectionTransform(
      * Apply scale correction for the tree transform.
      * This will apply scale to the screen-orientated axes.
      */
-    if (
-        !isCloseTo(treeScale.x, 1, scaleThreshold) ||
-        !isCloseTo(treeScale.y, 1, scaleThreshold)
-    ) {
+    if (treeScale.x !== 1 || treeScale.y !== 1) {
         transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y}) `
     }
 
@@ -47,10 +41,7 @@ export function buildProjectionTransform(
      */
     const elementScaleX = delta.x.scale * treeScale.x
     const elementScaleY = delta.y.scale * treeScale.y
-    if (
-        !isCloseTo(elementScaleX, 1, scaleThreshold) ||
-        !isCloseTo(elementScaleY, 1, scaleThreshold)
-    ) {
+    if (elementScaleX !== 1 || elementScaleY !== 1) {
         transform += `scale(${elementScaleX}, ${elementScaleY})`
     }
 

--- a/packages/framer-motion/src/projection/styles/transform.ts
+++ b/packages/framer-motion/src/projection/styles/transform.ts
@@ -1,5 +1,8 @@
 import { ResolvedValues } from "../../render/types"
 import { Delta, Point } from "../geometry/types"
+import { isCloseTo } from "../geometry/utils"
+
+const scaleThreshold = 0.0000000001
 
 export function buildProjectionTransform(
     delta: Delta,
@@ -24,7 +27,10 @@ export function buildProjectionTransform(
      * Apply scale correction for the tree transform.
      * This will apply scale to the screen-orientated axes.
      */
-    if (treeScale.x !== 1 || treeScale.y !== 1) {
+    if (
+        !isCloseTo(treeScale.x, 1, scaleThreshold) ||
+        !isCloseTo(treeScale.y, 1, scaleThreshold)
+    ) {
         transform += `scale(${1 / treeScale.x}, ${1 / treeScale.y}) `
     }
 
@@ -41,7 +47,10 @@ export function buildProjectionTransform(
      */
     const elementScaleX = delta.x.scale * treeScale.x
     const elementScaleY = delta.y.scale * treeScale.y
-    if (elementScaleX !== 1 || elementScaleY !== 1) {
+    if (
+        !isCloseTo(elementScaleX, 1, scaleThreshold) ||
+        !isCloseTo(elementScaleY, 1, scaleThreshold)
+    ) {
         transform += `scale(${elementScaleX}, ${elementScaleY})`
     }
 


### PR DESCRIPTION
This PR adds a threshold for rendered scales. In deep trees when many elements are effectively `scale: 1` this might get calculated (due to floating point inaccuracy) as `1.0000000001` etc. These actually get rendered as `scale(1)` when set in the browser so they're truly useless.

By not rendering these scales we achieve a 25% higher framerate in the included stress test.