### PR TITLE
Flip equality conditionals

### DIFF
--- a/packages/framer-motion/src/projection/geometry/utils.ts
+++ b/packages/framer-motion/src/projection/geometry/utils.ts
@@ -3,7 +3,7 @@ import { Box, Delta } from "./types"
 
 export function isDeltaZero(delta: Delta) {
     /**
-     * Making !(condition || condition) vs condition && condition allows
+     * Making !(!condition || !condition) vs condition && condition allows
      * earlier bailout.
      */
     return !(

--- a/packages/framer-motion/src/projection/geometry/utils.ts
+++ b/packages/framer-motion/src/projection/geometry/utils.ts
@@ -1,20 +1,25 @@
 import { calcLength } from "./delta-calc"
-import { AxisDelta, Box, Delta } from "./types"
-
-function isAxisDeltaZero(delta: AxisDelta) {
-    return delta.translate === 0 && delta.scale === 1
-}
+import { Box, Delta } from "./types"
 
 export function isDeltaZero(delta: Delta) {
-    return isAxisDeltaZero(delta.x) && isAxisDeltaZero(delta.y)
+    /**
+     * Making !(condition || condition) vs condition && condition allows
+     * earlier bailout.
+     */
+    return !(
+        delta.x.translate !== 0 ||
+        delta.x.scale !== 1 ||
+        delta.y.translate !== 0 ||
+        delta.y.scale !== 1
+    )
 }
 
 export function boxEquals(a: Box, b: Box) {
-    return (
-        a.x.min === b.x.min &&
-        a.x.max === b.x.max &&
-        a.y.min === b.y.min &&
-        a.y.max === b.y.max
+    return !(
+        a.x.min !== b.x.min ||
+        a.x.max !== b.x.max ||
+        a.y.min !== b.y.min ||
+        a.y.max !== b.y.max
     )
 }
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -661,9 +661,11 @@ export function createProjectionNode<I>({
          * the next step.
          */
         updateProjection = () => {
+            const start = performance.now()
             this.nodes!.forEach(propagateDirtyNodes)
             this.nodes!.forEach(resolveTargetDelta)
             this.nodes!.forEach(calcProjection)
+            console.log(performance.now() - start)
         }
 
         /**


### PR DESCRIPTION
An equality check like 

```
const is = a && b && c && d
```

Has to check all four conditionals to resolve `is`. Flipping the conditional to

```
const is = !(!a || !b || !c || !d)
```

Allows the equality check to bail out as soon as any one of them is not true.

This reduces per-frame JS by ~8-10% in "worst case scenario" situations - i.e. it disproportionately improves framerate on animations that are otherwise tough to optimise.