### PR TITLE
Added `MotionValue.jump` to immediately set value while resetting animations and velocity 

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -654,7 +654,7 @@ describe("animate prop as variant", () => {
                     visible: {
                         opacity: 1,
                         transition: {
-                            duration: 0.0001,
+                            duration: 0.000001,
                         },
                     },
                 }

--- a/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
@@ -144,7 +144,7 @@ const convertChangedValueTypes = (
     changedKeys.forEach((key) => {
         // Restore styles to their **calculated computed style**, not their actual
         // originally set style. This allows us to animate between equivalent pixel units.
-        const value = visualElement.getValue(key) as MotionValue
+        const value = visualElement.getValue(key)
 
         value.set(origin[key], true)
         target[key] = positionalValues[key](targetBbox, elementComputedStyle)

--- a/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
@@ -146,7 +146,7 @@ const convertChangedValueTypes = (
         // originally set style. This allows us to animate between equivalent pixel units.
         const value = visualElement.getValue(key)
 
-        value.set(origin[key], true)
+        value.jump(origin[key])
         target[key] = positionalValues[key](targetBbox, elementComputedStyle)
     })
 
@@ -252,7 +252,7 @@ const checkAndConvertChangedValueTypes = (
                         ? transitionEnd[key]
                         : target[key]
 
-                value.set(to, true)
+                value.jump(to)
             }
         }
     })

--- a/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
@@ -146,7 +146,7 @@ const convertChangedValueTypes = (
         // originally set style. This allows us to animate between equivalent pixel units.
         const value = visualElement.getValue(key)
 
-        value.jump(origin[key])
+        value && value.jump(origin[key])
         target[key] = positionalValues[key](targetBbox, elementComputedStyle)
     })
 

--- a/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/unit-conversion.ts
@@ -27,13 +27,6 @@ const hasPositionalKey = (target: TargetWithKeyframes) => {
     return Object.keys(target).some(isPositionalKey)
 }
 
-const setAndResetVelocity = (value: MotionValue, to: string | number) => {
-    // Looks odd but setting it twice doesn't render, it'll just
-    // set both prev and current to the latest value
-    value.set(to, false)
-    value.set(to)
-}
-
 const isNumOrPxType = (v?: ValueType): v is ValueType =>
     v === number || v === px
 
@@ -153,7 +146,7 @@ const convertChangedValueTypes = (
         // originally set style. This allows us to animate between equivalent pixel units.
         const value = visualElement.getValue(key) as MotionValue
 
-        setAndResetVelocity(value, origin[key])
+        value.set(origin[key], true)
         target[key] = positionalValues[key](targetBbox, elementComputedStyle)
     })
 
@@ -259,7 +252,7 @@ const checkAndConvertChangedValueTypes = (
                         ? transitionEnd[key]
                         : target[key]
 
-                setAndResetVelocity(value, to)
+                value.set(to, true)
             }
         }
     })

--- a/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
@@ -107,7 +107,7 @@ describe("useSpring", () => {
                 })
 
                 React.useEffect(() => {
-                    y.set(100, true)
+                    y.jump(100)
 
                     setTimeout(() => {
                         resolve(output)

--- a/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
@@ -89,7 +89,7 @@ describe("useSpring", () => {
         expect(resolved).toEqual([0, 2, 4, 7, 10, 14, 19, 24, 29, 34])
     })
 
-    test("will not animate if immediate=true", async () => {
+    test.only("will not animate if immediate=true", async () => {
         const promise = new Promise((resolve) => {
             const output: number[] = []
             const Component = () => {

--- a/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
@@ -89,7 +89,7 @@ describe("useSpring", () => {
         expect(resolved).toEqual([0, 2, 4, 7, 10, 14, 19, 24, 29, 34])
     })
 
-    test.only("will not animate if immediate=true", async () => {
+    test("will not animate if immediate=true", async () => {
         const promise = new Promise((resolve) => {
             const output: number[] = []
             const Component = () => {

--- a/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
@@ -145,27 +145,4 @@ describe("useSpring", () => {
         // Cast to any here as `.events` is private API
         expect((a as any).events.change.getSize()).toBe(1)
     })
-
-    test("can create a motion value from a number", async () => {
-        const promise = new Promise((resolve) => {
-            const Component = () => {
-                const x = useSpring(0)
-
-                React.useEffect(() => {
-                    x.on("change", (v) => resolve(v))
-                    x.set(100)
-                })
-
-                return null
-            }
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        const resolved = await promise
-
-        expect(resolved).not.toBe(0)
-        expect(resolved).not.toBe(100)
-    })
 })

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -231,7 +231,7 @@ export class MotionValue<V = any> {
      * ```
      *
      * @param latest - Latest value to set.
-     * @param render - Whether to notify render subscribers. Defaults to `true`
+     * @param immediate - If `true`, set immediately with zero velocity.
      *
      * @public
      */

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -4,7 +4,6 @@ import { sync } from "../frameloop"
 import type { VisualElement } from "../render/VisualElement"
 import { SubscriptionManager } from "../utils/subscription-manager"
 import { velocityPerSecond } from "../utils/velocity-per-second"
-import { warning } from "hey-listen"
 
 export type Transformer<T> = (v: T) => T
 
@@ -244,21 +243,21 @@ export class MotionValue<V = any> {
         }
     }
 
+    setWithVelocity(prev: V, current: V, delta: number) {
+        this.set(current)
+        this.prev = prev
+        this.timeDelta = delta
+    }
+
     /**
      * Set the state of the `MotionValue`, stopping any active animations,
      * effects, and resets velocity to `0`.
      */
     jump(v: V) {
-        this.set(v)
+        this.updateAndNotify(v)
         this.prev = v
         this.stop()
         if (this.stopPassiveEffect) this.stopPassiveEffect()
-    }
-
-    setWithVelocity(prev: V, current: V, delta: number) {
-        this.set(current)
-        this.prev = prev
-        this.timeDelta = delta
     }
 
     updateAndNotify = (v: V, render = true) => {
@@ -272,7 +271,8 @@ export class MotionValue<V = any> {
             this.lastUpdated = timestamp
             sync.postRender(this.scheduleVelocityCheck)
         }
-
+        console.trace()
+        console.log(this.prev, this.current, this.events.change)
         // Update update subscribers
         if (this.prev !== this.current && this.events.change) {
             this.events.change.notify(this.current)

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -231,21 +231,27 @@ export class MotionValue<V = any> {
      * ```
      *
      * @param latest - Latest value to set.
-     * @param immediate - If `true`, set immediately with zero velocity.
+     * @param render - If `false`, skip rendering.
      *
      * @public
      */
-    set(v: V, immediate = false) {
-        if (immediate || !this.passiveEffect) {
-            this.updateAndNotify(v)
+    set(v: V, render = true) {
+        if (!render || !this.passiveEffect) {
+            this.updateAndNotify(v, render)
         } else {
             this.passiveEffect(v, this.updateAndNotify)
         }
+    }
 
-        if (immediate) {
-            this.prev = v
-            if (this.stopPassiveEffect) this.stopPassiveEffect()
-        }
+    /**
+     * Set the state of the `MotionValue`, stopping any active animations,
+     * effects, and resets velocity to `0`.
+     */
+    jump(v: V) {
+        this.set(v)
+        this.prev = v
+        this.stop()
+        if (this.stopPassiveEffect) this.stopPassiveEffect()
     }
 
     setWithVelocity(prev: V, current: V, delta: number) {
@@ -254,7 +260,7 @@ export class MotionValue<V = any> {
         this.timeDelta = delta
     }
 
-    updateAndNotify = (v: V) => {
+    updateAndNotify = (v: V, render = true) => {
         this.prev = this.current
         this.current = v
 
@@ -277,7 +283,7 @@ export class MotionValue<V = any> {
         }
 
         // Update render subscribers
-        if (this.events.renderRequest) {
+        if (render && this.events.renderRequest) {
             this.events.renderRequest.notify(this.current)
         }
     }

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -4,6 +4,7 @@ import { sync } from "../frameloop"
 import type { VisualElement } from "../render/VisualElement"
 import { SubscriptionManager } from "../utils/subscription-manager"
 import { velocityPerSecond } from "../utils/velocity-per-second"
+import { warning } from "hey-listen"
 
 export type Transformer<T> = (v: T) => T
 

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -232,7 +232,7 @@ export class MotionValue<V = any> {
      * ```
      *
      * @param latest - Latest value to set.
-     * @param render - If `false`, skip rendering.
+     * @param render - Whether to notify render subscribers. Defaults to `true`
      *
      * @public
      */

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -271,8 +271,7 @@ export class MotionValue<V = any> {
             this.lastUpdated = timestamp
             sync.postRender(this.scheduleVelocityCheck)
         }
-        console.trace()
-        console.log(this.prev, this.current, this.events.change)
+
         // Update update subscribers
         if (this.prev !== this.current && this.events.change) {
             this.events.change.notify(this.current)

--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -35,6 +35,12 @@ export function useSpring(
     const activeSpringAnimation = useRef<PlaybackControls | null>(null)
     const value = useMotionValue(isMotionValue(source) ? source.get() : source)
 
+    const stopAnimation = () => {
+        if (activeSpringAnimation.current) {
+            activeSpringAnimation.current.stop()
+        }
+    }
+
     useMemo(() => {
         return value.attach((v, set) => {
             /**
@@ -43,9 +49,7 @@ export function useSpring(
              */
             if (isStatic) return set(v)
 
-            if (activeSpringAnimation.current) {
-                activeSpringAnimation.current.stop()
-            }
+            stopAnimation()
 
             activeSpringAnimation.current = animate({
                 keyframes: [value.get(), v],
@@ -56,7 +60,7 @@ export function useSpring(
             })
 
             return value.get()
-        })
+        }, stopAnimation)
     }, [JSON.stringify(config)])
 
     useIsomorphicLayoutEffect(() => {

--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useContext } from "react"
+import { useRef, useContext, useInsertionEffect } from "react"
 import { MotionValue } from "../value"
 import { isMotionValue } from "./utils/is-motion-value"
 import { useMotionValue } from "./use-motion-value"
@@ -41,7 +41,7 @@ export function useSpring(
         }
     }
 
-    useMemo(() => {
+    useInsertionEffect(() => {
         return value.attach((v, set) => {
             /**
              * A more hollistic approach to this might be to use isStatic to fix VisualElement animations

--- a/yarn.lock
+++ b/yarn.lock
@@ -7909,8 +7909,8 @@ __metadata:
     cache-loader: ^1.2.5
     convert-tsconfig-paths-to-webpack-aliases: ^0.9.2
     fork-ts-checker-webpack-plugin: ^6.2.0
-    framer-motion: ^8.0.3
-    framer-motion-3d: ^8.0.3
+    framer-motion: ^8.0.4
+    framer-motion-3d: ^8.0.4
     path-browserify: ^1.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -7976,14 +7976,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion-3d@^8.0.3, framer-motion-3d@workspace:packages/framer-motion-3d":
+"framer-motion-3d@^8.0.4, framer-motion-3d@workspace:packages/framer-motion-3d":
   version: 0.0.0-use.local
   resolution: "framer-motion-3d@workspace:packages/framer-motion-3d"
   dependencies:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^8.0.3
+    framer-motion: ^8.0.4
     react-merge-refs: ^2.0.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
@@ -7993,7 +7993,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^8.0.3, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^8.0.4, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:


### PR DESCRIPTION
Closes https://github.com/framer/motion/issues/884

This PR adds an `jump` method to `MotionValue`. This sets `MotionValue` in a way that resets `velocity` and any active passive effects (currently only the spring from `useSpring()`)