### PR TITLE
FIX: add more animatable camelcase svg attributes to attr set

### DIFF
--- a/packages/framer-motion/src/render/svg/utils/camel-case-attrs.ts
+++ b/packages/framer-motion/src/render/svg/utils/camel-case-attrs.ts
@@ -22,4 +22,7 @@ export const camelCaseAttributes = new Set([
     "viewBox",
     "gradientTransform",
     "pathLength",
+    "startOffset",
+    "textLength",
+    "lengthAdjust",
 ])


### PR DESCRIPTION
This should resolve [#1152](https://github.com/framer/motion/issues/1152).