### PR TITLE
Adding support for back/circ easings to WAAPI

### DIFF
--- a/packages/framer-motion/src/animation/waapi/easing.ts
+++ b/packages/framer-motion/src/animation/waapi/easing.ts
@@ -1,19 +1,18 @@
 import { BezierDefinition, EasingDefinition } from "../../easing/types"
-import { camelToDash } from "../../render/dom/utils/camel-to-dash"
 
 export const cubicBezierAsString = ([a, b, c, d]: BezierDefinition) =>
     `cubic-bezier(${a}, ${b}, ${c}, ${d})`
 
-const validWaapiEasing = new Set([
-    "linear",
-    "ease-in",
-    "ease-out",
-    "ease-in-out",
-])
-
-export function mapEasingName(easingName: string): string {
-    const name = camelToDash(easingName)
-    return validWaapiEasing.has(name) ? name : "ease"
+export const supportedWaapiEasing = {
+    linear: "linear",
+    ease: "ease",
+    easeIn: "ease-in",
+    easeOut: "ease-out",
+    easeInOut: "ease-in-out",
+    circIn: cubicBezierAsString([0, 0.65, 0.55, 1]),
+    circOut: cubicBezierAsString([0.55, 0, 1, 0.45]),
+    backIn: cubicBezierAsString([0.31, 0.01, 0.66, -0.59]),
+    backOut: cubicBezierAsString([0.33, 1.53, 0.69, 0.99]),
 }
 
 export function mapEasingToNativeEasing(
@@ -22,5 +21,5 @@ export function mapEasingToNativeEasing(
     if (!easing) return undefined
     return Array.isArray(easing)
         ? cubicBezierAsString(easing)
-        : mapEasingName(easing)
+        : supportedWaapiEasing[easing]
 }

--- a/packages/framer-motion/src/easing/anticipate.ts
+++ b/packages/framer-motion/src/easing/anticipate.ts
@@ -1,12 +1,4 @@
-import { createBackIn } from "./back"
-import { EasingFunction } from "./types"
+import { backIn } from "./back"
 
-const createAnticipate = (power?: number): EasingFunction => {
-    const backEasing = createBackIn(power)
-    return (p) =>
-        (p *= 2) < 1
-            ? 0.5 * backEasing(p)
-            : 0.5 * (2 - Math.pow(2, -10 * (p - 1)))
-}
-
-export const anticipate = createAnticipate()
+export const anticipate = (p: number) =>
+    (p *= 2) < 1 ? 0.5 * backIn(p) : 0.5 * (2 - Math.pow(2, -10 * (p - 1)))

--- a/packages/framer-motion/src/easing/back.ts
+++ b/packages/framer-motion/src/easing/back.ts
@@ -1,12 +1,7 @@
+import { cubicBezier } from "./cubic-bezier"
 import { mirrorEasing } from "./modifiers/mirror"
 import { reverseEasing } from "./modifiers/reverse"
-import { EasingFunction } from "./types"
 
-export const createBackIn =
-    (power: number = 1.525): EasingFunction =>
-    (p) =>
-        p * p * ((power + 1) * p - power)
-
-export const backIn = createBackIn()
-export const backOut = reverseEasing(backIn)
+export const backOut = cubicBezier(0.33, 1.53, 0.69, 0.99)
+export const backIn = reverseEasing(backOut)
 export const backInOut = mirrorEasing(backIn)

--- a/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
@@ -161,11 +161,7 @@ describe("WAAPI animations", () => {
         )
     })
 
-    /**
-     * TODO: Wait for comments and either bump these back to the main thread,
-     * generate keyframes, generate linear() easing, or create similar cubic beziers.
-     */
-    test("Maps remaining easings to 'ease'", () => {
+    test("Maps 'circIn' to 'cubic-bezier(0, 0.65, 0.55, 1)'", () => {
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -173,7 +169,7 @@ describe("WAAPI animations", () => {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{
-                    ease: "anticipate",
+                    ease: "circIn",
                 }}
             />
         )
@@ -184,7 +180,94 @@ describe("WAAPI animations", () => {
         expect(ref.current!.animate).toBeCalledWith(
             { opacity: [0, 1], offset: undefined },
             {
-                easing: "ease",
+                easing: "cubic-bezier(0, 0.65, 0.55, 1)",
+                delay: -0,
+                duration: 0.3,
+                direction: "normal",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+    })
+
+    test("Maps 'circOut' to 'cubic-bezier(0.55, 0, 1, 0.45)'", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                    ease: "circIn",
+                }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            { opacity: [0, 1], offset: undefined },
+            {
+                easing: "cubic-bezier(0.55, 0, 1, 0.45)",
+                delay: -0,
+                duration: 0.3,
+                direction: "normal",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+    })
+
+    test("Maps 'backIn' to 'cubic-bezier(0.31, 0.01, 0.66, -0.59)'", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                    ease: "backIn",
+                }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            { opacity: [0, 1], offset: undefined },
+            {
+                easing: "cubic-bezier(0.31, 0.01, 0.66, -0.59)",
+                delay: -0,
+                duration: 0.3,
+                direction: "normal",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+    })
+
+    test("Maps 'backOut' to 'cubic-bezier(0.33, 1.53, 0.69, 0.99)'", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                    ease: "backOut",
+                }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            { opacity: [0, 1], offset: undefined },
+            {
+                easing: "cubic-bezier(0.33, 1.53, 0.69, 0.99)",
                 delay: -0,
                 duration: 0.3,
                 direction: "normal",
@@ -244,6 +327,70 @@ describe("WAAPI animations", () => {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 0.9 }}
                 transition={{ repeatDelay: 1 }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).not.toBeCalled()
+    })
+
+    test("Doesn't animate with WAAPI if ease is function", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.9 }}
+                transition={{ ease: (v) => v }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).not.toBeCalled()
+    })
+
+    test("Doesn't animate with WAAPI if ease is anticipate", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.9 }}
+                transition={{ ease: "anticipate" }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).not.toBeCalled()
+    })
+
+    test("Doesn't animate with WAAPI if ease is backInOut", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.9 }}
+                transition={{ ease: "backInOut" }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        expect(ref.current!.animate).not.toBeCalled()
+    })
+
+    test("Doesn't animate with WAAPI if ease is circInOut", () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.9 }}
+                transition={{ ease: "circInOut" }}
             />
         )
         const { rerender } = render(<Component />)


### PR DESCRIPTION
WAAPI doesn't support all the same easing functions as Framer Motion.

In this PR we detect easing functions we can approximate with a `cubic-bezier` curve and do so.

For those that we can't approximate, we opt-out.

In the future for remaining easings it will be possible either to generate `linear()` easings in supported browsers (currently none) or perhaps pre-generate keyframes.