### PR TITLE
Removing browser-safe `process.env.NODE_ENV`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Undocumented APIs should be considered internal and may change without warning.
 
 ## [8.1.5] 2023-01-03
 
+### Fixed
+
+-   Minification of `process.env`.
+
 ### Changed
 
 -   Display warning in development mode when Reduced Motion is enabled on device.

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -59,6 +59,5 @@
         "@react-three/fiber": "^8.2.2",
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1"
-    },
-    "gitHead": "9b38343d1dfecfc4da4d0fe1440c56a6e5e35c96"
+    }
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -72,32 +72,31 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "29.38 kB"
+            "maxSize": "29.2 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "4.74 kB"
+            "maxSize": "4.73 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "14.62 kB"
+            "maxSize": "14.45 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "25.35 kB"
+            "maxSize": "25.14 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
-            "maxSize": "4.96 kB"
+            "maxSize": "4.93 kB"
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "18.8 kB"
+            "maxSize": "18.51 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "30.35kB"
+            "maxSize": "30.08 kB"
         }
-    ],
-    "gitHead": "9b38343d1dfecfc4da4d0fe1440c56a6e5e35c96"
+    ]
 }

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -8,7 +8,6 @@ import {
     useContext,
 } from "react"
 import * as React from "react"
-import { env } from "../../utils/process"
 import { AnimatePresenceProps } from "./types"
 import { useForceUpdate } from "../../utils/use-force-update"
 import { useIsMounted } from "../../utils/use-is-mounted"
@@ -90,7 +89,9 @@ export const AnimatePresence: React.FunctionComponent<
     // Support deprecated exitBeforeEnter prop
     if (exitBeforeEnter) {
         mode = "wait"
-        warnOnce(false, "Replace exitBeforeEnter with mode='wait'")
+        if (process.env.NODE_ENV !== "production") {
+            warnOnce(false, "Replace exitBeforeEnter with mode='wait'")
+        }
     }
 
     // We want to force a re-render once all exiting animations have finished. We
@@ -242,7 +243,7 @@ export const AnimatePresence: React.FunctionComponent<
     })
 
     if (
-        env !== "production" &&
+        process.env.NODE_ENV !== "production" &&
         mode === "wait" &&
         childrenToRender.length > 1
     ) {

--- a/packages/framer-motion/src/motion/features/viewport/use-viewport.ts
+++ b/packages/framer-motion/src/motion/features/viewport/use-viewport.ts
@@ -1,4 +1,3 @@
-import { env } from "../../../utils/process"
 import { useEffect, useRef } from "react"
 import type { VisualElement } from "../../../render/VisualElement"
 import { AnimationType } from "../../../render/utils/types"
@@ -114,7 +113,7 @@ function useMissingIntersectionObserver(
     useEffect(() => {
         if (!shouldObserve || !fallback) return
 
-        if (env !== "production") {
+        if (process.env.NODE_ENV !== "production") {
             warnOnce(
                 false,
                 "IntersectionObserver not available on this device. whileInView animations will trigger on mount."

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -12,7 +12,6 @@ import { Box } from "../projection/geometry/types"
 import { IProjectionNode } from "../projection/node/types"
 import { TargetAndTransition } from "../types"
 import { isRefObject } from "../utils/is-ref-object"
-import { env } from "../utils/process"
 import { initPrefersReducedMotion } from "../utils/reduced-motion"
 import {
     hasReducedMotionListener,
@@ -392,7 +391,7 @@ export abstract class VisualElement<
                 ? true
                 : prefersReducedMotion.current
 
-        if (env !== "production") {
+        if (process.env.NODE_ENV !== "production") {
             warnOnce(
                 this.shouldReduceMotion !== true,
                 "You have Reduced Motion enabled on your device. Animations may not appear as expected."
@@ -474,7 +473,11 @@ export abstract class VisualElement<
          * If we're in development mode, check to make sure we're not rendering a motion component
          * as a child of LazyMotion, as this will break the file-size benefits of using it.
          */
-        if (env !== "production" && preloadedFeatures && isStrict) {
+        if (
+            process.env.NODE_ENV !== "production" &&
+            preloadedFeatures &&
+            isStrict
+        ) {
             invariant(
                 false,
                 "You have rendered a `motion` component within a `LazyMotion` component. This will break tree shaking. Import and render a `m` component instead."

--- a/packages/framer-motion/src/utils/process.ts
+++ b/packages/framer-motion/src/utils/process.ts
@@ -1,8 +1,0 @@
-/**
- * Browser-safe usage of process
- */
-const defaultEnvironment = "production"
-export const env =
-    typeof process === "undefined" || process.env === undefined
-        ? defaultEnvironment
-        : process.env.NODE_ENV || defaultEnvironment

--- a/packages/framer-motion/src/utils/reduced-motion/use-reduced-motion.ts
+++ b/packages/framer-motion/src/utils/reduced-motion/use-reduced-motion.ts
@@ -1,6 +1,5 @@
 import { useState } from "react"
 import { initPrefersReducedMotion } from "."
-import { env } from "../process"
 import { warnOnce } from "../warn-once"
 import { hasReducedMotionListener, prefersReducedMotion } from "./state"
 
@@ -38,7 +37,7 @@ export function useReducedMotion() {
 
     const [shouldReduceMotion] = useState(prefersReducedMotion.current)
 
-    if (env !== "production") {
+    if (process.env.NODE_ENV !== "production") {
         warnOnce(
             shouldReduceMotion !== true,
             "You have Reduced Motion enabled on your device. Animations may not appear as expected."

--- a/packages/framer-motion/src/value/scroll/use-element-scroll.ts
+++ b/packages/framer-motion/src/value/scroll/use-element-scroll.ts
@@ -6,9 +6,12 @@ import { useScroll } from "../use-scroll"
  * @deprecated useElementScroll is deprecated. Convert to useScroll({ container: ref })
  */
 export function useElementScroll(ref: RefObject<HTMLElement>) {
-    warnOnce(
-        false,
-        "useElementScroll is deprecated. Convert to useScroll({ container: ref })."
-    )
+    if (process.env.NODE_ENV === "development") {
+        warnOnce(
+            false,
+            "useElementScroll is deprecated. Convert to useScroll({ container: ref })."
+        )
+    }
+
     return useScroll({ container: ref })
 }

--- a/packages/framer-motion/src/value/scroll/use-viewport-scroll.ts
+++ b/packages/framer-motion/src/value/scroll/use-viewport-scroll.ts
@@ -5,6 +5,11 @@ import { useScroll } from "../use-scroll"
  * @deprecated useViewportScroll is deprecated. Convert to useScroll()
  */
 export function useViewportScroll() {
-    warnOnce(false, "useViewportScroll is deprecated. Convert to useScroll().")
+    if (process.env.NODE_ENV !== "production") {
+        warnOnce(
+            false,
+            "useViewportScroll is deprecated. Convert to useScroll()."
+        )
+    }
     return useScroll()
 }


### PR DESCRIPTION
This wasn't minifying correctly, meaning development-only error messages end up in production bundles (even though they never display).

Additionally, in https://github.com/framer/motion/blob/main/packages/framer-motion/src/render/utils/motion-values.ts#L34 there has been a `process.env.NODE_ENV` for a while that hasn't generated any error reports for us.