### PR TITLE
Adding isPrivate flag to motion values

### DIFF
--- a/packages/framer-motion/cypress/fixtures/appear-tests.json
+++ b/packages/framer-motion/cypress/fixtures/appear-tests.json
@@ -1,0 +1,1 @@
+["interrupt-delay-after.html","interrupt-delay-before.html","interrupt-spring.html","interrupt-tween-opacity.html","interrupt-tween-transforms.html","interrupt-tween-x.html","persist.html"]

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -724,7 +724,7 @@ export abstract class VisualElement<
         let value = this.values.get(key)
 
         if (value === undefined && defaultValue !== undefined) {
-            value = motionValue(defaultValue)
+            value = motionValue(defaultValue, { isPrivate: true })
             this.addValue(key, value)
         }
 

--- a/packages/framer-motion/src/render/utils/motion-values.ts
+++ b/packages/framer-motion/src/render/utils/motion-values.ts
@@ -42,7 +42,7 @@ export function updateMotionValuesFromProps(
              * If we're swapping from a motion value to a static value,
              * create a new motion value from that
              */
-            element.addValue(key, motionValue(nextValue))
+            element.addValue(key, motionValue(nextValue, { isPrivate: true }))
 
             if (isWillChangeMotionValue(willChange)) {
                 willChange.remove(key)

--- a/packages/framer-motion/src/render/utils/setters.ts
+++ b/packages/framer-motion/src/render/utils/setters.ts
@@ -29,7 +29,7 @@ function setMotionValue(
     if (visualElement.hasValue(key)) {
         visualElement.getValue(key)!.set(value)
     } else {
-        visualElement.addValue(key, motionValue(value))
+        visualElement.addValue(key, motionValue(value, { isPrivate: true }))
     }
 }
 

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -16,6 +16,10 @@ export type PassiveEffect<T> = (v: T, safeSetter: (v: T) => void) => void
 
 export type StartAnimation = (complete: () => void) => () => void
 
+export interface MotionValueOptions {
+    isPrivate?: boolean
+}
+
 const isFloat = (value: any): value is string => {
     return !isNaN(parseFloat(value))
 }
@@ -111,6 +115,12 @@ export class MotionValue<V = any> {
     private canTrackVelocity = false
 
     /**
+     * This flag determines whether this MotionValue is privately owned by
+     * a VisualElement and therefore can be considered to have no external listeners.
+     */
+    isPrivate: boolean
+
+    /**
      * @param init - The initiating value
      * @param config - Optional configuration options
      *
@@ -118,9 +128,10 @@ export class MotionValue<V = any> {
      *
      * @internal
      */
-    constructor(init: V) {
+    constructor(init: V, { isPrivate = false }: MotionValueOptions = {}) {
         this.prev = this.current = init
         this.canTrackVelocity = isFloat(this.current)
+        this.isPrivate = isPrivate
     }
 
     /**
@@ -378,6 +389,6 @@ export class MotionValue<V = any> {
     }
 }
 
-export function motionValue<V>(init: V) {
-    return new MotionValue<V>(init)
+export function motionValue<V>(init: V, options?: MotionValueOptions) {
+    return new MotionValue<V>(init, options)
 }


### PR DESCRIPTION
This PR adds an `isPrivate` flag to motion values created within a `VisualElement`.

Private motion values can be considered to have no external listeners, making them safe to animate via WAAPI.