### PR TITLE
Optimise tree scale calculations

### DIFF
--- a/dev/examples/layout-stress.tsx
+++ b/dev/examples/layout-stress.tsx
@@ -40,14 +40,14 @@ const Container = styled.div`
 
     .c {
         background-color: hsla(60, 50%, 50%);
-        width: var(--offset);
-        height: var(--offset);
+        width: 100px;
+        height: 100px;
     }
 
     .d {
         background-color: hsla(90, 50%, 50%);
-        width: var(--offset);
-        height: var(--offset);
+        width: 100px;
+        height: 100px;
     }
 
     .e {

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -73,7 +73,7 @@ export function applyBoxDelta(box: Box, { x, y }: Delta): void {
  */
 export function applyTreeDeltas(
     box: Box,
-    treeScale: Point,
+    _treeScale: Point,
     treePath: IProjectionNode[],
     isSharedTransition: boolean = false
 ) {
@@ -81,7 +81,7 @@ export function applyTreeDeltas(
     if (!treeLength) return
 
     // Reset the treeScale
-    treeScale.x = treeScale.y = 1
+    // treeScale.x = treeScale.y = 1
 
     let node: IProjectionNode
     let delta: Delta | undefined
@@ -104,9 +104,9 @@ export function applyTreeDeltas(
         }
 
         if (delta) {
-            // Incoporate each ancestor's scale into a culmulative treeScale for this component
-            treeScale.x *= delta.x.scale
-            treeScale.y *= delta.y.scale
+            // // Incoporate each ancestor's scale into a culmulative treeScale for this component
+            // treeScale.x *= delta.x.scale
+            // treeScale.y *= delta.y.scale
 
             // Apply each ancestor's calculated delta into this component's recorded layout box
             applyBoxDelta(box, delta)
@@ -117,15 +117,17 @@ export function applyTreeDeltas(
         }
     }
 
-    /**
-     * Snap tree scale back to 1 if it's within a non-perceivable threshold.
-     * This will help reduce useless scales getting rendered.
-     */
-    treeScale.x = snapToDefault(treeScale.x)
-    treeScale.y = snapToDefault(treeScale.y)
+    // /**
+    //  * Snap tree scale back to 1 if it's within a non-perceivable threshold.
+    //  * This will help reduce useless scales getting rendered.
+    //  */
+    // treeScale.x = snapToDefault(treeScale.x)
+    // treeScale.y = snapToDefault(treeScale.y)
+
+    // console.log(treeScale.x)
 }
 
-function snapToDefault(scale: number): number {
+export function snapToDefault(scale: number): number {
     if (Number.isInteger(scale)) return scale
     return scale > 1.0000000000001 || scale < 0.999999999999 ? scale : 1
 }

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -2,7 +2,7 @@ import { mix } from "popmotion"
 import { ResolvedValues } from "../../render/types"
 import { IProjectionNode } from "../node/types"
 import { hasTransform } from "../utils/has-transform"
-import { Axis, Box, Delta, Point } from "./types"
+import { Axis, Box, Delta } from "./types"
 
 /**
  * Scales a point based on a factor and an originPoint

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -73,15 +73,11 @@ export function applyBoxDelta(box: Box, { x, y }: Delta): void {
  */
 export function applyTreeDeltas(
     box: Box,
-    _treeScale: Point,
     treePath: IProjectionNode[],
     isSharedTransition: boolean = false
 ) {
     const treeLength = treePath.length
     if (!treeLength) return
-
-    // Reset the treeScale
-    // treeScale.x = treeScale.y = 1
 
     let node: IProjectionNode
     let delta: Delta | undefined
@@ -104,10 +100,6 @@ export function applyTreeDeltas(
         }
 
         if (delta) {
-            // // Incoporate each ancestor's scale into a culmulative treeScale for this component
-            // treeScale.x *= delta.x.scale
-            // treeScale.y *= delta.y.scale
-
             // Apply each ancestor's calculated delta into this component's recorded layout box
             applyBoxDelta(box, delta)
         }
@@ -116,15 +108,6 @@ export function applyTreeDeltas(
             transformBox(box, node.latestValues)
         }
     }
-
-    // /**
-    //  * Snap tree scale back to 1 if it's within a non-perceivable threshold.
-    //  * This will help reduce useless scales getting rendered.
-    //  */
-    // treeScale.x = snapToDefault(treeScale.x)
-    // treeScale.y = snapToDefault(treeScale.y)
-
-    // console.log(treeScale.x)
 }
 
 export function snapToDefault(scale: number): number {

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1094,30 +1094,38 @@ export function createProjectionNode<I>({
 
         hasProjected: boolean = false
 
-        calcProjection() {
+        propagateTreeScale() {
             if (!this.parent) {
                 /**
                  * If this is the top of the tree, reset the treeScale to 1
                  */
                 this.treeScale.x = 1
                 this.treeScale.y = 1
-            } else if (this.parent.projectionDelta) {
+            } else if (this.parent?.projectionDelta) {
                 /**
-                 * For all children nodes, take the parent treeScale, apply the parent's
-                 *
+                 * If the parent has calculated a projectionDelta, incorporate
+                 * it into the tree scale of this node.
                  */
                 this.treeScale.x = snapToDefault(
-                    this.parent.treeScale!.x *
+                    this.parent.treeScale.x *
                         this.parent.projectionDelta.x.scale
                 )
                 this.treeScale.y = snapToDefault(
-                    this.parent.treeScale!.y *
+                    this.parent.treeScale.y *
                         this.parent.projectionDelta.y.scale
                 )
             } else {
-                this.treeScale.x = this.parent.treeScale!.x
-                this.treeScale.y = this.parent.treeScale!.y
+                /**
+                 * If the parent doesn't have an active projection then
+                 * forward its tree scale.
+                 */
+                this.treeScale.x = this.parent.treeScale.x
+                this.treeScale.y = this.parent.treeScale.y
             }
+        }
+
+        calcProjection() {
+            this.propagateTreeScale()
 
             const { isProjectionDirty, isTransformDirty } = this
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -9,7 +9,11 @@ import { ResolvedValues } from "../../render/types"
 import { SubscriptionManager } from "../../utils/subscription-manager"
 import { mixValues } from "../animation/mix-values"
 import { copyBoxInto } from "../geometry/copy"
-import { applyBoxDelta, applyTreeDeltas } from "../geometry/delta-apply"
+import {
+    applyBoxDelta,
+    applyTreeDeltas,
+    snapToDefault,
+} from "../geometry/delta-apply"
 import {
     calcBoxDelta,
     calcLength,
@@ -1089,6 +1093,29 @@ export function createProjectionNode<I>({
         hasProjected: boolean = false
 
         calcProjection() {
+            if (this.parent) {
+                if (this.parent.projectionDelta) {
+                    /**
+                     * Snap tree scale back to 1 if it's within a non-perceivable threshold.
+                     * This will help reduce useless scales getting rendered.
+                     */
+                    this.treeScale.x = snapToDefault(
+                        this.parent.treeScale!.x *
+                            this.parent.projectionDelta.x.scale
+                    )
+                    this.treeScale.y = snapToDefault(
+                        this.parent.treeScale!.y *
+                            this.parent.projectionDelta.y.scale
+                    )
+                } else {
+                    this.treeScale.x = this.parent.treeScale!.x
+                    this.treeScale.y = this.parent.treeScale!.y
+                }
+            } else {
+                this.treeScale.x = 1
+                this.treeScale.y = 1
+            }
+
             const { isProjectionDirty, isTransformDirty } = this
 
             this.isProjectionDirty = this.isTransformDirty = false

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -667,9 +667,7 @@ export function createProjectionNode<I>({
         updateProjection = () => {
             this.nodes!.forEach(propagateDirtyNodes)
             this.nodes!.forEach(resolveTargetDelta)
-            const start = performance.now()
             this.nodes!.forEach(calcProjection)
-            console.log(performance.now() - start)
         }
 
         /**

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -57,7 +57,7 @@ export interface IProjectionNode<I = unknown> {
     targetDelta?: Delta
     targetWithTransforms?: Box
     scroll?: ScrollMeasurements
-    treeScale?: Point
+    treeScale: Point
     projectionDelta?: Delta
     projectionDeltaWithTransform?: Delta
     latestValues: ResolvedValues


### PR DESCRIPTION
This PR flattens the calculation of `treeScale`. What this means is instead of every node looping through its ancestor path, calculating the `treeScale` from every ancestor node, we use the existing global `calcProjection` loop to prepare and forward `treeScale` down through every node.

I expect this change to have no perceivable impact. Each node's ancestor loop still exists (though this is a step towards potentially removing it). We are reducing the number of `*` operations - for deep trees, by quite a lot. But the ancestor loop now gets skipped for some nodes, and soon hopefully more. So for some nodes we're doing work we previously weren't. 

On balance, and from my testing, it makes little to no difference (with a lean on a slight speed increase). However, in a later PR I would like to use the `hasTreeScaleChanged` information from putting this step where it is to help limit the propagation of `isProjectionDirty` safely.