### PR TITLE
Use cached scroll if possible

### DIFF
--- a/dev/projection/single-element-page-scroll-cache.html
+++ b/dev/projection/single-element-page-scroll-cache.html
@@ -1,0 +1,81 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #box.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="box" data-layout-correct="true"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-undo.js"></script>
+        <script>
+            const { createNode } = window.Undo
+            const { matchViewportBox, addPageScroll } = window.Assert
+            const box = document.getElementById("box")
+            const boxProjection = createNode(box)
+
+            const boxOrigin = box.getBoundingClientRect()
+
+            boxProjection.willUpdate()
+
+            const scrollOffset = [50, 100]
+            window.scrollTo(...scrollOffset)
+
+            boxProjection.root.didUpdate()
+
+            matchViewportBox(box, addPageScroll(boxOrigin, ...scrollOffset))
+
+            requestAnimationFrame(() => {
+                window.scrollTo(0, 0)
+
+                boxProjection.willUpdate()
+
+                boxProjection.root.didUpdate()
+
+                // matchViewportBox(box, boxOrigin)
+
+                // window.scrollTo(100, 100)
+                // boxProjection.willUpdate()
+                // boxProjection.root.didUpdate()
+                //     window.scrollTo(0, 0)
+                //     console.log("scroll 0")
+                //     boxProjection.willUpdate()
+
+                //     matchViewportBox(box, boxOrigin)
+            })
+        </script>
+    </body>
+</html>

--- a/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
@@ -10,8 +10,19 @@ export const TestRootNode = createProjectionNode<{}>({
 })
 
 interface TestInstance {
+    id?: string
+    addEventListener?: Element["addEventListener"]
+    removeEventListener?: Element["removeEventListener"]
     resetTransform?: () => void
     box?: Box
+}
+
+export function testInstance(instance: Partial<TestInstance>): TestInstance {
+    return {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        ...instance,
+    }
 }
 
 export const TestProjectionNode = createProjectionNode<TestInstance>({

--- a/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/TestProjectionNode.ts
@@ -17,14 +17,6 @@ interface TestInstance {
     box?: Box
 }
 
-export function testInstance(instance: Partial<TestInstance>): TestInstance {
-    return {
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        ...instance,
-    }
-}
-
 export const TestProjectionNode = createProjectionNode<TestInstance>({
     measureScroll: (_instance) => ({ x: 0, y: 0 }),
     defaultParent: () => {

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -236,6 +236,10 @@ export function createProjectionNode<I>({
          */
         isProjectionDirty = false
 
+        /**
+         * This will be flagged to true if current scroll measurements are updated. This will
+         * help reduce the number of times they're sampled (which can trigger style recalculations).
+         */
         isScrollDirty = false
 
         /**
@@ -737,6 +741,11 @@ export function createProjectionNode<I>({
             }
 
             if (needsMeasurement) {
+                /**
+                 * Because renders are sync and scroll event listeners are non-blocking,
+                 * we can only use cached scroll during the pre-render snapshot phase,
+                 * as we will have had time since the last render for a scroll event to fire.
+                 */
                 const useCachedScroll =
                     !this.isScrollDirty && this.scroll && phase === "snapshot"
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -325,7 +325,7 @@ export function createProjectionNode<I extends WithEventListeners>({
 
         preserveOpacity?: boolean
 
-        dirtyScroll?: VoidFunction
+        dirtyScroll?: (event: Event) => void
 
         constructor(
             elementId: number | undefined,
@@ -424,7 +424,22 @@ export function createProjectionNode<I extends WithEventListeners>({
              * scroll, add an event listener to flag when the scroll measurements are outdated.
              */
             if (this === this.root || this.options.layoutScroll) {
-                this.dirtyScroll = () => (this.isScrollDirty = true)
+                this.dirtyScroll = (event: Event) => {
+                    if (
+                        // true ||
+                        !this.scroll ||
+                        event.timeStamp > this.scroll.timeStamp
+                    ) {
+                        console.log("setting is scroll dirty")
+                        this.isScrollDirty = true
+                    } else {
+                        console.log(
+                            "not dirty",
+                            event.timeStamp,
+                            this.scroll.timeStamp
+                        )
+                    }
+                }
                 this.instance.addEventListener?.("scroll", this.dirtyScroll)
             }
 
@@ -769,9 +784,18 @@ export function createProjectionNode<I extends WithEventListeners>({
                  */
                 const useCachedScroll =
                     !this.isScrollDirty && this.scroll && phase === "snapshot"
-
+                console.log(
+                    phase,
+                    this.isScrollDirty,
+                    this.scroll?.offset,
+                    {
+                        useCachedScroll,
+                    },
+                    performance.now()
+                )
                 this.scroll = {
                     animationId: this.root.animationId,
+                    timeStamp: performance.now(),
                     phase,
                     isRoot: checkIsScrollRoot(this.instance),
                     offset: useCachedScroll

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -59,7 +59,12 @@ const animationTarget = 1000
 
 let id = 0
 
-export function createProjectionNode<I>({
+interface WithEventListeners {
+    addEventListener: Element["addEventListener"]
+    removeEventListener: Element["removeEventListener"]
+}
+
+export function createProjectionNode<I extends WithEventListeners>({
     attachResizeListener,
     defaultParent,
     measureScroll,
@@ -420,10 +425,7 @@ export function createProjectionNode<I>({
              */
             if (this === this.root || this.options.layoutScroll) {
                 this.dirtyScroll = () => (this.isScrollDirty = true)
-                ;(this.instance as any).addEventListener(
-                    "scroll",
-                    this.dirtyScroll
-                )
+                this.instance.addEventListener("scroll", this.dirtyScroll)
             }
 
             // Only register the handler if it requires layout animation
@@ -534,10 +536,7 @@ export function createProjectionNode<I>({
             this.parent?.children.delete(this)
 
             if (this.dirtyScroll) {
-                ;(this.instance as any).removeEventListener(
-                    "scroll",
-                    this.dirtyScroll
-                )
+                this.instance.removeEventListener("scroll", this.dirtyScroll)
             }
 
             ;(this.instance as any) = undefined

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -60,8 +60,8 @@ const animationTarget = 1000
 let id = 0
 
 interface WithEventListeners {
-    addEventListener: Element["addEventListener"]
-    removeEventListener: Element["removeEventListener"]
+    addEventListener?: Element["addEventListener"]
+    removeEventListener?: Element["removeEventListener"]
 }
 
 export function createProjectionNode<I extends WithEventListeners>({
@@ -425,7 +425,7 @@ export function createProjectionNode<I extends WithEventListeners>({
              */
             if (this === this.root || this.options.layoutScroll) {
                 this.dirtyScroll = () => (this.isScrollDirty = true)
-                this.instance.addEventListener("scroll", this.dirtyScroll)
+                this.instance.addEventListener?.("scroll", this.dirtyScroll)
             }
 
             // Only register the handler if it requires layout animation
@@ -536,7 +536,7 @@ export function createProjectionNode<I extends WithEventListeners>({
             this.parent?.children.delete(this)
 
             if (this.dirtyScroll) {
-                this.instance.removeEventListener("scroll", this.dirtyScroll)
+                this.instance.removeEventListener?.("scroll", this.dirtyScroll)
             }
 
             ;(this.instance as any) = undefined

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -236,6 +236,8 @@ export function createProjectionNode<I>({
          */
         isProjectionDirty = false
 
+        isScrollDirty = false
+
         /**
          * Block layout updates for instant layout transitions throughout the tree.
          */
@@ -735,13 +737,20 @@ export function createProjectionNode<I>({
             }
 
             if (needsMeasurement) {
+                const useCachedScroll =
+                    !this.isScrollDirty && this.scroll && phase === "snapshot"
+
                 this.scroll = {
                     animationId: this.root.animationId,
                     phase,
                     isRoot: checkIsScrollRoot(this.instance),
-                    offset: measureScroll(this.instance),
+                    offset: useCachedScroll
+                        ? this.scroll!.offset
+                        : measureScroll(this.instance),
                 }
             }
+
+            this.isScrollDirty = false
         }
 
         resetTransform() {

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -419,9 +419,11 @@ export function createProjectionNode<I>({
              * scroll, add an event listener to flag when the scroll measurements are outdated.
              */
             if (this === this.root || this.options.layoutScroll) {
-                const element = this.instance as Element
                 this.dirtyScroll = () => (this.isScrollDirty = true)
-                element.addEventListener("scroll", this.dirtyScroll)
+                ;(this.instance as any).addEventListener(
+                    "scroll",
+                    this.dirtyScroll
+                )
             }
 
             // Only register the handler if it requires layout animation
@@ -532,8 +534,10 @@ export function createProjectionNode<I>({
             this.parent?.children.delete(this)
 
             if (this.dirtyScroll) {
-                const element = this.instance as Element
-                element.removeEventListener("scroll", this.dirtyScroll)
+                ;(this.instance as any).removeEventListener(
+                    "scroll",
+                    this.dirtyScroll
+                )
             }
 
             ;(this.instance as any) = undefined

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -20,6 +20,7 @@ export type Phase = "snapshot" | "measure"
 
 export interface ScrollMeasurements {
     animationId: number
+    timeStamp: number
     phase: Phase
     isRoot: boolean
     offset: Point


### PR DESCRIPTION
Reading scroll can trigger style recalculations. Here we use the cached scroll if possible. It might be possible to do this post-render too but some testing needs doing to see if the scroll event will fire before the useLayoutEffect (unlikely)