### PR TITLE
Accept motion values as children

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -39,7 +39,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 src/motion/__tests__/child-motion-value.test.tsx",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -39,7 +39,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 --detectOpenHandles",
+        "test-client": "jest --config jest.config.json --max-workers=2 src/motion/__tests__/child-motion-value.test.tsx",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
@@ -661,6 +661,7 @@ describe("animate prop as object", () => {
             const Component = () => {
                 const x = useMotionValue(0)
                 useMotionValueEvent(x, "animationStart", fn)
+
                 return (
                     <motion.div
                         animate={{ x: 100 }}

--- a/packages/framer-motion/src/motion/__tests__/child-motion-value.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/child-motion-value.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "../../../jest.setup"
+import * as React from "react"
+import { motion } from "../../render/dom/motion"
+import { motionValue } from "../../value"
+import { sync } from "../../frameloop"
+
+describe("child as motion value", () => {
+    test("accepts motion values as children", async () => {
+        const promise = new Promise<HTMLDivElement>((resolve) => {
+            const child = motionValue(1)
+            const Component = () => <motion.div>{child}</motion.div>
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+            resolve(container.firstChild as HTMLDivElement)
+        })
+
+        return expect(promise).resolves.toHaveTextContent("1")
+    })
+
+    test("updates textContent when motion value changes", async () => {
+        const promise = new Promise<HTMLDivElement>((resolve) => {
+            const child = motionValue(1)
+            const Component = () => <motion.div>{child}</motion.div>
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+
+            sync.postRender(() => {
+                child.set(2)
+
+                sync.postRender(() => {
+                    resolve(container.firstChild as HTMLDivElement)
+                })
+            })
+        })
+
+        return expect(promise).resolves.toHaveTextContent("2")
+    })
+})

--- a/packages/framer-motion/src/motion/__tests__/custom.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/custom.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import { motion } from "../.."
+import { motion, useMotionValue } from "../.."
 import * as React from "react"
 import { RefObject } from "react"
 import { MotionProps } from "../types"
@@ -48,7 +48,10 @@ describe("motion()", () => {
         let animate: any
         let foo: boolean = false
         const BaseComponent = React.forwardRef(
-            (props: Props & MotionProps, ref: RefObject<HTMLDivElement>) => {
+            (
+                props: React.PropsWithChildren<Props & MotionProps>,
+                ref: RefObject<HTMLDivElement>
+            ) => {
                 animate = props.animate
                 foo = props.foo
                 return <div ref={ref} />
@@ -65,5 +68,28 @@ describe("motion()", () => {
 
         expect(animate).toEqual({ x: 100 })
         expect(foo).toBe(true)
+    })
+
+    test("forwards MotionValue children as raw values", () => {
+        let children: number
+        const BaseComponent = React.forwardRef(
+            (
+                props: React.PropsWithChildren<Props & MotionProps>,
+                ref: RefObject<HTMLDivElement>
+            ) => {
+                children = props.children as any
+                return <div ref={ref} />
+            }
+        )
+
+        const MotionComponent = motion<Props>(BaseComponent)
+
+        const Component = () => (
+            <MotionComponent foo>{useMotionValue(5)}</MotionComponent>
+        )
+
+        render(<Component />)
+
+        expect(children!).toEqual(5)
     })
 })

--- a/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { renderToString, renderToStaticMarkup } from "react-dom/server"
-import { motion } from "../../"
+import { motion, useMotionValue } from "../../"
 import { motionValue } from "../../value"
 import { AnimatePresence } from "../../components/AnimatePresence"
 import { Reorder } from "../../components/Reorder"
@@ -167,6 +167,18 @@ function runTests(render: (components: any) => string) {
         expect(div).toBe(
             `<div><div style="z-index:unset;transform:none;-webkit-touch-callout:none;-webkit-user-select:none;user-select:none;touch-action:pan-x" draggable="false"></div></div>`
         )
+    })
+
+    test("renders motion value child", () => {
+        function Component() {
+            const value = useMotionValue(5)
+
+            return <motion.div>{value}</motion.div>
+        }
+
+        const string = render(<Component />)
+
+        expect(string).toBe("<div>5</div>")
     })
 }
 

--- a/packages/framer-motion/src/motion/features/types.ts
+++ b/packages/framer-motion/src/motion/features/types.ts
@@ -69,5 +69,5 @@ export type RenderComponent<Instance, RenderState> = (
     ref: React.Ref<Instance>,
     visualState: VisualState<Instance, RenderState>,
     isStatic: boolean,
-    visualElement?: VisualElement
+    visualElement?: VisualElement<Instance>
 ) => any

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -343,6 +343,8 @@ export interface MotionProps
      * @param values -
      */
     transformValues?<V extends ResolvedValues>(values: V): V
+
+    children?: React.ReactNode | MotionValue<number> | MotionValue<string>
 }
 
 export type TransformTemplate = (

--- a/packages/framer-motion/src/motion/utils/VisualElementHandler.tsx
+++ b/packages/framer-motion/src/motion/utils/VisualElementHandler.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import { MotionConfigProps } from "../.."
+import { MotionConfigContext } from "../../context/MotionConfigContext"
 import type { VisualElement } from "../../render/VisualElement"
 import { MotionProps } from "../types"
 
 interface Props<Instance> {
     visualElement?: VisualElement<Instance>
-    props: MotionProps & MotionConfigProps
+    props: MotionProps & Partial<MotionConfigContext>
 }
 
 export class VisualElementHandler<Instance> extends React.Component<

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -7,14 +7,13 @@ import { CreateVisualElement } from "../../render/types"
 import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
 import { VisualState } from "./use-visual-state"
 import { LazyContext } from "../../context/LazyContext"
-import { MotionConfigProps } from "../../components/MotionConfig"
 import { MotionConfigContext } from "../../context/MotionConfigContext"
 import type { VisualElement } from "../../render/VisualElement"
 
 export function useVisualElement<Instance, RenderState>(
     Component: string | React.ComponentType<React.PropsWithChildren<unknown>>,
     visualState: VisualState<Instance, RenderState>,
-    props: MotionProps & MotionConfigProps,
+    props: MotionProps & Partial<MotionConfigContext>,
     createVisualElement?: CreateVisualElement<Instance>
 ): VisualElement<Instance> | undefined {
     const parent = useVisualElementContext()

--- a/packages/framer-motion/src/render/dom/use-motion-value-child.ts
+++ b/packages/framer-motion/src/render/dom/use-motion-value-child.ts
@@ -1,0 +1,19 @@
+import { useConstant } from "../../utils/use-constant"
+import { useMotionValueEvent } from "../../utils/use-motion-value-event"
+import { MotionValue } from "../../value"
+import type { VisualElement } from "../VisualElement"
+
+export function useMotionValueChild(
+    children: MotionValue<number | string>,
+    visualElement?: VisualElement<HTMLElement | SVGElement>
+) {
+    const render = useConstant(() => children.get())
+
+    useMotionValueEvent(children, "change", (latest) => {
+        if (visualElement && visualElement.current) {
+            visualElement.current.textContent = `${latest}`
+        }
+    })
+
+    return render
+}

--- a/packages/framer-motion/src/render/dom/use-render.ts
+++ b/packages/framer-motion/src/render/dom/use-render.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react"
+import { createElement, useMemo } from "react"
 import { useHTMLProps } from "../html/use-props"
 import { filterProps } from "./utils/filter-props"
 import { isSVGComponent } from "./utils/is-svg-component"
@@ -6,6 +6,7 @@ import { useSVGProps } from "../svg/use-props"
 import { RenderComponent } from "../../motion/features/types"
 import { HTMLRenderState } from "../html/types"
 import { SVGRenderState } from "../svg/types"
+import { isMotionValue } from "../../value/utils/is-motion-value"
 
 export function createUseRender(forwardMotionProps = false) {
     const useRender: RenderComponent<
@@ -33,11 +34,25 @@ export function createUseRender(forwardMotionProps = false) {
             ref,
         }
 
+        /**
+         * If component has been handed a motion value as its child,
+         * memoise its initial value and render that. Subsequent updates
+         * will be handled by the onChange handler
+         */
+        const { children } = props
+        const renderedChildren = useMemo(
+            () => (isMotionValue(children) ? children.get() : children),
+            [children]
+        )
+
         if (projectionId) {
             elementProps["data-projection-id"] = projectionId
         }
 
-        return createElement<any>(Component, elementProps)
+        return createElement<any>(Component, {
+            ...elementProps,
+            children: renderedChildren,
+        })
     }
 
     return useRender


### PR DESCRIPTION
This PR allows `motion` components to accept a `MotionValue` as its child.

When the `MotionValue` updates, its latest value is directly assigned to `element.textContent`, making it straightforward to animate content without triggering React state.

```jsx
const value = useMotionValue(0)

return <motion.span>{value}</motion.span>
```

Fixes https://github.com/framer/motion/issues/1476