### PR TITLE
Removing `popmotion` as a dependency

### DIFF
--- a/dev/examples/AnimatePresence-image-gallery.tsx
+++ b/dev/examples/AnimatePresence-image-gallery.tsx
@@ -1,7 +1,6 @@
-import { motion, AnimatePresence } from "framer-motion"
+import { motion, AnimatePresence, wrap } from "framer-motion"
 import * as React from "react"
 import { useState } from "react"
-import { wrap } from "popmotion"
 
 /**
  * An example of a single-image, single-child image gallery using AnimatePresence

--- a/dev/examples/Animation-height-auto-display-none.tsx
+++ b/dev/examples/Animation-height-auto-display-none.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { useState } from "react"
-import { motion } from "framer-motion"
-import { mix } from "popmotion"
+import { mix, motion } from "framer-motion"
 
 /**
  * This is an example of animating height: auto from a component that was display: none
@@ -47,7 +46,7 @@ export const App = () => {
 
     return (
         <div className="example-container">
-            {[0, 1, 2, 3].map(i => (
+            {[0, 1, 2, 3].map((i) => (
                 <Accordion
                     i={i}
                     expanded={expanded}
@@ -134,16 +133,14 @@ const generateWordLength = () => randomInt(20, 100)
 const paragraphs = Array(3)
     .fill(1)
     .map(() => {
-        return Array(generateParagraphLength())
-            .fill(1)
-            .map(generateWordLength)
+        return Array(generateParagraphLength()).fill(1).map(generateWordLength)
     })
 
 export const Word = ({ width }) => <div className="word" style={{ width }} />
 
 const Paragraph = ({ words }) => (
     <div className="paragraph">
-        {words.map(width => (
+        {words.map((width) => (
             <Word width={width} />
         ))}
     </div>
@@ -155,7 +152,7 @@ export const ContentPlaceholder = () => (
         transition={{ duration: 0.8 }}
         className="content-placeholder"
     >
-        {paragraphs.map(words => (
+        {paragraphs.map((words) => (
             <Paragraph words={words} />
         ))}
     </motion.div>

--- a/dev/examples/Animation-height-auto-rotate-scale.tsx
+++ b/dev/examples/Animation-height-auto-rotate-scale.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { useState } from "react"
-import { motion } from "framer-motion"
-import { mix } from "popmotion"
+import { motion, mix } from "framer-motion"
 
 /**
  * This is an example of animating height: auto while also animation scale and rotate on the same element
@@ -46,7 +45,7 @@ export const App = () => {
 
     return (
         <div className="example-container">
-            {[0, 1, 2, 3].map(i => (
+            {[0, 1, 2, 3].map((i) => (
                 <Accordion
                     i={i}
                     expanded={expanded}
@@ -133,16 +132,14 @@ const generateWordLength = () => randomInt(20, 100)
 const paragraphs = Array(3)
     .fill(1)
     .map(() => {
-        return Array(generateParagraphLength())
-            .fill(1)
-            .map(generateWordLength)
+        return Array(generateParagraphLength()).fill(1).map(generateWordLength)
     })
 
 export const Word = ({ width }) => <div className="word" style={{ width }} />
 
 const Paragraph = ({ words }) => (
     <div className="paragraph">
-        {words.map(width => (
+        {words.map((width) => (
             <Word width={width} />
         ))}
     </div>
@@ -150,7 +147,7 @@ const Paragraph = ({ words }) => (
 
 export const ContentPlaceholder = () => (
     <motion.div transition={{ duration: 0.8 }} className="content-placeholder">
-        {paragraphs.map(words => (
+        {paragraphs.map((words) => (
             <Paragraph words={words} />
         ))}
     </motion.div>

--- a/dev/examples/Animation-stagger-custom.tsx
+++ b/dev/examples/Animation-stagger-custom.tsx
@@ -1,7 +1,5 @@
 import * as React from "react"
-import { render } from "react-dom"
-import { Frame, useCycle, useAnimation } from "framer-motion"
-import { wrap, distance } from "popmotion"
+import { useAnimation, distance2D, wrap } from "framer-motion"
 import { motion } from "framer-motion"
 
 const count = 100
@@ -48,7 +46,7 @@ export const App = () => {
 const Cell = ({ center, i, onClick }) => {
     const x = col(i)
     const y = row(i)
-    const d = distance({ x, y }, center)
+    const d = distance2D({ x, y }, center)
     const n = Math.max(d / max, 0.05) // normalized
 
     const animation = useAnimation()

--- a/dev/examples/Layout-Projection-custom-values.tsx
+++ b/dev/examples/Layout-Projection-custom-values.tsx
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { useState } from "react"
-import { motion, addScaleCorrector } from "framer-motion"
-import { mix } from "popmotion"
+import { mix, motion, addScaleCorrector } from "framer-motion"
 import styled from "styled-components"
 
 /**

--- a/dev/examples/ThreeButton.tsx
+++ b/dev/examples/ThreeButton.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
 import { useRef, useState } from "react"
-import { degreesToRadians } from "popmotion"
 import { motion as motionThree, MotionCanvas } from "framer-motion-3d"
 import { motion, Variants } from "framer-motion"
 import styled from "styled-components"
 import { PointLight, Mesh, BoxGeometry, MeshPhongMaterial, Group } from "three"
 import { extend } from "@react-three/fiber"
+
+const degreesToRadians = (degrees: number) => (degrees * Math.PI) / 180
 
 extend({
     PointLight,

--- a/dev/examples/useScroll.tsx
+++ b/dev/examples/useScroll.tsx
@@ -1,7 +1,12 @@
 import * as React from "react"
 import { useEffect, useState, useRef } from "react"
-import { motion, useElementScroll, useSpring, useTransform } from "framer-motion"
-import { mix } from "popmotion"
+import {
+    mix,
+    motion,
+    useElementScroll,
+    useSpring,
+    useTransform,
+} from "framer-motion"
 
 const randomInt = (min, max) => Math.round(mix(min, max, Math.random()))
 const generateParagraphLength = () => randomInt(10, 40)
@@ -16,7 +21,7 @@ const Word = ({ width }) => <div className="word" style={{ width }} />
 
 const Paragraph = ({ words }) => (
     <div className="paragraph">
-        {words.map(width => (
+        {words.map((width) => (
             <Word width={width} />
         ))}
     </div>
@@ -29,7 +34,7 @@ export const ContentPlaceholder = () => (
             <Word width={245} />
             <Word width={120} />
         </div>
-        {paragraphs.map(words => (
+        {paragraphs.map((words) => (
             <Paragraph words={words} />
         ))}
     </div>
@@ -42,7 +47,7 @@ export const Example = () => {
     const yRange = useTransform(scrollYProgress, [0, 0.9], [0, 1])
     const pathLength = useSpring(yRange, { stiffness: 400, damping: 90 })
 
-    useEffect(() => yRange.onChange(v => setIsComplete(v >= 1)), [yRange])
+    useEffect(() => yRange.onChange((v) => setIsComplete(v >= 1)), [yRange])
 
     return (
         <div

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -1,9 +1,7 @@
 import * as React from "react"
 import { useState, useMemo, useEffect, useRef } from "react"
 import { render } from "react-dom"
-import { motion, useMotionValue, useSpring } from "framer-motion"
-import { distance } from "popmotion"
-import { spring } from "popmotion"
+import { distance2D, motion, useMotionValue, useSpring } from "framer-motion"
 
 //const grid = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
 const grid = [[0]]
@@ -14,7 +12,7 @@ const pushFactor = 0.4
 const Square = ({ active, setActive, colIndex, rowIndex, itemIndex, x, y }) => {
     const isDragging = colIndex === active.col && rowIndex === active.row
     const diagonalIndex = (360 / 6) * (colIndex + rowIndex)
-    const d = distance(
+    const d = distance2D(
         { x: active.col, y: active.row },
         { x: colIndex, y: rowIndex }
     )

--- a/dev/examples/useViewportScroll.tsx
+++ b/dev/examples/useViewportScroll.tsx
@@ -1,7 +1,12 @@
 import * as React from "react"
 import { useEffect, useState } from "react"
-import { motion, useViewportScroll, useSpring, useTransform } from "framer-motion"
-import { mix } from "popmotion"
+import {
+    mix,
+    motion,
+    useViewportScroll,
+    useSpring,
+    useTransform,
+} from "framer-motion"
 
 const randomInt = (min, max) => Math.round(mix(min, max, Math.random()))
 const generateParagraphLength = () => randomInt(10, 40)
@@ -16,7 +21,7 @@ const Word = ({ width }) => <div className="word" style={{ width }} />
 
 const Paragraph = ({ words }) => (
     <div className="paragraph">
-        {words.map(width => (
+        {words.map((width) => (
             <Word width={width} />
         ))}
     </div>
@@ -29,7 +34,7 @@ export const ContentPlaceholder = () => (
             <Word width={245} />
             <Word width={120} />
         </div>
-        {paragraphs.map(words => (
+        {paragraphs.map((words) => (
             <Paragraph words={words} />
         ))}
     </div>
@@ -41,7 +46,7 @@ export const Example = () => {
     const yRange = useTransform(scrollYProgress, [0, 0.9], [0, 1])
     const pathLength = useSpring(yRange, { stiffness: 400, damping: 90 })
 
-    useEffect(() => yRange.onChange(v => setIsComplete(v >= 1)), [yRange])
+    useEffect(() => yRange.onChange((v) => setIsComplete(v >= 1)), [yRange])
 
     return (
         <>

--- a/dev/tests/layout-preserve-ratio.tsx
+++ b/dev/tests/layout-preserve-ratio.tsx
@@ -1,5 +1,4 @@
-import { motion, useAnimationFrame, useMotionValue } from "framer-motion"
-import { mix } from "popmotion"
+import { mix, motion, useAnimationFrame, useMotionValue } from "framer-motion"
 import * as React from "react"
 
 const transition = {

--- a/packages/framer-motion-3d/src/components/MotionCanvas.tsx
+++ b/packages/framer-motion-3d/src/components/MotionCanvas.tsx
@@ -7,6 +7,7 @@ import {
     MutableRefObject,
 } from "react"
 import {
+    clamp,
     MotionContext,
     MotionConfigContext,
     useForceUpdate,
@@ -23,7 +24,6 @@ import {
     ReconcilerRoot,
 } from "@react-three/fiber"
 import { DimensionsState, MotionCanvasContext } from "./MotionCanvasContext"
-import { clamp } from "popmotion"
 
 export interface MotionCanvasProps extends Omit<Props, "resize"> {}
 

--- a/packages/framer-motion-3d/src/components/use-layout-camera.ts
+++ b/packages/framer-motion-3d/src/components/use-layout-camera.ts
@@ -5,8 +5,7 @@ import { LayoutCameraProps } from "./types"
 import { useVisualElementContext } from "framer-motion"
 import { MotionCanvasContext } from "./MotionCanvasContext"
 import { invariant } from "hey-listen"
-import { calcLength } from "framer-motion"
-import { clamp } from "popmotion"
+import { calcLength, clamp } from "framer-motion"
 
 const calcBoxSize = ({ x, y }: Box) => ({
     width: calcLength(x),

--- a/packages/framer-motion-3d/src/render/gestures/use-tap.ts
+++ b/packages/framer-motion-3d/src/render/gestures/use-tap.ts
@@ -1,11 +1,11 @@
 import { MeshProps } from "@react-three/fiber"
-import { pipe } from "popmotion"
 import { useRef } from "react"
 import {
     addPointerEvent,
     isDragActive,
     wrapHandler,
     AnimationType,
+    pipe,
 } from "framer-motion"
 import type { VisualElement, EventInfo } from "framer-motion"
 import { ThreeMotionProps } from "../../types"

--- a/packages/framer-motion/cypress/integration/layout-shared-lightbox-crossfade-repeated.ts
+++ b/packages/framer-motion/cypress/integration/layout-shared-lightbox-crossfade-repeated.ts
@@ -1,4 +1,4 @@
-import { pipe } from "popmotion"
+import { pipe } from "framer-motion"
 
 interface BoundingBox {
     top: number

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -63,7 +63,6 @@
         "@motionone/dom": "10.13.1",
         "framesync": "6.1.2",
         "hey-listen": "^1.0.8",
-        "popmotion": "11.0.5",
         "style-value-types": "5.1.2",
         "tslib": "2.4.0"
     },

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -72,7 +72,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "29.65 kB"
+            "maxSize": "28.8 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -80,11 +80,11 @@
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "14.9 kB"
+            "maxSize": "14.1 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "25.7 kB"
+            "maxSize": "24.75 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
@@ -92,12 +92,11 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "19.20 kB"
+            "maxSize": "18.3 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "30.9kB"
+            "maxSize": "29.9kB"
         }
-    ],
-    "gitHead": "96dee88b1914347acf154ba5d6772609411de00c"
+    ]
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -72,7 +72,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "28.8 kB"
+            "maxSize": "28.9 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -80,11 +80,11 @@
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "14.1 kB"
+            "maxSize": "14.13 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "24.75 kB"
+            "maxSize": "24.9 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
@@ -92,11 +92,11 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "18.3 kB"
+            "maxSize": "18.4 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "29.9kB"
+            "maxSize": "30kB"
         }
     ]
 }

--- a/packages/framer-motion/src/animation/legacy-popmotion/decay.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/decay.ts
@@ -1,0 +1,37 @@
+import { Animation, AnimationState, DecayOptions } from "./types"
+
+export function decay({
+    velocity = 0,
+    from = 0,
+    power = 0.8,
+    timeConstant = 350,
+    restDelta = 0.5,
+    modifyTarget,
+}: DecayOptions): Animation<number> {
+    /**
+     * This is the Iterator-spec return value. We ensure it's mutable rather than using a generator
+     * to reduce GC during animation.
+     */
+    const state: AnimationState<number> = { done: false, value: from }
+
+    let amplitude = power * velocity
+    const ideal = from + amplitude
+
+    const target = modifyTarget === undefined ? ideal : modifyTarget(ideal)
+
+    /**
+     * If the target has changed we need to re-calculate the amplitude, otherwise
+     * the animation will start from the wrong position.
+     */
+    if (target !== ideal) amplitude = target - from
+
+    return {
+        next: (t: number) => {
+            const delta = -amplitude * Math.exp(-t / timeConstant)
+            state.done = !(delta > restDelta || delta < -restDelta)
+            state.value = state.done ? target : target + delta
+            return state
+        },
+        flipTarget: () => {},
+    }
+}

--- a/packages/framer-motion/src/animation/legacy-popmotion/find-spring.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/find-spring.ts
@@ -1,0 +1,115 @@
+import { warning } from "hey-listen"
+import { clamp } from "../../utils/clamp"
+import { SpringOptions } from "./types"
+
+/**
+ * This is ported from the Framer implementation of duration-based spring resolution.
+ */
+
+type Resolver = (num: number) => number
+
+const safeMin = 0.001
+export const minDuration = 0.01
+export const maxDuration = 10.0
+export const minDamping = 0.05
+export const maxDamping = 1
+
+export function findSpring({
+    duration = 800,
+    bounce = 0.25,
+    velocity = 0,
+    mass = 1,
+}: SpringOptions) {
+    let envelope: Resolver
+    let derivative: Resolver
+
+    warning(
+        duration <= maxDuration * 1000,
+        "Spring duration must be 10 seconds or less"
+    )
+
+    let dampingRatio = 1 - bounce
+
+    /**
+     * Restrict dampingRatio and duration to within acceptable ranges.
+     */
+    dampingRatio = clamp(minDamping, maxDamping, dampingRatio)
+    duration = clamp(minDuration, maxDuration, duration / 1000)
+
+    if (dampingRatio < 1) {
+        /**
+         * Underdamped spring
+         */
+        envelope = (undampedFreq) => {
+            const exponentialDecay = undampedFreq * dampingRatio
+            const delta = exponentialDecay * duration
+            const a = exponentialDecay - velocity
+            const b = calcAngularFreq(undampedFreq, dampingRatio)
+            const c = Math.exp(-delta)
+            return safeMin - (a / b) * c
+        }
+
+        derivative = (undampedFreq) => {
+            const exponentialDecay = undampedFreq * dampingRatio
+            const delta = exponentialDecay * duration
+            const d = delta * velocity + velocity
+            const e =
+                Math.pow(dampingRatio, 2) * Math.pow(undampedFreq, 2) * duration
+            const f = Math.exp(-delta)
+            const g = calcAngularFreq(Math.pow(undampedFreq, 2), dampingRatio)
+            const factor = -envelope(undampedFreq) + safeMin > 0 ? -1 : 1
+            return (factor * ((d - e) * f)) / g
+        }
+    } else {
+        /**
+         * Critically-damped spring
+         */
+        envelope = (undampedFreq) => {
+            const a = Math.exp(-undampedFreq * duration)
+            const b = (undampedFreq - velocity) * duration + 1
+            return -safeMin + a * b
+        }
+
+        derivative = (undampedFreq) => {
+            const a = Math.exp(-undampedFreq * duration)
+            const b = (velocity - undampedFreq) * (duration * duration)
+            return a * b
+        }
+    }
+
+    const initialGuess = 5 / duration
+    const undampedFreq = approximateRoot(envelope, derivative, initialGuess)
+
+    duration = duration * 1000
+    if (isNaN(undampedFreq)) {
+        return {
+            stiffness: 100,
+            damping: 10,
+            duration,
+        }
+    } else {
+        const stiffness = Math.pow(undampedFreq, 2) * mass
+        return {
+            stiffness,
+            damping: dampingRatio * 2 * Math.sqrt(mass * stiffness),
+            duration,
+        }
+    }
+}
+
+const rootIterations = 12
+function approximateRoot(
+    envelope: Resolver,
+    derivative: Resolver,
+    initialGuess: number
+): number {
+    let result = initialGuess
+    for (let i = 1; i < rootIterations; i++) {
+        result = result - envelope(result) / derivative(result)
+    }
+    return result
+}
+
+export function calcAngularFreq(undampedFreq: number, dampingRatio: number) {
+    return undampedFreq * Math.sqrt(1 - dampingRatio * dampingRatio)
+}

--- a/packages/framer-motion/src/animation/legacy-popmotion/index.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/index.ts
@@ -63,7 +63,7 @@ export function animate<V = number>({
     let { to } = options
     let driverControls: DriverControls
     let repeatCount = 0
-    let computedDuration = (options as KeyframeOptions<V>).duration
+    let computedDuration = (options as KeyframeOptions<V>).duration || 0
     let latest: V
     let isComplete = false
     let isForwardPlayback = true

--- a/packages/framer-motion/src/animation/legacy-popmotion/index.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/index.ts
@@ -6,10 +6,11 @@ import {
 } from "./types"
 import { keyframes } from "./keyframes"
 import { spring } from "./spring"
+import { decay } from "./decay"
 import sync, { cancelSync, FrameData } from "framesync"
 import { interpolate } from "../../utils/interpolate"
 
-const types = { keyframes, spring }
+const types = { decay, keyframes, spring }
 
 export function loopElapsed(elapsed: number, duration: number, delay = 0) {
     return elapsed - duration - delay

--- a/packages/framer-motion/src/animation/legacy-popmotion/index.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/index.ts
@@ -1,0 +1,157 @@
+import {
+    AnimationOptions,
+    Driver,
+    DriverControls,
+    KeyframeOptions,
+} from "./types"
+import { keyframes } from "./keyframes"
+import { spring } from "./spring"
+import sync, { cancelSync, FrameData } from "framesync"
+import { interpolate } from "../../utils/interpolate"
+
+const types = { keyframes, spring }
+
+export function loopElapsed(elapsed: number, duration: number, delay = 0) {
+    return elapsed - duration - delay
+}
+
+export function reverseElapsed(
+    elapsed: number,
+    duration: number,
+    delay = 0,
+    isForwardPlayback = true
+) {
+    return isForwardPlayback
+        ? loopElapsed(duration + -elapsed, duration, delay)
+        : duration - (elapsed - duration) + delay
+}
+
+export function hasRepeatDelayElapsed(
+    elapsed: number,
+    duration: number,
+    delay: number,
+    isForwardPlayback: boolean
+) {
+    return isForwardPlayback ? elapsed >= duration + delay : elapsed <= -delay
+}
+
+const framesync: Driver = (update) => {
+    const passTimestamp = ({ delta }: FrameData) => update(delta)
+
+    return {
+        start: () => sync.update(passTimestamp, true),
+        stop: () => cancelSync.update(passTimestamp),
+    }
+}
+
+export function animate<V = number>({
+    from,
+    autoplay = true,
+    driver = framesync,
+    elapsed = 0,
+    repeat: repeatMax = 0,
+    repeatType = "loop",
+    repeatDelay = 0,
+    onPlay,
+    onStop,
+    onComplete,
+    onRepeat,
+    onUpdate,
+    type = "keyframes",
+    ...options
+}: AnimationOptions<V>) {
+    let { to } = options
+    let driverControls: DriverControls
+    let repeatCount = 0
+    let computedDuration = (options as KeyframeOptions<V>).duration
+    let latest: V
+    let isComplete = false
+    let isForwardPlayback = true
+
+    let interpolateFromNumber: (t: number) => V
+
+    const animator = types[type]
+
+    if ((animator as any).needsInterpolation?.(from, to)) {
+        interpolateFromNumber = interpolate([0, 100], [from, to], {
+            clamp: false,
+        }) as (t: number) => V
+        from = 0 as any
+        to = 100 as any
+    }
+
+    const animation = animator({ ...options, from, to } as any)
+
+    function repeat() {
+        repeatCount++
+
+        if (repeatType === "reverse") {
+            isForwardPlayback = repeatCount % 2 === 0
+            elapsed = reverseElapsed(
+                elapsed,
+                computedDuration,
+                repeatDelay,
+                isForwardPlayback
+            )
+        } else {
+            elapsed = loopElapsed(elapsed, computedDuration, repeatDelay)
+            if (repeatType === "mirror") animation.flipTarget()
+        }
+
+        isComplete = false
+        onRepeat && onRepeat()
+    }
+
+    function complete() {
+        driverControls.stop()
+        onComplete && onComplete()
+    }
+
+    function update(delta: number) {
+        if (!isForwardPlayback) delta = -delta
+
+        elapsed += delta
+
+        if (!isComplete) {
+            const state = animation.next(Math.max(0, elapsed))
+            latest = state.value as any
+
+            if (interpolateFromNumber)
+                latest = interpolateFromNumber(latest as any)
+
+            isComplete = isForwardPlayback ? state.done : elapsed <= 0
+        }
+
+        onUpdate?.(latest)
+
+        if (isComplete) {
+            if (repeatCount === 0) computedDuration ??= elapsed
+
+            if (repeatCount < repeatMax) {
+                hasRepeatDelayElapsed(
+                    elapsed,
+                    computedDuration,
+                    repeatDelay,
+                    isForwardPlayback
+                ) && repeat()
+            } else {
+                complete()
+            }
+        }
+    }
+
+    function play() {
+        onPlay?.()
+        driverControls = driver(update)
+        driverControls.start()
+    }
+
+    autoplay && play()
+
+    return {
+        stop: () => {
+            onStop?.()
+            driverControls.stop()
+        },
+    }
+}

--- a/packages/framer-motion/src/animation/legacy-popmotion/inertia.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/inertia.ts
@@ -87,8 +87,9 @@ export function inertia({
             velocity = velocityPerSecond(v - prev, getFrameData().delta)
 
             if (
-                (heading === 1 && v > boundary) ||
-                (heading === -1 && v < boundary)
+                boundary !== undefined &&
+                ((heading === 1 && v > boundary) ||
+                    (heading === -1 && v < boundary))
             ) {
                 startSpring({ from: v, to: boundary, velocity })
             }

--- a/packages/framer-motion/src/animation/legacy-popmotion/inertia.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/inertia.ts
@@ -43,6 +43,7 @@ export function inertia({
         currentAnimation = animate({
             ...options,
             driver,
+            type: "decay",
             onUpdate: (v: number) => {
                 onUpdate?.(v)
                 options.onUpdate?.(v)

--- a/packages/framer-motion/src/animation/legacy-popmotion/inertia.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/inertia.ts
@@ -1,0 +1,112 @@
+import {
+    InertiaOptions,
+    PlaybackControls,
+    AnimationOptions,
+    SpringOptions,
+} from "./types"
+import { animate } from "."
+import { getFrameData } from "framesync"
+import { velocityPerSecond } from "../../utils/velocity-per-second"
+
+export function inertia({
+    from = 0,
+    velocity = 0,
+    min,
+    max,
+    power = 0.8,
+    timeConstant = 750,
+    bounceStiffness = 500,
+    bounceDamping = 10,
+    restDelta = 1,
+    modifyTarget,
+    driver,
+    onUpdate,
+    onComplete,
+    onStop,
+}: InertiaOptions) {
+    let currentAnimation: PlaybackControls
+
+    function isOutOfBounds(v: number) {
+        return (min !== undefined && v < min) || (max !== undefined && v > max)
+    }
+
+    function boundaryNearest(v: number) {
+        if (min === undefined) return max
+        if (max === undefined) return min
+
+        return Math.abs(min - v) < Math.abs(max - v) ? min : max
+    }
+
+    function startAnimation(options: AnimationOptions<number>) {
+        currentAnimation?.stop()
+
+        currentAnimation = animate({
+            ...options,
+            driver,
+            onUpdate: (v: number) => {
+                onUpdate?.(v)
+                options.onUpdate?.(v)
+            },
+            onComplete,
+            onStop,
+        })
+    }
+
+    function startSpring(options: SpringOptions) {
+        startAnimation({
+            type: "spring",
+            stiffness: bounceStiffness,
+            damping: bounceDamping,
+            restDelta,
+            ...options,
+        })
+    }
+
+    if (isOutOfBounds(from)) {
+        // Start the animation with spring if outside the defined boundaries
+        startSpring({ from, velocity, to: boundaryNearest(from) })
+    } else {
+        /**
+         * Or if the value is out of bounds, simulate the inertia movement
+         * with the decay animation.
+         *
+         * Pre-calculate the target so we can detect if it's out-of-bounds.
+         * If it is, we want to check per frame when to switch to a spring
+         * animation
+         */
+        let target = power * velocity + from
+        if (typeof modifyTarget !== "undefined") target = modifyTarget(target)
+        const boundary = boundaryNearest(target)
+        const heading = boundary === min ? -1 : 1
+        let prev: number
+        let current: number
+
+        const checkBoundary = (v: number) => {
+            prev = current
+            current = v
+            velocity = velocityPerSecond(v - prev, getFrameData().delta)
+
+            if (
+                (heading === 1 && v > boundary) ||
+                (heading === -1 && v < boundary)
+            ) {
+                startSpring({ from: v, to: boundary, velocity })
+            }
+        }
+
+        startAnimation({
+            type: "decay",
+            from,
+            velocity,
+            timeConstant,
+            power,
+            restDelta,
+            modifyTarget,
+            onUpdate: isOutOfBounds(target) ? checkBoundary : undefined,
+        })
+    }
+
+    return {
+        stop: () => currentAnimation?.stop(),
+    }
+}

--- a/packages/framer-motion/src/animation/legacy-popmotion/keyframes.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/keyframes.ts
@@ -1,0 +1,73 @@
+import { easeInOut } from "../../../easing/ease"
+import { EasingFunction } from "../../../easing/types"
+import { interpolate } from "../../../utils/interpolate"
+import { Animation, AnimationState, KeyframeOptions } from "../types"
+
+export function defaultEasing(
+    values: any[],
+    easing?: EasingFunction
+): EasingFunction[] {
+    return values.map(() => easing || easeInOut).splice(0, values.length - 1)
+}
+
+export function defaultOffset(values: any[]): number[] {
+    const numValues = values.length
+    return values.map((_value: number, i: number): number =>
+        i !== 0 ? i / (numValues - 1) : 0
+    )
+}
+
+export function convertOffsetToTimes(offset: number[], duration: number) {
+    return offset.map((o) => o * duration)
+}
+
+export function keyframes({
+    from = 0,
+    to = 1,
+    ease,
+    offset,
+    duration = 300,
+}: KeyframeOptions): Animation<number | string> {
+    /**
+     * This is the Iterator-spec return value. We ensure it's mutable rather than using a generator
+     * to reduce GC during animation.
+     */
+    const state: AnimationState<typeof from> = { done: false, value: from }
+
+    /**
+     * Convert values to an array if they've been given as from/to options
+     */
+    const values = Array.isArray(to) ? to : [from, to]
+
+    /**
+     * Create a times array based on the provided 0-1 offsets
+     */
+    const times = convertOffsetToTimes(
+        // Only use the provided offsets if they're the correct length
+        // TODO Maybe we should warn here if there's a length mismatch
+        offset && offset.length === values.length
+            ? offset
+            : defaultOffset(values),
+        duration
+    )
+
+    function createInterpolator() {
+        return interpolate(times, values, {
+            ease: Array.isArray(ease) ? ease : defaultEasing(values, ease),
+        })
+    }
+
+    let interpolator = createInterpolator()
+
+    return {
+        next: (t: number) => {
+            state.value = interpolator(t)
+            state.done = t >= duration
+            return state
+        },
+        flipTarget: () => {
+            values.reverse()
+            interpolator = createInterpolator()
+        },
+    }
+}

--- a/packages/framer-motion/src/animation/legacy-popmotion/keyframes.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/keyframes.ts
@@ -1,7 +1,7 @@
-import { easeInOut } from "../../../easing/ease"
-import { EasingFunction } from "../../../easing/types"
-import { interpolate } from "../../../utils/interpolate"
-import { Animation, AnimationState, KeyframeOptions } from "../types"
+import { easeInOut } from "../../easing/ease"
+import { EasingFunction } from "../../easing/types"
+import { interpolate } from "../../utils/interpolate"
+import { Animation, AnimationState, KeyframeOptions } from "./types"
 
 export function defaultEasing(
     values: any[],

--- a/packages/framer-motion/src/animation/legacy-popmotion/spring.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/spring.ts
@@ -1,0 +1,209 @@
+import type {
+    SpringOptions,
+    PhysicsSpringOptions,
+    Animation,
+    AnimationState,
+} from "./types"
+import { calcAngularFreq, findSpring } from "./find-spring"
+
+const durationKeys = ["duration", "bounce"]
+const physicsKeys = ["stiffness", "damping", "mass"]
+
+function isSpringType(options: SpringOptions, keys: string[]) {
+    return keys.some((key) => (options as any)[key] !== undefined)
+}
+
+function getSpringOptions(options: SpringOptions): PhysicsSpringOptions & {
+    duration?: number
+    isResolvedFromDuration: boolean
+} {
+    let springOptions = {
+        velocity: 0.0,
+        stiffness: 100,
+        damping: 10,
+        mass: 1.0,
+        isResolvedFromDuration: false,
+        ...options,
+    }
+
+    // stiffness/damping/mass overrides duration/bounce
+    if (
+        !isSpringType(options, physicsKeys) &&
+        isSpringType(options, durationKeys)
+    ) {
+        const derived = findSpring(options)
+
+        springOptions = {
+            ...springOptions,
+            ...derived,
+            velocity: 0.0,
+            mass: 1.0,
+        }
+        springOptions.isResolvedFromDuration = true
+    }
+
+    return springOptions
+}
+
+/**
+ * This is based on the spring implementation of Wobble https://github.com/skevy/wobble
+ */
+export function spring({
+    from = 0.0,
+    to = 1.0,
+    restSpeed = 2,
+    restDelta,
+    ...options
+}: SpringOptions): Animation<number> {
+    /**
+     * This is the Iterator-spec return value. We ensure it's mutable rather than using a generator
+     * to reduce GC during animation.
+     */
+    const state: AnimationState<number> = { done: false, value: from }
+
+    let {
+        stiffness,
+        damping,
+        mass,
+        velocity,
+        duration,
+        isResolvedFromDuration,
+    } = getSpringOptions(options)
+
+    let resolveSpring = zero
+    let resolveVelocity = zero
+
+    function createSpring() {
+        const initialVelocity = velocity ? -(velocity / 1000) : 0.0
+        const initialDelta = to - from
+        const dampingRatio = damping / (2 * Math.sqrt(stiffness * mass))
+        const undampedAngularFreq = Math.sqrt(stiffness / mass) / 1000
+
+        /**
+         * If we're working within what looks like a 0-1 range, change the default restDelta
+         * to 0.01
+         */
+        if (restDelta === undefined) {
+            restDelta = Math.min(Math.abs(to - from) / 100, 0.4)
+        }
+
+        if (dampingRatio < 1) {
+            const angularFreq = calcAngularFreq(
+                undampedAngularFreq,
+                dampingRatio
+            )
+
+            // Underdamped spring
+            resolveSpring = (t: number) => {
+                const envelope = Math.exp(
+                    -dampingRatio * undampedAngularFreq * t
+                )
+
+                return (
+                    to -
+                    envelope *
+                        (((initialVelocity +
+                            dampingRatio * undampedAngularFreq * initialDelta) /
+                            angularFreq) *
+                            Math.sin(angularFreq * t) +
+                            initialDelta * Math.cos(angularFreq * t))
+                )
+            }
+
+            resolveVelocity = (t: number) => {
+                // TODO Resolve these calculations with the above
+                const envelope = Math.exp(
+                    -dampingRatio * undampedAngularFreq * t
+                )
+
+                return (
+                    dampingRatio *
+                        undampedAngularFreq *
+                        envelope *
+                        ((Math.sin(angularFreq * t) *
+                            (initialVelocity +
+                                dampingRatio *
+                                    undampedAngularFreq *
+                                    initialDelta)) /
+                            angularFreq +
+                            initialDelta * Math.cos(angularFreq * t)) -
+                    envelope *
+                        (Math.cos(angularFreq * t) *
+                            (initialVelocity +
+                                dampingRatio *
+                                    undampedAngularFreq *
+                                    initialDelta) -
+                            angularFreq *
+                                initialDelta *
+                                Math.sin(angularFreq * t))
+                )
+            }
+        } else if (dampingRatio === 1) {
+            // Critically damped spring
+            resolveSpring = (t: number) =>
+                to -
+                Math.exp(-undampedAngularFreq * t) *
+                    (initialDelta +
+                        (initialVelocity + undampedAngularFreq * initialDelta) *
+                            t)
+        } else {
+            // Overdamped spring
+            const dampedAngularFreq =
+                undampedAngularFreq * Math.sqrt(dampingRatio * dampingRatio - 1)
+
+            resolveSpring = (t: number) => {
+                const envelope = Math.exp(
+                    -dampingRatio * undampedAngularFreq * t
+                )
+
+                // When performing sinh or cosh values can hit Infinity so we cap them here
+                const freqForT = Math.min(dampedAngularFreq * t, 300)
+
+                return (
+                    to -
+                    (envelope *
+                        ((initialVelocity +
+                            dampingRatio * undampedAngularFreq * initialDelta) *
+                            Math.sinh(freqForT) +
+                            dampedAngularFreq *
+                                initialDelta *
+                                Math.cosh(freqForT))) /
+                        dampedAngularFreq
+                )
+            }
+        }
+    }
+
+    createSpring()
+
+    return {
+        next: (t: number) => {
+            const current = resolveSpring(t)
+
+            if (!isResolvedFromDuration) {
+                const currentVelocity = resolveVelocity(t) * 1000
+                const isBelowVelocityThreshold =
+                    Math.abs(currentVelocity) <= restSpeed
+                const isBelowDisplacementThreshold =
+                    Math.abs(to - current) <= restDelta
+                state.done =
+                    isBelowVelocityThreshold && isBelowDisplacementThreshold
+            } else {
+                state.done = t >= duration
+            }
+
+            state.value = state.done ? to : current
+            return state
+        },
+        flipTarget: () => {
+            velocity = -velocity
+            ;[from, to] = [to, from]
+            createSpring()
+        },
+    }
+}
+
+spring.needsInterpolation = (a: any, b: any) =>
+    typeof a === "string" || typeof b === "string"
+
+const zero = (_t: number) => 0

--- a/packages/framer-motion/src/animation/legacy-popmotion/spring.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/spring.ts
@@ -52,7 +52,7 @@ export function spring({
     from = 0.0,
     to = 1.0,
     restSpeed = 2,
-    restDelta,
+    restDelta = 0.01,
     ...options
 }: SpringOptions): Animation<number> {
     /**
@@ -189,7 +189,7 @@ export function spring({
                 state.done =
                     isBelowVelocityThreshold && isBelowDisplacementThreshold
             } else {
-                state.done = t >= duration
+                state.done = t >= duration!
             }
 
             state.value = state.done ? to : current

--- a/packages/framer-motion/src/animation/legacy-popmotion/types.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/types.ts
@@ -77,13 +77,13 @@ export interface DecayOptions {
 }
 
 export interface PhysicsSpringOptions {
-    velocity?: number
-    stiffness?: number
-    damping?: number
-    mass?: number
+    velocity: number
+    stiffness: number
+    damping: number
+    mass: number
 }
 
-export interface SpringOptions extends PhysicsSpringOptions {
+export interface SpringOptions extends Partial<PhysicsSpringOptions> {
     from?: number
     to?: number
     duration?: number

--- a/packages/framer-motion/src/animation/legacy-popmotion/types.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/types.ts
@@ -1,0 +1,109 @@
+import { EasingFunction } from "../../easing/types"
+
+export interface Animation<V> {
+    next: (t: number) => {
+        value: V
+        done: boolean
+    }
+    // TODO Change this mutative approach for a factory
+    flipTarget: () => void
+}
+
+export interface AnimationState<V> {
+    value: V
+    done: boolean
+}
+
+export interface PlaybackControls {
+    stop: () => void
+}
+
+/**
+ * An update function. It accepts a timestamp used to advance the animation.
+ */
+type Update = (timestamp: number) => void
+
+/**
+ * Drivers accept a update function and call it at an interval. This interval
+ * could be a synchronous loop, a setInterval, or tied to the device's framerate.
+ */
+export interface DriverControls {
+    start: () => void
+    stop: () => void
+}
+export type Driver = (update: Update) => DriverControls
+
+/**
+ * Playback options common to all animations.
+ */
+export interface PlaybackOptions<V> {
+    /**
+     * Whether to autoplay the animation when animate is called. If
+     * set to false, the animation must be started manually via the returned
+     * play method.
+     */
+    autoplay?: boolean
+
+    driver?: Driver
+    elapsed?: number
+    from?: V
+    repeat?: number
+    repeatType?: "loop" | "reverse" | "mirror"
+    repeatDelay?: number
+    type?: "spring" | "decay" | "keyframes"
+    onUpdate?: (latest: V) => void
+    onPlay?: () => void
+    onComplete?: () => void
+    onRepeat?: () => void
+    onStop?: () => void
+}
+
+export interface KeyframeOptions<V = number> {
+    to: V | V[]
+    from?: V
+    duration?: number
+    ease?: EasingFunction | EasingFunction[]
+    offset?: number[]
+}
+
+export interface DecayOptions {
+    from?: number
+    to?: number
+    velocity?: number
+    power?: number
+    timeConstant?: number
+    modifyTarget?: (target: number) => number
+    restDelta?: number
+}
+
+export interface PhysicsSpringOptions {
+    velocity?: number
+    stiffness?: number
+    damping?: number
+    mass?: number
+}
+
+export interface SpringOptions extends PhysicsSpringOptions {
+    from?: number
+    to?: number
+    duration?: number
+    bounce?: number
+    restSpeed?: number
+    restDelta?: number
+}
+
+export interface InertiaOptions extends DecayOptions {
+    bounceStiffness?: number
+    bounceDamping?: number
+    min?: number
+    max?: number
+    restSpeed?: number
+    restDelta?: number
+    driver?: Driver
+    onUpdate?: (v: number) => void
+    onComplete?: () => void
+    onStop?: () => void
+}
+
+export type AnimationOptions<V> = PlaybackOptions<V> &
+    (DecayOptions | KeyframeOptions<V> | SpringOptions)

--- a/packages/framer-motion/src/animation/utils/__tests__/easing.test.ts
+++ b/packages/framer-motion/src/animation/utils/__tests__/easing.test.ts
@@ -1,9 +1,12 @@
+import { backIn } from "../../../easing/back"
+import { cubicBezier } from "../../../easing/cubic-bezier"
+import { easeInOut } from "../../../easing/ease"
+import { noop } from "../../../utils/noop"
 import { easingDefinitionToFunction } from "../easing"
-import { linear, cubicBezier, easeInOut, backIn } from "popmotion"
 
 describe("easingDefinitionToFunction", () => {
     test("Maps easing to lookup", () => {
-        expect(easingDefinitionToFunction("linear")).toBe(linear)
+        expect(easingDefinitionToFunction("linear")).toBe(noop)
         expect(easingDefinitionToFunction("easeInOut")).toBe(easeInOut)
         expect(easingDefinitionToFunction("backIn")).toBe(backIn)
         expect(easingDefinitionToFunction(backIn)).toBe(backIn)

--- a/packages/framer-motion/src/animation/utils/__tests__/transitions.test.ts
+++ b/packages/framer-motion/src/animation/utils/__tests__/transitions.test.ts
@@ -12,7 +12,9 @@ import {
     criticallyDampedSpring,
     linearTween,
 } from "../default-transitions"
-import { linear, easeInOut, circIn } from "popmotion"
+import { noop } from "../../../utils/noop"
+import { easeInOut } from "../../../easing/ease"
+import { circIn } from "../../../easing/circ"
 
 describe("isTransitionDefined", () => {
     test("Detects a transition", () => {
@@ -63,7 +65,7 @@ describe("convertTransitionToAnimationOptions", () => {
                 ease: "linear",
             })
         ).toEqual({
-            ease: linear,
+            ease: noop,
             type: "keyframes",
         })
 
@@ -145,7 +147,7 @@ describe("getPopmotionAnimationOptions", () => {
             from: 0,
             to: 1,
             ...linearTween(),
-            ease: linear,
+            ease: noop,
             duration: 300,
         })
 

--- a/packages/framer-motion/src/animation/utils/easing.ts
+++ b/packages/framer-motion/src/animation/utils/easing.ts
@@ -1,25 +1,14 @@
 import { invariant } from "hey-listen"
-import { cubicBezier } from "popmotion"
-import {
-    linear,
-    easeIn,
-    easeInOut,
-    easeOut,
-    circIn,
-    circInOut,
-    circOut,
-    backIn,
-    backInOut,
-    backOut,
-    anticipate,
-    bounceIn,
-    bounceInOut,
-    bounceOut,
-} from "popmotion"
-import { Easing } from "../../types"
+import { cubicBezier } from "../../easing/cubic-bezier"
+import { noop } from "../../utils/noop"
+import { easeIn, easeInOut, easeOut } from "../../easing/ease"
+import { circIn, circInOut, circOut } from "../../easing/circ"
+import { backIn, backInOut, backOut } from "../../easing/back"
+import { anticipate } from "../../easing/anticipate"
+import { Easing } from "../../easing/types"
 
 const easingLookup = {
-    linear,
+    linear: noop,
     easeIn,
     easeInOut,
     easeOut,
@@ -30,9 +19,6 @@ const easingLookup = {
     backInOut,
     backOut,
     anticipate,
-    bounceIn,
-    bounceInOut,
-    bounceOut,
 }
 
 export const easingDefinitionToFunction = (definition: Easing) => {

--- a/packages/framer-motion/src/animation/utils/transitions.ts
+++ b/packages/framer-motion/src/animation/utils/transitions.ts
@@ -3,7 +3,6 @@ import {
     PermissiveTransitionDefinition,
     ResolvedValueTarget,
 } from "../../types"
-import { AnimationOptions, animate, inertia } from "popmotion"
 import { secondsToMilliseconds } from "../../utils/time-conversion"
 import { isEasingArray, easingDefinitionToFunction } from "./easing"
 import { MotionValue } from "../../value"
@@ -14,6 +13,9 @@ import { getAnimatableNone } from "../../render/dom/value-types/animatable-none"
 import { instantAnimationState } from "../../utils/use-instant-transition-state"
 import { resolveFinalValueInKeyframes } from "../../utils/resolve-value"
 import { delay } from "../../utils/delay"
+import { AnimationOptions } from "../legacy-popmotion/types"
+import { inertia } from "../legacy-popmotion/inertia"
+import { animate } from "../legacy-popmotion"
 
 type StopAnimation = { stop: () => void }
 

--- a/packages/framer-motion/src/components/Reorder/utils/check-reorder.ts
+++ b/packages/framer-motion/src/components/Reorder/utils/check-reorder.ts
@@ -1,5 +1,5 @@
-import { mix } from "popmotion"
 import { moveItem } from "../../../utils/array"
+import { mix } from "../../../utils/mix"
 import { ItemData } from "../types"
 
 export function checkReorder<T>(

--- a/packages/framer-motion/src/easing/__tests__/cubic-bezier.test.ts
+++ b/packages/framer-motion/src/easing/__tests__/cubic-bezier.test.ts
@@ -1,0 +1,18 @@
+import { cubicBezier } from "../cubic-bezier"
+
+describe("cubicBezier", () => {
+    test("correctly generates easing functions from curve definitions", () => {
+        const linear = cubicBezier(0, 0, 1, 1)
+        expect(linear(0)).toBe(0)
+        expect(linear(1)).toBe(1)
+        expect(linear(0.5)).toBe(0.5)
+
+        const curve = cubicBezier(0.5, 0.1, 0.31, 0.96)
+        expect(curve(0)).toBe(0)
+        expect(curve(0.01)).toBeCloseTo(0.002, 2)
+        expect(curve(0.25)).toBeCloseTo(0.164, 2)
+        expect(curve(0.75)).toBeCloseTo(0.935, 2)
+        expect(curve(0.99)).toBeCloseTo(0.999, 2)
+        expect(curve(1)).toBe(1)
+    })
+})

--- a/packages/framer-motion/src/easing/anticipate.ts
+++ b/packages/framer-motion/src/easing/anticipate.ts
@@ -1,0 +1,12 @@
+import { createBackIn } from "./back"
+import { EasingFunction } from "./types"
+
+const createAnticipate = (power?: number): EasingFunction => {
+    const backEasing = createBackIn(power)
+    return (p) =>
+        (p *= 2) < 1
+            ? 0.5 * backEasing(p)
+            : 0.5 * (2 - Math.pow(2, -10 * (p - 1)))
+}
+
+export const anticipate = createAnticipate()

--- a/packages/framer-motion/src/easing/back.ts
+++ b/packages/framer-motion/src/easing/back.ts
@@ -1,0 +1,12 @@
+import { mirrorEasing } from "./modifiers/mirror"
+import { reverseEasing } from "./modifiers/reverse"
+import { EasingFunction } from "./types"
+
+export const createBackIn =
+    (power: number = 1.525): EasingFunction =>
+    (p) =>
+        p * p * ((power + 1) * p - power)
+
+export const backIn = createBackIn()
+export const backOut = reverseEasing(backIn)
+export const backInOut = mirrorEasing(backIn)

--- a/packages/framer-motion/src/easing/circ.ts
+++ b/packages/framer-motion/src/easing/circ.ts
@@ -1,0 +1,7 @@
+import { mirrorEasing } from "./modifiers/mirror"
+import { reverseEasing } from "./modifiers/reverse"
+import { EasingFunction } from "./types"
+
+export const circIn: EasingFunction = (p) => 1 - Math.sin(Math.acos(p))
+export const circOut = reverseEasing(circIn)
+export const circInOut = mirrorEasing(circOut)

--- a/packages/framer-motion/src/easing/cubic-bezier.ts
+++ b/packages/framer-motion/src/easing/cubic-bezier.ts
@@ -1,0 +1,70 @@
+/*
+  Bezier function generator
+  This has been modified from Gaëtan Renaudeau's BezierEasing
+  https://github.com/gre/bezier-easing/blob/master/src/index.js
+  https://github.com/gre/bezier-easing/blob/master/LICENSE
+  
+  I've removed the newtonRaphsonIterate algo because in benchmarking it
+  wasn't noticiably faster than binarySubdivision, indeed removing it
+  usually improved times, depending on the curve.
+  I also removed the lookup table, as for the added bundle size and loop we're
+  only cutting ~4 or so subdivision iterations. I bumped the max iterations up
+  to 12 to compensate and this still tended to be faster for no perceivable
+  loss in accuracy.
+  Usage
+    const easeOut = cubicBezier(.17,.67,.83,.67);
+    const x = easeOut(0.5); // returns 0.627...
+*/
+
+import { noop } from "../utils/noop"
+
+// Returns x(t) given t, x1, and x2, or y(t) given t, y1, and y2.
+const calcBezier = (t: number, a1: number, a2: number) =>
+    (((1.0 - 3.0 * a2 + 3.0 * a1) * t + (3.0 * a2 - 6.0 * a1)) * t + 3.0 * a1) *
+    t
+
+const subdivisionPrecision = 0.0000001
+const subdivisionMaxIterations = 12
+
+function binarySubdivide(
+    x: number,
+    lowerBound: number,
+    upperBound: number,
+    mX1: number,
+    mX2: number
+) {
+    let currentX: number
+    let currentT: number
+    let i: number = 0
+
+    do {
+        currentT = lowerBound + (upperBound - lowerBound) / 2.0
+        currentX = calcBezier(currentT, mX1, mX2) - x
+        if (currentX > 0.0) {
+            upperBound = currentT
+        } else {
+            lowerBound = currentT
+        }
+    } while (
+        Math.abs(currentX) > subdivisionPrecision &&
+        ++i < subdivisionMaxIterations
+    )
+
+    return currentT
+}
+
+export function cubicBezier(
+    mX1: number,
+    mY1: number,
+    mX2: number,
+    mY2: number
+) {
+    // If this is a linear gradient, return linear easing
+    if (mX1 === mY1 && mX2 === mY2) return noop
+
+    const getTForX = (aX: number) => binarySubdivide(aX, 0, 1, mX1, mX2)
+
+    // If animation is at start/end, return t without easing
+    return (t: number) =>
+        t === 0 || t === 1 ? t : calcBezier(getTForX(t), mY1, mY2)
+}

--- a/packages/framer-motion/src/easing/ease.ts
+++ b/packages/framer-motion/src/easing/ease.ts
@@ -1,0 +1,6 @@
+import { mirrorEasing } from "./modifiers/mirror"
+import { reverseEasing } from "./modifiers/reverse"
+
+export const easeIn = (p: number) => p * p
+export const easeOut = reverseEasing(easeIn)
+export const easeInOut = mirrorEasing(easeIn)

--- a/packages/framer-motion/src/easing/modifiers/__tests__/mirror.test.ts
+++ b/packages/framer-motion/src/easing/modifiers/__tests__/mirror.test.ts
@@ -1,3 +1,6 @@
+import { mirrorEasing } from "../mirror"
+import { easeIn, easeInOut } from "../../ease"
+
 describe("mirrorEasing", () => {
     test("correctly mirrors an easing curve", () => {
         expect(mirrorEasing(easeIn)(0.25)).toEqual(easeInOut(0.25))

--- a/packages/framer-motion/src/easing/modifiers/__tests__/mirror.test.ts
+++ b/packages/framer-motion/src/easing/modifiers/__tests__/mirror.test.ts
@@ -1,0 +1,6 @@
+describe("mirrorEasing", () => {
+    test("correctly mirrors an easing curve", () => {
+        expect(mirrorEasing(easeIn)(0.25)).toEqual(easeInOut(0.25))
+        expect(mirrorEasing(easeIn)(0.75)).toEqual(easeInOut(0.75))
+    })
+})

--- a/packages/framer-motion/src/easing/modifiers/__tests__/reverse.test.ts
+++ b/packages/framer-motion/src/easing/modifiers/__tests__/reverse.test.ts
@@ -1,0 +1,5 @@
+describe("reverseEasing", () => {
+    test("correctly reverses an easing curve", () => {
+        expect(reverseEasing(easeOut)(0.25)).toEqual(1 - easeOut(0.75))
+    })
+})

--- a/packages/framer-motion/src/easing/modifiers/__tests__/reverse.test.ts
+++ b/packages/framer-motion/src/easing/modifiers/__tests__/reverse.test.ts
@@ -1,3 +1,6 @@
+import { reverseEasing } from "../reverse"
+import { easeOut } from "../../ease"
+
 describe("reverseEasing", () => {
     test("correctly reverses an easing curve", () => {
         expect(reverseEasing(easeOut)(0.25)).toEqual(1 - easeOut(0.75))

--- a/packages/framer-motion/src/easing/modifiers/mirror.ts
+++ b/packages/framer-motion/src/easing/modifiers/mirror.ts
@@ -1,0 +1,7 @@
+// Accepts an easing function and returns a new one that outputs mirrored values for
+
+import { EasingModifier } from "../types"
+
+// the second half of the animation. Turns easeIn into easeInOut.
+export const mirrorEasing: EasingModifier = (easing) => (p) =>
+    p <= 0.5 ? easing(2 * p) / 2 : (2 - easing(2 * (1 - p))) / 2

--- a/packages/framer-motion/src/easing/modifiers/reverse.ts
+++ b/packages/framer-motion/src/easing/modifiers/reverse.ts
@@ -1,0 +1,7 @@
+// Accepts an easing function and returns a new one that outputs reversed values.
+
+import { EasingModifier } from "../types"
+
+// Turns easeIn into easeOut.
+export const reverseEasing: EasingModifier = (easing) => (p) =>
+    1 - easing(1 - p)

--- a/packages/framer-motion/src/easing/types.ts
+++ b/packages/framer-motion/src/easing/types.ts
@@ -1,0 +1,27 @@
+export type EasingFunction = (v: number) => number
+
+export type EasingModifier = (easing: EasingFunction) => EasingFunction
+
+/**
+ * The easing function to use. Set as one of:
+ *
+ * - The name of an in-built easing function.
+ * - An array of four numbers to define a cubic bezier curve.
+ * - An easing function, that accepts and returns a progress value between `0` and `1`.
+ *
+ * @public
+ */
+export type Easing =
+    | [number, number, number, number]
+    | "linear"
+    | "easeIn"
+    | "easeOut"
+    | "easeInOut"
+    | "circIn"
+    | "circOut"
+    | "circInOut"
+    | "backIn"
+    | "backOut"
+    | "backInOut"
+    | "anticipate"
+    | EasingFunction

--- a/packages/framer-motion/src/gestures/PanSession.ts
+++ b/packages/framer-motion/src/gestures/PanSession.ts
@@ -4,8 +4,9 @@ import { extractEventInfo } from "../events/event-info"
 import sync, { getFrameData, cancelSync } from "framesync"
 import { secondsToMilliseconds } from "../utils/time-conversion"
 import { addPointerEvent } from "../events/use-pointer-event"
-import { distance, pipe } from "popmotion"
 import { Point, TransformPoint } from "../projection/geometry/types"
+import { pipe } from "../utils/pipe"
+import { distance2D } from "../utils/distance"
 
 export type AnyPointerEvent = MouseEvent | TouchEvent | PointerEvent
 
@@ -180,7 +181,7 @@ export class PanSession {
         // any larger than this we'll want to reset the pointer history
         // on the first update to avoid visual snapping to the cursoe.
         const isDistancePastThreshold =
-            distance(info.offset, { x: 0, y: 0 }) >= 3
+            distance2D(info.offset, { x: 0, y: 0 }) >= 3
 
         if (!isPanStarted && !isDistancePastThreshold) return
 

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -29,9 +29,9 @@ import {
 } from "../../projection/geometry/conversion"
 import { LayoutUpdateData } from "../../projection/node/types"
 import { addDomEvent } from "../../events/use-dom-event"
-import { mix } from "popmotion"
 import { percent } from "style-value-types"
 import { calcLength } from "../../projection/geometry/delta-calc"
+import { mix } from "../../utils/mix"
 
 export const elementDragControls = new WeakMap<
     VisualElement,

--- a/packages/framer-motion/src/gestures/drag/utils/constraints.ts
+++ b/packages/framer-motion/src/gestures/drag/utils/constraints.ts
@@ -1,4 +1,4 @@
-import { clamp, mix, progress as calcProgress } from "popmotion"
+import { progress as calcProgress } from "../../../utils/progress"
 import { calcLength } from "../../../projection/geometry/delta-calc"
 import {
     Axis,
@@ -6,6 +6,8 @@ import {
     Box,
     Point,
 } from "../../../projection/geometry/types"
+import { clamp } from "../../../utils/clamp"
+import { mix } from "../../../utils/mix"
 import { DragElastic, ResolvedConstraints } from "../types"
 
 /**

--- a/packages/framer-motion/src/gestures/use-tap-gesture.ts
+++ b/packages/framer-motion/src/gestures/use-tap-gesture.ts
@@ -3,10 +3,10 @@ import { EventInfo } from "../events/types"
 import { isNodeOrChild } from "./utils/is-node-or-child"
 import { addPointerEvent, usePointerEvent } from "../events/use-pointer-event"
 import { useUnmountEffect } from "../utils/use-unmount-effect"
-import { pipe } from "popmotion"
 import { AnimationType } from "../render/utils/types"
 import { isDragActive } from "./drag/utils/lock"
 import { FeatureProps } from "../motion/features/types"
+import { pipe } from "../utils/pipe"
 
 /**
  * @param handlers -

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -82,7 +82,12 @@ export { useInstantTransition } from "./utils/use-instant-transition"
 export { useInstantLayoutTransition } from "./projection/use-instant-layout-transition"
 export { useResetProjection } from "./projection/use-reset-projection"
 export { buildTransform } from "./render/html/utils/build-transform"
+export { clamp } from "./utils/clamp"
 export * from "./utils/delay"
+export * from "./utils/distance"
+export { mix } from "./utils/mix"
+export { pipe } from "./utils/pipe"
+export { wrap } from "./utils/wrap"
 
 /**
  * Contexts
@@ -124,7 +129,6 @@ export {
     Keyframes,
     Inertia,
     None,
-    EasingFunction,
     Target,
     TargetAndTransition,
     Transition,
@@ -138,6 +142,7 @@ export {
     Variant,
     Variants,
 } from "./types"
+export * from "./easing/types"
 export { EventInfo } from "./events/types"
 export * from "./motion/features/types"
 export {

--- a/packages/framer-motion/src/motion/__tests__/animated-values.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animated-values.test.tsx
@@ -6,8 +6,9 @@ import {
     useMotionValue,
     useTransform,
 } from "../.."
-import { degreesToRadians } from "popmotion"
 import * as React from "react"
+
+const degreesToRadians = (degrees: number) => (degrees * Math.PI) / 180
 
 describe("values prop", () => {
     test("Performs animations only on motion values provided via values", async () => {

--- a/packages/framer-motion/src/projection/animation/mix-values.ts
+++ b/packages/framer-motion/src/projection/animation/mix-values.ts
@@ -1,7 +1,10 @@
-import { circOut, linear, mix, progress as calcProgress } from "popmotion"
 import { percent, px } from "style-value-types"
+import { circOut } from "../../easing/circ"
+import { EasingFunction } from "../../easing/types"
 import { ResolvedValues } from "../../render/types"
-import { EasingFunction } from "../../types"
+import { progress as calcProgress } from "../../utils/progress"
+import { mix } from "../../utils/mix"
+import { noop } from "../../utils/noop"
 
 const borders = ["TopLeft", "TopRight", "BottomLeft", "BottomRight"]
 const numBorders = borders.length
@@ -114,7 +117,7 @@ function getRadius(values: ResolvedValues, radiusName: string) {
 // }
 
 const easeCrossfadeIn = compress(0, 0.5, circOut)
-const easeCrossfadeOut = compress(0.5, 0.95, linear)
+const easeCrossfadeOut = compress(0.5, 0.95, noop)
 
 function compress(
     min: number,

--- a/packages/framer-motion/src/projection/geometry/delta-apply.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-apply.ts
@@ -1,5 +1,5 @@
-import { mix } from "popmotion"
 import { ResolvedValues } from "../../render/types"
+import { mix } from "../../utils/mix"
 import { IProjectionNode } from "../node/types"
 import { hasTransform } from "../utils/has-transform"
 import { Axis, Box, Delta, Point } from "./types"

--- a/packages/framer-motion/src/projection/geometry/delta-calc.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-calc.ts
@@ -1,5 +1,5 @@
-import { mix } from "popmotion"
 import { ResolvedValues } from "../../render/types"
+import { mix } from "../../utils/mix"
 import { Axis, AxisDelta, Box, Delta } from "./types"
 
 export function calcLength(axis: Axis) {

--- a/packages/framer-motion/src/projection/geometry/delta-remove.ts
+++ b/packages/framer-motion/src/projection/geometry/delta-remove.ts
@@ -1,6 +1,6 @@
-import { mix } from "popmotion"
 import { percent } from "style-value-types"
 import { ResolvedValues } from "../../render/types"
+import { mix } from "../../utils/mix"
 import { scalePoint } from "./delta-apply"
 import { Axis, Box } from "./types"
 

--- a/packages/framer-motion/src/projection/index.ts
+++ b/packages/framer-motion/src/projection/index.ts
@@ -6,7 +6,8 @@ export { calcBoxDelta } from "./geometry/delta-calc"
  * For debugging purposes
  */
 import sync from "framesync"
-import { animate, mix } from "popmotion"
+import { mix } from "../utils/mix"
+import { animate } from "../animation/legacy-popmotion/index"
 export { sync, animate, mix }
 export { buildTransform } from "../render/html/utils/build-transform"
 export { addScaleCorrector } from "./styles/scale-correction"

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1,5 +1,4 @@
 import sync, { cancelSync, flushSync, Process } from "framesync"
-import { mix } from "popmotion"
 import {
     animate,
     AnimationOptions,
@@ -44,6 +43,7 @@ import { resolveMotionValue } from "../../value/utils/resolve-motion-value"
 import { MotionStyle } from "../../motion/types"
 import { globalProjectionState } from "./state"
 import { delay } from "../../utils/delay"
+import { mix } from "../../utils/mix"
 
 const transformAxes = ["", "X", "Y", "Z"]
 

--- a/packages/framer-motion/src/projection/styles/scale-box-shadow.ts
+++ b/packages/framer-motion/src/projection/styles/scale-box-shadow.ts
@@ -1,6 +1,6 @@
-import { mix } from "popmotion"
 import { complex } from "style-value-types"
 import { cssVariableRegex } from "../../render/dom/utils/css-variables-conversion"
+import { mix } from "../../utils/mix"
 import { ScaleCorrectorDefinition } from "./types"
 
 const varToken = "_$css"

--- a/packages/framer-motion/src/types.ts
+++ b/packages/framer-motion/src/types.ts
@@ -1,4 +1,5 @@
 import { CSSProperties, SVGAttributes } from "react"
+import { Easing } from "./easing/types"
 import {
     TransformProperties,
     CustomStyles,
@@ -43,48 +44,6 @@ export type ValueTarget = SingleTarget | KeyframesTarget
  * @public
  */
 export type Props = { [key: string]: any }
-
-/**
- * A function that accepts a progress value between `0` and `1` and returns a
- * new one.
- *
- * ```jsx
- * <motion.div
- *   animate={{ opacity: 0 }}
- *   transition={{
- *     duration: 1,
- *     ease: progress => progress * progress
- *   }}
- * />
- * ```
- *
- * @public
- */
-export type EasingFunction = (v: number) => number
-
-/**
- * The easing function to use. Set as one of:
- *
- * - The name of an in-built easing function.
- * - An array of four numbers to define a cubic bezier curve.
- * - An easing function, that accepts and returns a progress value between `0` and `1`.
- *
- * @public
- */
-export type Easing =
-    | [number, number, number, number]
-    | "linear"
-    | "easeIn"
-    | "easeOut"
-    | "easeInOut"
-    | "circIn"
-    | "circOut"
-    | "circInOut"
-    | "backIn"
-    | "backOut"
-    | "backInOut"
-    | "anticipate"
-    | EasingFunction
 
 /**
  * Options for orchestrating the timing of animations.

--- a/packages/framer-motion/src/utils/__tests__/clamp.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/clamp.test.ts
@@ -1,0 +1,7 @@
+import { clamp } from "../clamp"
+
+test("clamp", () => {
+    expect(clamp(100, 200, 99)).toBe(100)
+    expect(clamp(100, 200, 201)).toBe(200)
+    expect(clamp(100, 200, 150)).toBe(150)
+})

--- a/packages/framer-motion/src/utils/__tests__/distance.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/distance.test.ts
@@ -1,0 +1,21 @@
+import { distance, distance2D } from "../distance"
+
+test("distance", () => {
+    expect(distance(-100, 100)).toBe(200)
+    expect(distance(100, -100)).toBe(200)
+})
+
+test("should return the correct distance between two 2D points", () => {
+    expect(
+        distance2D(
+            {
+                x: 0,
+                y: 0,
+            },
+            {
+                x: 1,
+                y: 1,
+            }
+        )
+    ).toBe(1.4142135623730951)
+})

--- a/packages/framer-motion/src/utils/__tests__/hsla-to-rgba.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/hsla-to-rgba.test.ts
@@ -1,0 +1,14 @@
+import { hslaToRgba } from "../hsla-to-rgba"
+
+describe("hslaToRgba", () => {
+    test("Correctly converts hsla to rgba", () => {
+        expect(
+            hslaToRgba({
+                hue: 190,
+                saturation: 100,
+                lightness: 80,
+                alpha: 1,
+            })
+        ).toEqual({ red: 153, green: 238, blue: 255, alpha: 1 })
+    })
+})

--- a/packages/framer-motion/src/utils/__tests__/interpolate.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/interpolate.test.ts
@@ -1,0 +1,112 @@
+import { interpolate } from "../interpolate"
+
+const invert = (v: number) => -v
+
+test("interpolate numbers", () => {
+    const f = interpolate([0, 100], [0, 1])
+    expect(f(50)).toBe(0.5)
+
+    const s = interpolate([-100, 100, 200], [0, 100, 0])
+    expect(s(-200)).toBe(0)
+    expect(s(0)).toBe(50)
+    expect(s(201)).toBe(0)
+})
+
+test("interpolate - ease", () => {
+    const f = interpolate([0, 100], [0, 100], { ease: invert })
+    expect(f(50)).toBe(-50)
+})
+
+test("interpolate - negative", () => {
+    const f = interpolate([-500, 500], [0, 1])
+    expect(f(-250)).toBe(0.25)
+    const s = interpolate([-500, 500, 600], [0, 1, 2])
+    expect(s(-250)).toBe(0.25)
+})
+
+test("interpolate - out of range", () => {
+    const f = interpolate([0, 100], [200, 100])
+    expect(f(50)).toBe(150)
+    expect(f(150)).toBe(100)
+    expect(f(0)).toBe(200)
+    expect(f(-100)).toBe(200)
+
+    const s = interpolate([0, 100, 200], [100, 200, 100])
+    expect(s(-50)).toBe(100)
+    expect(s(250)).toBe(100)
+})
+
+test("interpolate - unclamped", () => {
+    const f = interpolate([0, 100], [200, 100], { clamp: false })
+    expect(f(50)).toBe(150)
+    expect(f(150)).toBe(50)
+    expect(f(0)).toBe(200)
+    expect(f(-100)).toBe(300)
+
+    const s = interpolate([0, 100, 200], [1, 2, 3], { clamp: false })
+    expect(s(-100)).toBe(0)
+})
+
+test("interpolate - complex", () => {
+    const a = interpolate([0, 100, 200], [1000, 500, 1000])
+    expect(a(100)).toBe(500)
+})
+
+test("interpolate - reverse", () => {
+    const a = interpolate([1000, 0], [500, 600])
+    expect(a(500)).toBe(550)
+    expect(a(1000)).toBe(500)
+    expect(a(0)).toBe(600)
+})
+
+test("interpolate - reverse complex", () => {
+    const a = interpolate([0, 100, 200], [1000, 500, 1000])
+    expect(a(100)).toBe(500)
+    expect(a(0)).toBe(1000)
+    expect(a(200)).toBe(1000)
+})
+
+test("interpolate complex strings", () => {
+    const a = interpolate(
+        [0, 1, 2],
+        [
+            "20px, rgba(0, 0, 0, 0)",
+            "10px, rgba(255, 255, 255, 1)",
+            "40px, rgba(100, 100, 100, 0.5)",
+        ]
+    )
+
+    expect(a(0)).toBe("20px, rgba(0, 0, 0, 0)")
+    expect(a(1.5)).toBe("25px, rgba(194, 194, 194, 0.75)")
+
+    const b = interpolate([0, 1], ["invert(0)", "invert(1)"])
+    expect(b(0.5)).toBe("invert(0.5)")
+})
+
+test("interpolate colors", () => {
+    const a = interpolate([0, 1], ["#000", "#fff"])
+    expect(a(0.5)).toBe("rgba(180, 180, 180, 1)")
+})
+
+test("interpolate objects", () => {
+    const a = interpolate([0, 100], [{ opacity: 0 }, { opacity: 1 }])
+    expect(a(50)).toEqual({ opacity: 0.5 })
+})
+
+test("interpolate arrays", () => {
+    const a = interpolate(
+        [0, 100],
+        [
+            [100, 300],
+            [0, 600],
+        ]
+    )
+    expect(a(50)).toEqual([50, 450])
+})
+
+test("custom mixer", () => {
+    const a = interpolate([0, 1], [0, 1], {
+        mixer: () => () => 42,
+    })
+    expect(a(0.5)).toBe(42)
+})

--- a/packages/framer-motion/src/utils/__tests__/mix-array.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-array.test.ts
@@ -1,0 +1,12 @@
+import { mixArray } from "../mix-complex"
+
+test("mixArray", () => {
+    const a = [0, "100px 0px", "#fff"]
+    const b = [50, "200px 100px", "#000"]
+
+    const blender = mixArray(a, b)
+
+    expect(blender(0)).toEqual([0, "100px 0px", "rgba(255, 255, 255, 1)"])
+    expect(blender(1)).toEqual([50, "200px 100px", "rgba(0, 0, 0, 1)"])
+    expect(blender(0.5)).toEqual([25, "150px 50px", "rgba(180, 180, 180, 1)"])
+})

--- a/packages/framer-motion/src/utils/__tests__/mix-color.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-color.test.ts
@@ -1,0 +1,118 @@
+import { mixColor, mixLinearColor } from "../mix-color"
+
+test("mixColor hex", () => {
+    expect(mixColor("#fff", "#000")(0.5)).toBe("rgba(180, 180, 180, 1)")
+})
+
+test("mixColor rgba", () => {
+    expect(mixColor("rgba(0, 0, 0, 0)", "rgba(255, 255, 255, 1)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("mixColor rgba out of bounds", () => {
+    expect(mixColor("rgba(0, 0, 0, 0)", "rgba(255, 255, 255, 1)")(2)).toBe(
+        "rgba(255, 255, 255, 1)"
+    )
+    expect(mixColor("rgba(0, 0, 0, 0)", "rgba(255, 255, 255, 1)")(-1)).toBe(
+        "rgba(0, 0, 0, 0)"
+    )
+})
+
+test("mixColor rgb", () => {
+    expect(mixColor("rgb(0, 0, 0)", "rgba(255, 255, 255)")(0.5)).toBe(
+        "rgba(180, 180, 180, 1)"
+    )
+})
+
+test("mixColor rgb out of bounds", () => {
+    expect(mixColor("rgb(0, 0, 0)", "rgba(255, 255, 255)")(2)).toBe(
+        "rgba(255, 255, 255, 1)"
+    )
+    expect(mixColor("rgb(0, 0, 0)", "rgba(255, 255, 255)")(-1)).toBe(
+        "rgba(0, 0, 0, 1)"
+    )
+})
+
+test("mixColor hsla", () => {
+    expect(mixColor("hsla(0, 0%, 0%, 0)", "hsla(0, 0%, 100%, 1)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+
+    expect(
+        mixColor(
+            "hsla(177, 37.4978%, 76.66804%, 1)",
+            "hsla(0, 0%, 100%, 1)"
+        )(0.5)
+    ).toBe("rgba(218, 237, 236, 1)")
+})
+
+test("mixColor hsla out of bounds", () => {
+    expect(mixColor("hsla(120, 0%, 0%, 0)", "hsla(360, 100%, 50%, 1)")(2)).toBe(
+        "rgba(255, 0, 0, 1)"
+    )
+    expect(
+        mixColor("hsla(120, 0%, 0%, 0)", "hsla(360, 100%, 50%, 1)")(-1)
+    ).toBe("rgba(0, 0, 0, 0)")
+})
+
+test("mixColor hsl", () => {
+    expect(mixColor("hsl(120, 0%, 0%)", "hsl(360, 100%, 50%)")(0.5)).toBe(
+        "rgba(180, 0, 0, 1)"
+    )
+})
+
+test("mixColor hsl out of bounds", () => {
+    expect(mixColor("hsl(120, 0%, 0%)", "hsl(360, 100%, 50%)")(2)).toBe(
+        "rgba(255, 0, 0, 1)"
+    )
+    expect(mixColor("hsl(120, 0%, 0%)", "hsl(360, 100%, 50%)")(-1)).toBe(
+        "rgba(0, 0, 0, 1)"
+    )
+})
+
+test("mixColor rgb to hex", () => {
+    expect(mixColor("rgb(255, 255, 255)", "#000")(0.5)).toBe(
+        "rgba(180, 180, 180, 1)"
+    )
+})
+
+test("mixColor hsla to rgba", () => {
+    expect(mixColor("hsla(0, 0, 0, 0)", "rgba(255, 255, 255, 1)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("mixColor hsla to hex", () => {
+    expect(mixColor("hsla(0, 0, 0, 0)", "#fff")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("mixColor hex to hsla", () => {
+    expect(mixColor("#fff", "hsla(0, 0, 0, 0)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("mixColor rgba to hsla", () => {
+    expect(mixColor("rgba(255, 255, 255, 1)", "hsla(0, 0, 0, 0)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("mixColor rgba with slash to rgba without", () => {
+    expect(mixColor("rgb(255, 255, 255 / 1)", "rgba(0, 0, 0, 0)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("mixColor rgba with slash (without slash spaces) to rgba without", () => {
+    expect(mixColor("rgb(255 255 255/1)", "rgba(0, 0, 0, 0)")(0.5)).toBe(
+        "rgba(180, 180, 180, 0.5)"
+    )
+})
+
+test("doesn't return NaN", () => {
+    expect(mixLinearColor(255, 0, 2)).not.toBeNaN()
+})

--- a/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
@@ -1,0 +1,40 @@
+import { mixComplex } from "../mix-complex"
+
+test("mixComplex", () => {
+    expect(mixComplex("20px", "10px")(0.5)).toBe("15px")
+    expect(
+        mixComplex(
+            "20px, rgba(0, 0, 0, 0)",
+            "10px, rgba(255, 255, 255, 1)"
+        )(0.5)
+    ).toBe("15px, rgba(180, 180, 180, 0.5)")
+})
+
+test("mixComplex gracefully handles numbers", () => {
+    expect(mixComplex(20, "10")(0.5)).toBe("15")
+})
+
+test("mixComplex errors", () => {
+    expect(mixComplex("hsla(100%, 100, 100, 1)", "#fff")(0)).toBe(
+        "hsla(100%, 100, 100, 1)"
+    )
+    expect(mixComplex("hsla(100%, 100, 100, 1)", "#fff")(0.1)).toBe("#fff")
+})
+
+test("mixComplex can interpolate out-of-order values", () => {
+    expect(mixComplex("#fff 0px 0px", "20px 0px #000")(0.5)).toBe(
+        "10px 0px rgba(180, 180, 180, 1)"
+    )
+})
+
+test("mixComplex can animate from a value-less prop", () => {
+    expect(mixComplex("#fff 0 0px", "20px 0px #000")(0.5)).toBe(
+        "10px 0px rgba(180, 180, 180, 1)"
+    )
+})
+
+test("mixComplex can animate from a value with extra zeros", () => {
+    expect(mixComplex("#fff 0 0px 0px", "20px 0px #000")(0.5)).toBe(
+        "10px 0px rgba(180, 180, 180, 1)"
+    )
+})

--- a/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
@@ -16,9 +16,11 @@ test("mixComplex gracefully handles numbers", () => {
 
 test("mixComplex errors", () => {
     expect(mixComplex("hsla(100%, 100, 100, 1)", "#fff")(0)).toBe(
-        "hsla(100%, 100, 100, 1)"
+        "rgba(255, 255, 255, 1)"
     )
-    expect(mixComplex("hsla(100%, 100, 100, 1)", "#fff")(0.1)).toBe("#fff")
+    expect(mixComplex("hsla(100%, 100, 100, 1)", "#fff")(0.1)).toBe(
+        "rgba(255, 255, 255, 1)"
+    )
 })
 
 test("mixComplex can interpolate out-of-order values", () => {

--- a/packages/framer-motion/src/utils/__tests__/mix-object.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-object.test.ts
@@ -1,0 +1,25 @@
+import { mixObject } from "../mix-complex"
+
+test("mixObject", () => {
+    expect(
+        mixObject(
+            {
+                x: 0,
+                y: "0px",
+                color: "#fff",
+                shadow: "#000 0px 20px 0px",
+            },
+            {
+                x: 100,
+                y: "100px",
+                color: "#000",
+                shadow: "0px 10px #fff",
+            }
+        )(0.5)
+    ).toEqual({
+        x: 50,
+        y: "50px",
+        color: "rgba(180, 180, 180, 1)",
+        shadow: "0px 15px rgba(180, 180, 180, 1)",
+    })
+})

--- a/packages/framer-motion/src/utils/__tests__/mix.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix.test.ts
@@ -1,0 +1,11 @@
+import { mix } from "../mix"
+
+test("mix", () => {
+    expect(mix(0, 1, 0.5)).toBe(0.5)
+    expect(mix(-100, 100, 2)).toBe(300)
+    expect(mix(10, 20, 0.5)).toBe(15)
+    expect(mix(-10, -20, 0.5)).toBe(-15)
+    expect(mix(0, 80, 0.5)).toBe(40)
+    expect(mix(100, 200, 2)).toBe(300)
+    expect(mix(-100, 100, 2)).toBe(300)
+})

--- a/packages/framer-motion/src/utils/__tests__/progress.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/progress.test.ts
@@ -1,0 +1,7 @@
+import { progress } from "../progress"
+
+test("progress", () => {
+    expect(progress(0, 100, 50)).toBe(0.5)
+    expect(progress(100, -100, 50)).toBe(0.25)
+    expect(progress(100, -100, -300)).toBe(2)
+})

--- a/packages/framer-motion/src/utils/__tests__/velocity-per-second.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/velocity-per-second.test.ts
@@ -1,0 +1,6 @@
+import { velocityPerSecond } from "../velocity-per-second"
+
+test("velocityPerSecond", () => {
+    expect(velocityPerSecond(0.835, 16.7)).toBe(50)
+    expect(velocityPerSecond(0.835, 0)).toBe(0)
+})

--- a/packages/framer-motion/src/utils/__tests__/wrap.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/wrap.test.ts
@@ -1,0 +1,8 @@
+import { wrap } from "../wrap"
+
+test("wrap", () => {
+    expect(wrap(-100, 100, -100)).toBe(-100)
+    expect(wrap(-100, 100, 0)).toBe(0)
+    expect(wrap(-100, 100, -200)).toBe(0)
+    expect(wrap(-100, 100, 101)).toBe(-99)
+})

--- a/packages/framer-motion/src/utils/clamp.ts
+++ b/packages/framer-motion/src/utils/clamp.ts
@@ -1,0 +1,2 @@
+export const clamp = (min: number, max: number, v: number) =>
+    Math.min(Math.max(v, min), max)

--- a/packages/framer-motion/src/utils/distance.ts
+++ b/packages/framer-motion/src/utils/distance.ts
@@ -1,0 +1,10 @@
+import { Point } from "../projection/geometry/types"
+
+export const distance = (a: number, b: number) => Math.abs(a - b)
+
+export function distance2D(a: Point, b: Point): number {
+    // Multi-dimensional
+    const xDelta = distance(a.x, b.x)
+    const yDelta = distance(a.y, b.y)
+    return Math.sqrt(xDelta ** 2 + yDelta ** 2)
+}

--- a/packages/framer-motion/src/utils/hsla-to-rgba.ts
+++ b/packages/framer-motion/src/utils/hsla-to-rgba.ts
@@ -1,0 +1,42 @@
+import { HSLA, RGBA } from "style-value-types"
+
+// Adapted from https://gist.github.com/mjackson/5311256
+function hueToRgb(p: number, q: number, t: number) {
+    if (t < 0) t += 1
+    if (t > 1) t -= 1
+    if (t < 1 / 6) return p + (q - p) * 6 * t
+    if (t < 1 / 2) return q
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+    return p
+}
+
+export function hslaToRgba({ hue, saturation, lightness, alpha }: HSLA): RGBA {
+    hue /= 360
+    saturation /= 100
+    lightness /= 100
+
+    let red = 0
+    let green = 0
+    let blue = 0
+
+    if (!saturation) {
+        red = green = blue = lightness
+    } else {
+        const q =
+            lightness < 0.5
+                ? lightness * (1 + saturation)
+                : lightness + saturation - lightness * saturation
+        const p = 2 * lightness - q
+
+        red = hueToRgb(p, q, hue + 1 / 3)
+        green = hueToRgb(p, q, hue)
+        blue = hueToRgb(p, q, hue - 1 / 3)
+    }
+
+    return {
+        red: Math.round(red * 255),
+        green: Math.round(green * 255),
+        blue: Math.round(blue * 255),
+        alpha,
+    }
+}

--- a/packages/framer-motion/src/utils/interpolate.ts
+++ b/packages/framer-motion/src/utils/interpolate.ts
@@ -1,0 +1,125 @@
+import { invariant } from "hey-listen"
+import { color } from "style-value-types"
+import { EasingFunction } from "../easing/types"
+import { clamp } from "./clamp"
+import { mix } from "./mix"
+import { mixColor } from "./mix-color"
+import { mixArray, mixComplex, mixObject } from "./mix-complex"
+import { pipe } from "./pipe"
+import { progress } from "./progress"
+
+type Mix<T> = (v: number) => T
+export type MixerFactory<T> = (from: T, to: T) => Mix<T>
+
+export interface InterpolateOptions<T> {
+    clamp?: boolean
+    ease?: EasingFunction | EasingFunction[]
+    mixer?: MixerFactory<T>
+}
+
+const mixNumber = (from: number, to: number) => (p: number) => mix(from, to, p)
+
+function detectMixerFactory<T>(v: T): MixerFactory<any> {
+    if (typeof v === "number") {
+        return mixNumber
+    } else if (typeof v === "string") {
+        if (color.test(v)) {
+            return mixColor
+        } else {
+            return mixComplex
+        }
+    } else if (Array.isArray(v)) {
+        return mixArray
+    } else if (typeof v === "object") {
+        return mixObject
+    }
+    return mixNumber
+}
+
+function createMixers<T>(
+    output: T[],
+    ease?: EasingFunction | EasingFunction[],
+    customMixer?: MixerFactory<T>
+) {
+    const mixers: Array<Mix<T>> = []
+    const mixerFactory: MixerFactory<T> =
+        customMixer || detectMixerFactory(output[0])
+    const numMixers = output.length - 1
+
+    for (let i = 0; i < numMixers; i++) {
+        let mixer = mixerFactory(output[i], output[i + 1])
+
+        if (ease) {
+            const easingFunction = Array.isArray(ease) ? ease[i] : ease
+            mixer = pipe(easingFunction, mixer) as Mix<T>
+        }
+
+        mixers.push(mixer)
+    }
+
+    return mixers
+}
+
+/**
+ * Create a function that maps from a numerical input array to a generic output array.
+ *
+ * Accepts:
+ *   - Numbers
+ *   - Colors (hex, hsl, hsla, rgb, rgba)
+ *   - Complex (combinations of one or more numbers or strings)
+ *
+ * ```jsx
+ * const mixColor = interpolate([0, 1], ['#fff', '#000'])
+ *
+ * mixColor(0.5) // 'rgba(128, 128, 128, 1)'
+ * ```
+ *
+ * TODO Revist this approach once we've moved to data models for values,
+ * probably not needed to pregenerate mixer functions.
+ *
+ * @public
+ */
+export function interpolate<T>(
+    input: number[],
+    output: T[],
+    { clamp: isClamp = true, ease, mixer }: InterpolateOptions<T> = {}
+) {
+    const inputLength = input.length
+
+    invariant(
+        inputLength === output.length,
+        "Both input and output ranges must be the same length"
+    )
+
+    invariant(
+        !ease || !Array.isArray(ease) || ease.length === inputLength - 1,
+        "Array of easing functions must be of length `input.length - 1`, as it applies to the transitions **between** the defined values."
+    )
+
+    // If input runs highest -> lowest, reverse both arrays
+    if (input[0] > input[inputLength - 1]) {
+        input = [...input].reverse()
+        output = [...output].reverse()
+    }
+
+    const mixers = createMixers(output, ease, mixer)
+    const numMixers = mixers.length
+
+    const interpolator = (t: number): T => {
+        let i = 0
+        if (numMixers) {
+            for (; i < length - 2; i++) {
+                if (t < input[i + 1]) break
+            }
+        }
+
+        const progressInRange = clamp(0, 1, progress(input[i], input[i + 1], t))
+
+        return mixers[i](progressInRange)
+    }
+
+    return isClamp
+        ? (v: number) =>
+              interpolator(clamp(input[0], input[inputLength - 1], v))
+        : interpolator
+}

--- a/packages/framer-motion/src/utils/interpolate.ts
+++ b/packages/framer-motion/src/utils/interpolate.ts
@@ -105,15 +105,15 @@ export function interpolate<T>(
     const mixers = createMixers(output, ease, mixer)
     const numMixers = mixers.length
 
-    const interpolator = (t: number): T => {
+    const interpolator = (v: number): T => {
         let i = 0
-        if (numMixers) {
-            for (; i < length - 2; i++) {
-                if (t < input[i + 1]) break
+        if (numMixers > 1) {
+            for (; i < input.length - 2; i++) {
+                if (v < input[i + 1]) break
             }
         }
 
-        const progressInRange = clamp(0, 1, progress(input[i], input[i + 1], t))
+        const progressInRange = progress(input[i], input[i + 1], v)
 
         return mixers[i](progressInRange)
     }

--- a/packages/framer-motion/src/utils/mix-color.ts
+++ b/packages/framer-motion/src/utils/mix-color.ts
@@ -1,0 +1,48 @@
+import { mix } from "./mix"
+import { hsla, rgba, hex, Color } from "style-value-types"
+import { invariant } from "hey-listen"
+import { hslaToRgba } from "./hsla-to-rgba"
+
+// Linear color space blending
+// Explained https://www.youtube.com/watch?v=LKnqECcg6Gw
+// Demonstrated http://codepen.io/osublake/pen/xGVVaN
+export const mixLinearColor = (from: number, to: number, v: number) => {
+    const fromExpo = from * from
+    return Math.sqrt(Math.max(0, v * (to * to - fromExpo) + fromExpo))
+}
+
+const colorTypes = [hex, rgba, hsla]
+const getColorType = (v: Color | string) =>
+    colorTypes.find((type) => type.test(v))
+
+function asRGBA(color: Color | string) {
+    const type = getColorType(color)
+
+    invariant(
+        Boolean(type),
+        `'${color}' is not an animatable color. Use the equivalent color code instead.`
+    )
+
+    let model = type!.parse(color)
+
+    if (type === hsla) {
+        model = hslaToRgba(model)
+    }
+
+    return model
+}
+
+export const mixColor = (from: Color | string, to: Color | string) => {
+    const fromRGBA = asRGBA(from)
+    const toRGBA = asRGBA(to)
+
+    const blended = { ...fromRGBA }
+
+    return (v: number) => {
+        blended.red = mixLinearColor(fromRGBA.red, toRGBA.red, v)
+        blended.green = mixLinearColor(fromRGBA.green, toRGBA.green, v)
+        blended.blue = mixLinearColor(fromRGBA.blue, toRGBA.blue, v)
+        blended.alpha = mix(fromRGBA.alpha, toRGBA.alpha, v)
+        return rgba.transform!(blended)
+    }
+}

--- a/packages/framer-motion/src/utils/mix-complex.ts
+++ b/packages/framer-motion/src/utils/mix-complex.ts
@@ -1,0 +1,103 @@
+import { color, complex, RGBA, HSLA } from "style-value-types"
+import { mix } from "./mix"
+import { mixColor } from "./mix-color"
+import { pipe } from "./pipe"
+import { warning } from "hey-listen"
+
+type MixComplex = (p: number) => string
+
+type BlendableArray = Array<number | RGBA | HSLA | string>
+type BlendableObject = {
+    [key: string]: string | number | RGBA | HSLA
+}
+
+function getMixer(origin: any, target: any) {
+    if (typeof origin === "number") {
+        return (v: number) => mix(origin, target as number, v)
+    } else if (color.test(origin)) {
+        return mixColor(origin, target as HSLA | RGBA | string)
+    } else {
+        return mixComplex(origin as string, target as string)
+    }
+}
+
+export const mixArray = (from: BlendableArray, to: BlendableArray) => {
+    const output = [...from]
+    const numValues = output.length
+
+    const blendValue = from.map((fromThis, i) => getMixer(fromThis, to[i]))
+
+    return (v: number) => {
+        for (let i = 0; i < numValues; i++) {
+            output[i] = blendValue[i](v)
+        }
+        return output
+    }
+}
+
+export const mixObject = (origin: BlendableObject, target: BlendableObject) => {
+    const output = { ...origin, ...target }
+    const blendValue: { [key: string]: (v: number) => any } = {}
+
+    for (const key in output) {
+        if (origin[key] !== undefined && target[key] !== undefined) {
+            blendValue[key] = getMixer(origin[key], target[key])
+        }
+    }
+
+    return (v: number) => {
+        for (const key in blendValue) {
+            output[key] = blendValue[key](v)
+        }
+        return output
+    }
+}
+
+/**
+ * TODO: Combine with function within complex when style-value-types moved inside Framer Motion
+ */
+function analyse(value: string | number) {
+    const parsed = complex.parse(value)
+    const numValues = parsed.length
+    let numNumbers = 0
+    let numColors = 0
+
+    for (let i = 0; i < numValues; i++) {
+        // Parsed complex values return with colors first, so if we've seen any number
+        // we're already past that part of the array and don't need to continue running typeof
+        if (numNumbers || typeof parsed[i] === "number") {
+            numNumbers++
+        } else {
+            numColors++
+        }
+    }
+
+    return { parsed, numNumbers, numColors }
+}
+
+export const mixComplex = (
+    origin: string | number,
+    target: string | number
+): MixComplex => {
+    const template = complex.createTransformer(target)
+    const originStats = analyse(origin)
+    const targetStats = analyse(target)
+
+    const canInterpolate =
+        originStats.numColors === targetStats.numColors &&
+        originStats.numNumbers >= targetStats.numNumbers
+
+    if (canInterpolate) {
+        return pipe(
+            mixArray(originStats.parsed, targetStats.parsed),
+            template
+        ) as MixComplex
+    } else {
+        warning(
+            true,
+            `Complex values '${origin}' and '${target}' too different to mix. Ensure all colors are of the same type, and that each contains the same quantity of number and color values. Falling back to instant transition.`
+        )
+
+        return (p: number) => `${p > 0 ? target : origin}`
+    }
+}

--- a/packages/framer-motion/src/utils/mix.ts
+++ b/packages/framer-motion/src/utils/mix.ts
@@ -1,0 +1,23 @@
+/*
+  Value in range from progress
+
+  Given a lower limit and an upper limit, we return the value within
+  that range as expressed by progress (usually a number from 0 to 1)
+
+  So progress = 0.5 would change
+
+  from -------- to
+
+  to
+
+  from ---- to
+
+  E.g. from = 10, to = 20, progress = 0.5 => 15
+
+  @param [number]: Lower limit of range
+  @param [number]: Upper limit of range
+  @param [number]: The progress between lower and upper limits expressed 0-1
+  @return [number]: Value as calculated from progress within range (not limited within range)
+*/
+export const mix = (from: number, to: number, progress: number) =>
+    -progress * from + progress * to + from

--- a/packages/framer-motion/src/utils/noop.ts
+++ b/packages/framer-motion/src/utils/noop.ts
@@ -1,3 +1,1 @@
-export function noop<T>(any: T): T {
-    return any
-}
+export const noop = <T>(any: T): T => any

--- a/packages/framer-motion/src/utils/pipe.ts
+++ b/packages/framer-motion/src/utils/pipe.ts
@@ -1,0 +1,10 @@
+/**
+ * Pipe
+ * Compose other transformers to run linearily
+ * pipe(min(20), max(40))
+ * @param  {...functions} transformers
+ * @return {function}
+ */
+const combineFunctions = (a: Function, b: Function) => (v: any) => b(a(v))
+export const pipe = (...transformers: Function[]) =>
+    transformers.reduce(combineFunctions)

--- a/packages/framer-motion/src/utils/progress.ts
+++ b/packages/framer-motion/src/utils/progress.ts
@@ -1,0 +1,17 @@
+/*
+  Progress within given range
+
+  Given a lower limit and an upper limit, we return the progress
+  (expressed as a number 0-1) represented by the given value, and
+  limit that progress to within 0-1.
+
+  @param [number]: Lower limit
+  @param [number]: Upper limit
+  @param [number]: Value to find progress within given range
+  @return [number]: Progress of value within range as expressed 0-1
+*/
+export const progress = (from: number, to: number, value: number) => {
+    const toFromDifference = to - from
+
+    return toFromDifference === 0 ? 1 : (value - from) / toFromDifference
+}

--- a/packages/framer-motion/src/utils/transform.ts
+++ b/packages/framer-motion/src/utils/transform.ts
@@ -1,5 +1,6 @@
-import { interpolate, Easing } from "popmotion"
+import { EasingFunction } from "../easing/types"
 import { CustomValueType } from "../types"
+import { interpolate } from "./interpolate"
 
 /**
  * @public
@@ -19,7 +20,7 @@ export interface TransformOptions<T> {
      *
      * @public
      */
-    ease?: Easing | Easing[]
+    ease?: EasingFunction | EasingFunction[]
 
     /**
      * Provide a function that can interpolate between any two values in the provided range.

--- a/packages/framer-motion/src/utils/use-cycle.ts
+++ b/packages/framer-motion/src/utils/use-cycle.ts
@@ -1,5 +1,5 @@
-import { wrap } from "popmotion"
 import { useCallback, useRef, useState } from "react"
+import { wrap } from "./wrap"
 
 export type Cycle = (i?: number) => void
 

--- a/packages/framer-motion/src/utils/velocity-per-second.ts
+++ b/packages/framer-motion/src/utils/velocity-per-second.ts
@@ -1,0 +1,9 @@
+/*
+  Convert velocity into velocity per second
+
+  @param [number]: Unit per frame
+  @param [number]: Frame duration in ms
+*/
+export function velocityPerSecond(velocity: number, frameDuration: number) {
+    return frameDuration ? velocity * (1000 / frameDuration) : 0
+}

--- a/packages/framer-motion/src/utils/wrap.ts
+++ b/packages/framer-motion/src/utils/wrap.ts
@@ -1,0 +1,4 @@
+export const wrap = (min: number, max: number, v: number) => {
+    const rangeSize = max - min
+    return ((((v - min) % rangeSize) + rangeSize) % rangeSize) + min
+}

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -4,7 +4,7 @@ import { useVelocity } from "../use-velocity"
 import { useMotionValue } from "../use-motion-value"
 import { animate } from "../../animation/animate"
 import sync, { getFrameData } from "framesync"
-import { pipe } from "popmotion"
+import { pipe } from "../../utils/pipe"
 
 const setFrameData = (interval: number, time: number) => {
     const data = getFrameData()

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -1,6 +1,6 @@
 import sync, { getFrameData, FrameData } from "framesync"
-import { velocityPerSecond } from "popmotion"
 import { SubscriptionManager } from "../utils/subscription-manager"
+import { velocityPerSecond } from "../utils/velocity-per-second"
 
 export type Transformer<T> = (v: T) => T
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8002,7 +8002,6 @@ __metadata:
     "@motionone/dom": 10.13.1
     framesync: 6.1.2
     hey-listen: ^1.0.8
-    popmotion: 11.0.5
     style-value-types: 5.1.2
     tslib: 2.4.0
   peerDependencies:


### PR DESCRIPTION
Moving the bits of Popmotion we use into Framer Motion to make way for future performance improvements like
- Replacing string values with data models
- animations -> classes
- Blending in WAAPI animations where possible

In the main, stuff has been brought over without changes, with the exception of `interpolate` and `cubicBezier` which have had size reductions based on my latest version in Motion One
