### PR TITLE
Removing ability to start animations within the render function

### DIFF
--- a/packages/framer-motion/src/animation/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/index.test.tsx
@@ -4,7 +4,6 @@ import { useEffect } from "react"
 import { motion } from "../.."
 import { useAnimation } from "../hooks/use-animation"
 import { useMotionValue } from "../../value/use-motion-value"
-import { motionValue } from "../../value"
 
 describe("useAnimation", () => {
     test("animates on mount", async () => {
@@ -20,25 +19,6 @@ describe("useAnimation", () => {
                 useEffect(() => {
                     animation.start({ x: 100 }).then(() => resolve(x.get()))
                 }, [])
-
-                return <motion.div animate={animation} style={{ x }} />
-            }
-
-            const { rerender } = render(<Component />)
-            rerender(<Component />)
-        })
-
-        await expect(promise).resolves.toBe(100)
-    })
-
-    test("doesn't fire a pre-mount animation callback until the animation has finished", async () => {
-        const promise = new Promise((resolve) => {
-            const Component = () => {
-                const animation = useAnimation()
-
-                const x = useMotionValue(0)
-
-                animation.start({ x: 100 }).then(() => resolve(x.get()))
 
                 return <motion.div animate={animation} style={{ x }} />
             }
@@ -291,40 +271,22 @@ describe("useAnimation", () => {
         return await expect(promise).resolves.toEqual("rgba(255, 255, 255, 1)")
     })
 
-    test("animates on mount", () => {
-        const x = motionValue(0)
-        const Component = () => {
-            const controls = useAnimation()
-            const variants = {
-                test: { x: 100 },
-            }
-
-            controls.start("test", { type: false })
-            return (
-                <motion.div
-                    style={{ x }}
-                    variants={variants}
-                    animate={controls}
-                />
-            )
-        }
-        const { rerender } = render(<Component />)
-        rerender(<Component />)
-        expect(x.get()).toBe(100)
-    })
-
     test("accepts array of variants", async () => {
         const promise = new Promise((resolve) => {
             const Component = () => {
                 const animation = useAnimation()
-                animation.start(["a", "b"])
+
+                useEffect(() => {
+                    animation.start(["a", "b"])
+
+                    resolve(true)
+                }, [])
+
                 return <motion.div animate={animation} />
             }
 
             const { rerender } = render(<Component />)
             rerender(<Component />)
-
-            resolve(true)
         })
 
         await expect(promise).resolves.not.toThrowError()

--- a/packages/framer-motion/src/animation/hooks/animation-controls.ts
+++ b/packages/framer-motion/src/animation/hooks/animation-controls.ts
@@ -5,7 +5,7 @@ import {
 } from "../../render/utils/animation"
 import { setValues } from "../../render/utils/setters"
 import type { VisualElement } from "../../render/VisualElement"
-import { AnimationControls, PendingAnimations } from "../types"
+import { AnimationControls } from "../types"
 
 /**
  * @public
@@ -15,12 +15,6 @@ export function animationControls(): AnimationControls {
      * Track whether the host component has mounted.
      */
     let hasMounted = false
-
-    /**
-     * Pending animations that are started before a component is mounted.
-     * TODO: Remove this as animations should only run in effects
-     */
-    const pendingAnimations: PendingAnimations[] = []
 
     /**
      * A collection of linked component animation controls.
@@ -34,31 +28,21 @@ export function animationControls(): AnimationControls {
         },
 
         start(definition, transitionOverride) {
-            /**
-             * TODO: We only perform this hasMounted check because in Framer we used to
-             * encourage the ability to start an animation within the render phase. This
-             * isn't behaviour concurrent-safe so when we make Framer concurrent-safe
-             * we can ditch this.
-             */
-            if (hasMounted) {
-                const animations: Array<Promise<any>> = []
-                subscribers.forEach((visualElement) => {
-                    animations.push(
-                        animateVisualElement(visualElement, definition, {
-                            transitionOverride,
-                        })
-                    )
-                })
+            invariant(
+                hasMounted,
+                "controls.start() should only be called after a component has mounted. Consider calling within a useEffect hook."
+            )
 
-                return Promise.all(animations)
-            } else {
-                return new Promise<void>((resolve) => {
-                    pendingAnimations.push({
-                        animation: [definition, transitionOverride],
-                        resolve,
+            const animations: Array<Promise<any>> = []
+            subscribers.forEach((visualElement) => {
+                animations.push(
+                    animateVisualElement(visualElement, definition, {
+                        transitionOverride,
                     })
-                })
-            }
+                )
+            })
+
+            return Promise.all(animations)
         },
 
         set(definition) {
@@ -80,9 +64,6 @@ export function animationControls(): AnimationControls {
 
         mount() {
             hasMounted = true
-            pendingAnimations.forEach(({ animation, resolve }) => {
-                controls.start(...animation).then(resolve)
-            })
 
             return () => {
                 hasMounted = false

--- a/packages/framer-motion/src/animation/hooks/use-animation.ts
+++ b/packages/framer-motion/src/animation/hooks/use-animation.ts
@@ -1,7 +1,7 @@
 import { animationControls } from "./animation-controls"
 import { AnimationControls } from "../types"
-import { useEffect } from "react"
 import { useConstant } from "../../utils/use-constant"
+import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
 
 /**
  * Creates `AnimationControls`, which can be used to manually start, stop
@@ -35,7 +35,7 @@ import { useConstant } from "../../utils/use-constant"
 export function useAnimationControls(): AnimationControls {
     const controls = useConstant(animationControls)
 
-    useEffect(controls.mount, [])
+    useIsomorphicLayoutEffect(controls.mount, [])
 
     return controls
 }

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -79,14 +79,6 @@ export type ControlsAnimationDefinition =
 /**
  * @public
  */
-export type PendingAnimations = {
-    animation: [ControlsAnimationDefinition, Transition | undefined]
-    resolve: () => void
-}
-
-/**
- * @public
- */
 export interface AnimationControls {
     /**
      * Subscribes a component's animation controls to this.


### PR DESCRIPTION
In the early days of Framer, back before concurrent rendering, people would write code like this

```jsx
function Component() {
  const controls = useAnimationControls()

  controls.start({ x: 100 })
  
  return <motion.div animate={controls} />
}
```

Because it usually worked (even though it was always a poor idea). However now with concurrent rendering, this is likely to break as components can be rendered multiple times, or prospectively with props that don't end up committed to the DOM.

This PR changes the behaviour here so that rather than obfuscating this by saving up pending animations on the initial render, we throw an error.
