### PR TITLE
staggerDirection Api Doc Fix

### DIFF
--- a/packages/framer-motion/src/types.ts
+++ b/packages/framer-motion/src/types.ts
@@ -192,7 +192,7 @@ export interface Orchestration {
      *   show: {
      *     opacity: 1,
      *     transition: {
-     *       delayChildren: 0.5,
+     *       staggerChildren: 0.5,
      *       staggerDirection: -1
      *     }
      *   }


### PR DESCRIPTION
#### Hi team,

I have noticed a small mistake in Api Documentation related to staggerDirection property. delayChildren should be replaced with staggerChildren without that Developers cannot notice the animation of staggerDirection.

#### Before:

![framer1](https://user-images.githubusercontent.com/52135949/211133695-664a6618-53f5-4e17-9664-d04b7e74c846.gif)


#### After:

![framer2](https://user-images.githubusercontent.com/52135949/211133703-1a69a52e-ee84-482a-80d7-6cab32f783be.gif)
