### PR TITLE
Allowing `bounce`/`stiffness` spring option combination

### DIFF
--- a/packages/framer-motion/src/animation/legacy-popmotion/__tests__/spring.test.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/__tests__/spring.test.ts
@@ -1,4 +1,4 @@
-import { AnimationOptions } from "../../types"
+import { AnimationOptions, SpringOptions } from "../../types"
 import { spring } from "../spring"
 import { animateSync } from "./utils"
 
@@ -122,20 +122,29 @@ describe("spring", () => {
         expect(noVelocity).not.toEqual(velocity)
     })
 
-    test("Spring defined with bounce and duration is same as just bounce", () => {
-        const settings = {
-            keyframes: [100, 1000],
-            bounce: 0.1,
+    test("Spring defined with bounce should affect dampingRatio", () => {
+        const testBounce = (options: SpringOptions = {}) => {
+            const output = animateSync(
+                spring({
+                    keyframes: [100, 1000],
+                    bounce: 0,
+                    restSpeed: 10,
+                    restDelta: 0.5,
+                    ...options,
+                }),
+                200
+            )
+
+            for (let i = 0; i < output.length; i++) {
+                expect(output[i]).toBeLessThanOrEqual(1000)
+            }
         }
 
-        const withoutDuration = animateSync(spring(settings), 200)
-        const withDuration = animateSync(
-            spring({ ...settings, duration: 800 }),
-            200
-        )
-
-        expect(withoutDuration).toEqual(withDuration)
-        // Check duration order of magnitude is correct
-        expect(withoutDuration.length).toBeGreaterThan(4)
+        testBounce()
+        testBounce({ velocity: 10000 })
+        testBounce({ duration: 1, velocity: 10000 })
+        testBounce({ duration: 1, velocity: 10000, mass: 0.1 })
+        testBounce({ stiffness: 100000 })
+        testBounce({ stiffness: 100000, velocity: 10000, mass: 0.1 })
     })
 })

--- a/packages/framer-motion/src/animation/legacy-popmotion/spring.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/spring.ts
@@ -1,43 +1,8 @@
 import type { Animation, AnimationState } from "./types"
-import { calcAngularFreq, findSpring } from "./find-spring"
+import { calcAngularFreq } from "./utils/find-spring"
+import { getSpringOptions } from "./utils/get-spring-options"
 import { velocityPerSecond } from "../../utils/velocity-per-second"
-import { AnimationOptions, SpringOptions } from "../types"
-
-const durationKeys = ["duration", "bounce"]
-const physicsKeys = ["stiffness", "damping", "mass"]
-
-function isSpringType(options: SpringOptions, keys: string[]) {
-    return keys.some((key) => (options as any)[key] !== undefined)
-}
-
-function getSpringOptions(options: SpringOptions) {
-    let springOptions = {
-        velocity: 0.0,
-        stiffness: 100,
-        damping: 10,
-        mass: 1.0,
-        isResolvedFromDuration: false,
-        ...options,
-    }
-
-    // stiffness/damping/mass overrides duration/bounce
-    if (
-        !isSpringType(options, physicsKeys) &&
-        isSpringType(options, durationKeys)
-    ) {
-        const derived = findSpring(options)
-
-        springOptions = {
-            ...springOptions,
-            ...derived,
-            velocity: 0.0,
-            mass: 1.0,
-        }
-        springOptions.isResolvedFromDuration = true
-    }
-
-    return springOptions
-}
+import { AnimationOptions } from "../types"
 
 const velocitySampleDuration = 5
 

--- a/packages/framer-motion/src/animation/legacy-popmotion/utils/find-spring.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/utils/find-spring.ts
@@ -1,6 +1,6 @@
 import { warning } from "hey-listen"
-import { clamp } from "../../utils/clamp"
-import { SpringOptions } from "../types"
+import { clamp } from "../../../utils/clamp"
+import { SpringOptions } from "../../types"
 
 /**
  * This is ported from the Framer implementation of duration-based spring resolution.

--- a/packages/framer-motion/src/animation/legacy-popmotion/utils/get-spring-options.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/utils/get-spring-options.ts
@@ -1,0 +1,45 @@
+import { SpringOptions } from "../../types"
+import { findSpring } from "./find-spring"
+
+export function getSpringOptions(options: SpringOptions) {
+    let springOptions = {
+        velocity: 0.0,
+        stiffness: 100,
+        damping: 10,
+        mass: 1.0,
+        isResolvedFromDuration: false,
+        ...options,
+    }
+
+    /**
+     * If bounce is defined, resolve some or all spring options
+     */
+    const { duration, bounce } = options
+    if (bounce !== undefined) {
+        if (duration) {
+            /**
+             * If duration is defined, resolve both stiffness and damping.
+             */
+            springOptions = {
+                ...springOptions,
+                ...findSpring(options),
+                isResolvedFromDuration: true,
+            }
+        } else {
+            /**
+             * Otherwise, use bounce to override
+             */
+            springOptions.damping =
+                (1 - bounce) *
+                2 *
+                Math.sqrt(springOptions.mass * springOptions.stiffness)
+        }
+
+        /**
+         * Velocity
+         */
+        springOptions.velocity = 0.0
+    }
+
+    return springOptions
+}

--- a/packages/framer-motion/src/animation/legacy-popmotion/utils/get-spring-options.ts
+++ b/packages/framer-motion/src/animation/legacy-popmotion/utils/get-spring-options.ts
@@ -27,7 +27,7 @@ export function getSpringOptions(options: SpringOptions) {
             }
         } else {
             /**
-             * Otherwise, use bounce to override
+             * Otherwise, use bounce to override just damping.
              */
             springOptions.damping =
                 (1 - bounce) *
@@ -36,7 +36,9 @@ export function getSpringOptions(options: SpringOptions) {
         }
 
         /**
-         * Velocity
+         * Velocity needs to be set as 0 when resolving from bounce. We resolve
+         * dampingRatio from bounce and if this is critically damped (no bounce)
+         * and initial velocity is non-zero, there will still be an unwanted bounce.
          */
         springOptions.velocity = 0.0
     }


### PR DESCRIPTION
Currently, springs can be defined either as `duration`/`bounce` or `stiffness`/`damping`.

The former was introduced as an easier way of defining the physically-based spring options but requires setting a `duration`. It might instead be the case that we want to play instead with strength of the spring (`stiffness`) while maintaining the overall feel of how the spring comes to reset.

Closes https://github.com/framer/motion/issues/1475