### PR TITLE
Limit dirty node propagation

### DIFF
--- a/dev/examples/layout-stress-limit-propagation.tsx
+++ b/dev/examples/layout-stress-limit-propagation.tsx
@@ -3,15 +3,18 @@ import * as React from "react"
 import { useState } from "react"
 import styled from "styled-components"
 
-const Container = styled.div`
+const Container = styled(motion.div)`
     --width: 200px;
     --height: 200px;
     --offset: 0px;
     width: 1000px;
     height: 4000px;
     overflow: hidden;
+    position: fixed;
+    top: 0;
+    left: 0;
     &.expanded {
-        --width: 500px;
+        width: 500px;
         --offset: 100px;
     }
     .a {
@@ -117,6 +120,7 @@ export const App = () => {
                 onClick={() => {
                     setExpanded(!expanded)
                 }}
+                layout
             >
                 <Group>
                     <Group />

--- a/dev/examples/layout-stress-limit-propagation.tsx
+++ b/dev/examples/layout-stress-limit-propagation.tsx
@@ -1,0 +1,376 @@
+import { motion, MotionConfig } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.div`
+    --width: 200px;
+    --height: 200px;
+    --offset: 0px;
+    width: 1000px;
+    height: 4000px;
+    overflow: hidden;
+    &.expanded {
+        --width: 500px;
+        --offset: 100px;
+    }
+    .a {
+        background-color: hsla(0, 50%, 50%);
+        position: relative;
+        width: var(--width);
+        height: var(--height);
+        display: flex;
+        .a {
+            width: 200px;
+            height: 200px;
+        }
+    }
+    .b {
+        background-color: hsla(20, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+    .c {
+        background-color: hsla(60, 50%, 50%);
+        width: 100px;
+        height: 100px;
+    }
+    .d {
+        background-color: hsla(90, 50%, 50%);
+        width: 100px;
+        height: 100px;
+    }
+    .e {
+        background-color: hsla(120, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+    .f {
+        background-color: hsla(170, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+    .g {
+        background-color: hsla(220, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+    .h {
+        background-color: hsla(260, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+    .i {
+        background-color: hsla(300, 50%, 50%);
+        width: 100px;
+        height: 100px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
+`
+
+function Group({ children }: React.PropsWithChildren) {
+    return (
+        <motion.div layout className="a">
+            <motion.div layout className="b"></motion.div>
+            <motion.div layout className="c"></motion.div>
+            <motion.div layout className="d">
+                {children}
+            </motion.div>
+            <motion.div layout className="e"></motion.div>
+            <motion.div layout className="f">
+                <motion.div layout className="g"></motion.div>
+                <motion.div layout className="h">
+                    <motion.div layout className="i">
+                        {children}
+                    </motion.div>
+                </motion.div>
+            </motion.div>
+        </motion.div>
+    )
+}
+
+export const App = () => {
+    const [expanded, setExpanded] = useState(false)
+
+    return (
+        <MotionConfig transition={{ duration: 2 }}>
+            <Container
+                data-layout
+                className={expanded ? "expanded" : ""}
+                onClick={() => {
+                    setExpanded(!expanded)
+                }}
+            >
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+                <Group>
+                    <Group />
+                </Group>
+            </Container>
+        </MotionConfig>
+    )
+}

--- a/dev/projection/perf-neighbours.html
+++ b/dev/projection/perf-neighbours.html
@@ -1,0 +1,109 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            .box {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+
+            .box.open {
+                height: 200px;
+            }
+
+            .b {
+                width: 50px;
+                height: 50px;
+                background-color: white;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+
+            .c {
+                width: 25px;
+                height: 25px;
+                background-color: #00cc88;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="top" class="box"></div>
+        <div id="bottom" class="box">
+            <div class="b"><div class="c"></div></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+            const duration = 10
+
+            const topEl = document.getElementById("top")
+            const topProjection = createNode(topEl, undefined, {}, { duration })
+
+            const bottom = document.getElementById("bottom")
+            const bottomProjection = createNode(
+                bottom,
+                undefined,
+                {},
+                { duration }
+            )
+
+            const b = document.querySelector(".b")
+            const bProjection = createNode(
+                b,
+                bottomProjection,
+                {},
+                { duration }
+            )
+
+            const c = document.querySelector(".c")
+            const cProjection = createNode(c, bProjection, {}, { duration })
+
+            topProjection.willUpdate()
+            bottomProjection.willUpdate()
+            bProjection.willUpdate()
+            cProjection.willUpdate()
+
+            topEl.classList.add("open")
+
+            topProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(topEl, 2, {
+                        totalNodes: 5,
+                        resolvedTargetDeltas: 3,
+                        recalculatedProjection: 3,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-neighbours.html
+++ b/dev/projection/perf-neighbours.html
@@ -60,7 +60,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
             const duration = 10
 
             const topEl = document.getElementById("top")
@@ -97,7 +97,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(topEl, 2, {
+                    checkFrame(topEl, 2, {
                         totalNodes: 5,
                         resolvedTargetDeltas: 3,
                         recalculatedProjection: 3,

--- a/dev/projection/perf-parent-child-static-grandchild.html
+++ b/dev/projection/perf-parent-child-static-grandchild.html
@@ -1,0 +1,112 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            #parent.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+                display: flex;
+                justify-content: flex-end;
+            }
+
+            .b #child {
+                width: 100px;
+                height: 100px;
+            }
+
+            #grandChild {
+                width: 100px;
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent">
+            <div id="child"><div id="grandChild"></div></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 0.1 }
+            )
+
+            const child = document.getElementById("child")
+            const childProjection = createNode(
+                child,
+                parentProjection,
+                {},
+                { duration: 0.1 }
+            )
+
+            const grandChild = document.getElementById("grandChild")
+            const grandChildProjection = createNode(
+                grandChild,
+                childProjection,
+                {},
+                { duration: 0.1 }
+            )
+
+            parentProjection.willUpdate()
+            childProjection.willUpdate()
+            grandChildProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(parent, 1, {
+                        totalNodes: 4,
+                        resolvedTargetDeltas: 3,
+                        recalculatedProjection: 3,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-parent-child-static-grandchild.html
+++ b/dev/projection/perf-parent-child-static-grandchild.html
@@ -63,7 +63,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const parent = document.getElementById("parent")
             const parentProjection = createNode(
@@ -100,7 +100,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 1, {
+                    checkFrame(parent, 1, {
                         totalNodes: 4,
                         resolvedTargetDeltas: 3,
                         recalculatedProjection: 3,

--- a/dev/projection/perf-parent-child.html
+++ b/dev/projection/perf-parent-child.html
@@ -1,0 +1,96 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            #parent.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+                display: flex;
+                justify-content: flex-end;
+            }
+
+            .b #child {
+                width: 100px;
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent"><div id="child"></div></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 0.1 }
+            )
+
+            const child = document.getElementById("child")
+            const childProjection = createNode(
+                child,
+                parentProjection,
+                {},
+                { duration: 0.1 }
+            )
+
+            parentProjection.willUpdate()
+            childProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(parent, 1, {
+                        totalNodes: 3,
+                        resolvedTargetDeltas: 2,
+                        recalculatedProjection: 2,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-parent-child.html
+++ b/dev/projection/perf-parent-child.html
@@ -56,7 +56,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const parent = document.getElementById("parent")
             const parentProjection = createNode(
@@ -84,7 +84,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 1, {
+                    checkFrame(parent, 1, {
                         totalNodes: 3,
                         resolvedTargetDeltas: 2,
                         recalculatedProjection: 2,

--- a/dev/projection/perf-parent-static-child-static-grandchild.html
+++ b/dev/projection/perf-parent-static-child-static-grandchild.html
@@ -31,6 +31,7 @@
             #grandChild {
                 width: 100px;
                 height: 100px;
+                background-color: black;
             }
 
             #trigger-overflow {
@@ -65,7 +66,7 @@
                 parent,
                 undefined,
                 {},
-                { duration: 0.1 }
+                { duration: 10 }
             )
 
             const child = document.getElementById("child")
@@ -73,7 +74,7 @@
                 child,
                 parentProjection,
                 {},
-                { type: false }
+                { duration: 0.0001 }
             )
 
             const grandChild = document.getElementById("grandChild")
@@ -81,7 +82,7 @@
                 grandChild,
                 childProjection,
                 {},
-                { type: false }
+                { duration: 0.0001 }
             )
 
             parentProjection.willUpdate()
@@ -95,7 +96,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 1, {
+                    checkFrames(parent, 2, {
                         totalNodes: 4,
                         resolvedTargetDeltas: 2,
                         recalculatedProjection: 2,

--- a/dev/projection/perf-parent-static-child-static-grandchild.html
+++ b/dev/projection/perf-parent-static-child-static-grandchild.html
@@ -59,7 +59,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const parent = document.getElementById("parent")
             const parentProjection = createNode(
@@ -96,7 +96,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 2, {
+                    checkFrame(parent, 2, {
                         totalNodes: 4,
                         resolvedTargetDeltas: 2,
                         recalculatedProjection: 2,

--- a/dev/projection/perf-parent-static-child-static-grandchild.html
+++ b/dev/projection/perf-parent-static-child-static-grandchild.html
@@ -1,0 +1,107 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            #parent.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+                display: flex;
+                justify-content: flex-end;
+            }
+
+            #grandChild {
+                width: 100px;
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent">
+            <div id="child"><div id="grandChild"></div></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 0.1 }
+            )
+
+            const child = document.getElementById("child")
+            const childProjection = createNode(
+                child,
+                parentProjection,
+                {},
+                { type: false }
+            )
+
+            const grandChild = document.getElementById("grandChild")
+            const grandChildProjection = createNode(
+                grandChild,
+                childProjection,
+                {},
+                { type: false }
+            )
+
+            parentProjection.willUpdate()
+            childProjection.willUpdate()
+            grandChildProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(parent, 1, {
+                        totalNodes: 4,
+                        resolvedTargetDeltas: 2,
+                        recalculatedProjection: 2,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-shared-deep.html
+++ b/dev/projection/perf-shared-deep.html
@@ -1,0 +1,139 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #a {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #b {
+                width: 200px;
+                height: 200px;
+                background-color: #0077ff;
+                position: absolute;
+                top: 50px;
+                left: 50px;
+            }
+
+            #a-2,
+            #b-2 {
+                width: 50px;
+                height: 50px;
+                background-color: #fff;
+            }
+
+            #a-3,
+            #b-3 {
+                width: 25px;
+                height: 25px;
+                background-color: #000;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="a">
+            <div id="a-2"><div id="a-3"></div></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+            const duration = 10
+
+            const a = document.getElementById("a")
+            const aProjection = createNode(
+                a,
+                undefined,
+                { layoutId: "box" },
+                { duration }
+            )
+            const a2 = document.getElementById("a-2")
+            const a2Projection = createNode(
+                a2,
+                aProjection,
+                { layoutId: "2" },
+                { duration }
+            )
+            const a3 = document.getElementById("a-3")
+            const a3Projection = createNode(
+                a3,
+                a2Projection,
+                { layoutId: "3" },
+                { duration }
+            )
+
+            aProjection.willUpdate()
+            a2Projection.willUpdate()
+            a3Projection.willUpdate()
+
+            const b = document.createElement("div")
+            b.id = "b"
+            document.body.appendChild(b)
+            const bProjection = createNode(
+                b,
+                undefined,
+                { layoutId: "box" },
+                { duration }
+            )
+            const b2 = document.createElement("div")
+            b2.id = "b-2"
+            b.appendChild(b2)
+            const b2Projection = createNode(
+                b2,
+                bProjection,
+                { layoutId: "2" },
+                { duration }
+            )
+            const b3 = document.createElement("div")
+            b3.id = "b-3"
+            b2.appendChild(b3)
+            const b3Projection = createNode(
+                b3,
+                b2Projection,
+                { layoutId: "3" },
+                { duration }
+            )
+
+            aProjection.root.didUpdate()
+
+            /**
+             * Shared element transition nodes are currently all recalculated,
+             * it would be good to investigate in the future if there's further
+             * safe optimisations we can make here.
+             */
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(a, 1, {
+                        totalNodes: 7,
+                        resolvedTargetDeltas: 3,
+                        recalculatedProjection: 6,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-shared-deep.html
+++ b/dev/projection/perf-shared-deep.html
@@ -60,7 +60,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
             const duration = 10
 
             const a = document.getElementById("a")
@@ -127,7 +127,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(a, 1, {
+                    checkFrame(a, 1, {
                         totalNodes: 7,
                         resolvedTargetDeltas: 3,
                         recalculatedProjection: 6,

--- a/dev/projection/perf-shared-single.html
+++ b/dev/projection/perf-shared-single.html
@@ -44,7 +44,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const a = document.getElementById("a")
             const aProjection = createNode(
@@ -71,7 +71,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(a, 1, {
+                    checkFrame(a, 1, {
                         totalNodes: 3,
                         resolvedTargetDeltas: 1, // We only need to resolve a target for the lead node
                         recalculatedProjection: 2, // But recalculate a projection for both

--- a/dev/projection/perf-shared-single.html
+++ b/dev/projection/perf-shared-single.html
@@ -6,31 +6,19 @@
                 margin: 0;
             }
 
-            #parent {
+            #a {
                 width: 100px;
                 height: 100px;
                 background-color: #00cc88;
             }
 
-            #child {
-                width: 50px;
-                height: 50px;
-                background-color: #0077ff;
-            }
-
-            #parent.b {
+            #b {
                 width: 200px;
+                height: 200px;
+                background-color: #0077ff;
                 position: absolute;
-                top: 100px;
-                left: 200px;
-                padding: 20px;
-                display: flex;
-                justify-content: flex-end;
-            }
-
-            .b #child {
-                width: 100px;
-                height: 100px;
+                top: 50px;
+                left: 50px;
             }
 
             #trigger-overflow {
@@ -48,46 +36,45 @@
         </style>
     </head>
     <body>
-        <div id="parent"><div id="child"></div></div>
+        <div id="a"></div>
         <div id="trigger-overflow"></div>
 
         <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
         <script src="./script-assert.js"></script>
         <script src="./script-animate.js"></script>
         <script>
-            const { createNode, relativeEase } = window.Animate
+            const { createNode } = window.Animate
             const { matchViewportBox, checkFrames } = window.Assert
 
-            const parent = document.getElementById("parent")
-            const parentProjection = createNode(
-                parent,
+            const a = document.getElementById("a")
+            const aProjection = createNode(
+                a,
                 undefined,
-                {},
-                { duration: 0.0001 }
-            )
-
-            const child = document.getElementById("child")
-            const childProjection = createNode(
-                child,
-                parentProjection,
-                {},
+                { layoutId: "box" },
                 { duration: 0.1 }
             )
 
-            parentProjection.willUpdate()
-            childProjection.willUpdate()
+            aProjection.willUpdate()
 
-            parent.classList.add("b")
+            const b = document.createElement("b")
+            b.id = "b"
+            document.body.appendChild(b)
+            const bProjection = createNode(
+                b,
+                undefined,
+                { layoutId: "box" },
+                { duration: 0.1 }
+            )
 
-            parentProjection.root.didUpdate()
+            aProjection.root.didUpdate()
 
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 2, {
+                    checkFrames(a, 1, {
                         totalNodes: 3,
-                        resolvedTargetDeltas: 1,
-                        recalculatedProjection: 1,
+                        resolvedTargetDeltas: 1, // We only need to resolve a target for the lead node
+                        recalculatedProjection: 2, // But recalculate a projection for both
                     })
                 })
             })

--- a/dev/projection/perf-single.html
+++ b/dev/projection/perf-single.html
@@ -1,0 +1,88 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            #parent.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+                display: flex;
+                justify-content: flex-end;
+            }
+
+            .b #child {
+                width: 100px;
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent"></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+
+            const parent = document.getElementById("parent")
+
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 0.1 }
+            )
+
+            parentProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(parent, 1, {
+                        totalNodes: 2,
+                        resolvedTargetDeltas: 1,
+                        recalculatedProjection: 1,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-single.html
+++ b/dev/projection/perf-single.html
@@ -56,7 +56,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const parent = document.getElementById("parent")
 
@@ -76,7 +76,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 1, {
+                    checkFrame(parent, 1, {
                         totalNodes: 2,
                         resolvedTargetDeltas: 1,
                         recalculatedProjection: 1,

--- a/dev/projection/perf-static-parent-child-grandchild.html
+++ b/dev/projection/perf-static-parent-child-grandchild.html
@@ -1,0 +1,107 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            #parent.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+                display: flex;
+                justify-content: flex-end;
+            }
+
+            #grandChild {
+                width: 100px;
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent">
+            <div id="child"><div id="grandChild"></div></div>
+        </div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { type: false }
+            )
+
+            const child = document.getElementById("child")
+            const childProjection = createNode(
+                child,
+                parentProjection,
+                {},
+                { duration: 0.1 }
+            )
+
+            const grandChild = document.getElementById("grandChild")
+            const grandChildProjection = createNode(
+                grandChild,
+                childProjection,
+                {},
+                { duration: 0.1 }
+            )
+
+            parentProjection.willUpdate()
+            childProjection.willUpdate()
+            grandChildProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(parent, 1, {
+                        totalNodes: 4,
+                        resolvedTargetDeltas: 2,
+                        recalculatedProjection: 2,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-static-parent-child-grandchild.html
+++ b/dev/projection/perf-static-parent-child-grandchild.html
@@ -31,6 +31,7 @@
             #grandChild {
                 width: 100px;
                 height: 100px;
+                background-color: ;
             }
 
             #trigger-overflow {
@@ -65,7 +66,7 @@
                 parent,
                 undefined,
                 {},
-                { type: false }
+                { duration: 0.0001 }
             )
 
             const child = document.getElementById("child")
@@ -95,7 +96,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 1, {
+                    checkFrames(parent, 2, {
                         totalNodes: 4,
                         resolvedTargetDeltas: 2,
                         recalculatedProjection: 2,

--- a/dev/projection/perf-static-parent-child-grandchild.html
+++ b/dev/projection/perf-static-parent-child-grandchild.html
@@ -59,7 +59,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const parent = document.getElementById("parent")
             const parentProjection = createNode(
@@ -96,7 +96,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 2, {
+                    checkFrame(parent, 2, {
                         totalNodes: 4,
                         resolvedTargetDeltas: 2,
                         recalculatedProjection: 2,

--- a/dev/projection/perf-static-parent-child.html
+++ b/dev/projection/perf-static-parent-child.html
@@ -1,0 +1,96 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                width: 100px;
+                height: 100px;
+                background-color: #00cc88;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            #parent.b {
+                width: 200px;
+                position: absolute;
+                top: 100px;
+                left: 200px;
+                padding: 20px;
+                display: flex;
+                justify-content: flex-end;
+            }
+
+            .b #child {
+                width: 100px;
+                height: 100px;
+            }
+
+            #trigger-overflow {
+                width: 1px;
+                height: 1px;
+                position: absolute;
+                top: 2000px;
+                left: 2000px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent"><div id="child"></div></div>
+        <div id="trigger-overflow"></div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox, checkFrames } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { type: false }
+            )
+
+            const child = document.getElementById("child")
+            const childProjection = createNode(
+                child,
+                parentProjection,
+                {},
+                { duration: 0.1 }
+            )
+
+            parentProjection.willUpdate()
+            childProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    console.log(window.ProjectionFrames)
+                    checkFrames(parent, 1, {
+                        totalNodes: 3,
+                        resolvedTargetDeltas: 1,
+                        recalculatedProjection: 1,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/perf-static-parent-child.html
+++ b/dev/projection/perf-static-parent-child.html
@@ -56,7 +56,7 @@
         <script src="./script-animate.js"></script>
         <script>
             const { createNode, relativeEase } = window.Animate
-            const { matchViewportBox, checkFrames } = window.Assert
+            const { matchViewportBox, checkFrame } = window.Assert
 
             const parent = document.getElementById("parent")
             const parentProjection = createNode(
@@ -84,7 +84,7 @@
             requestAnimationFrame(() => {
                 requestAnimationFrame(() => {
                     console.log(window.ProjectionFrames)
-                    checkFrames(parent, 2, {
+                    checkFrame(parent, 2, {
                         totalNodes: 3,
                         resolvedTargetDeltas: 1,
                         recalculatedProjection: 1,

--- a/dev/projection/script-assert.js
+++ b/dev/projection/script-assert.js
@@ -13,6 +13,15 @@ function showError(element, msg) {
     }
 }
 
+window.ProjectionFrames = []
+window.MotionDebug = {
+    record: (action) => {
+        if (action.type === "projectionFrame") {
+            window.ProjectionFrames.push({ ...action })
+        }
+    },
+}
+
 window.Assert = {
     matchViewportBox: (element, expected, threshold = 0.01) => {
         const bbox = element.getBoundingClientRect()
@@ -81,6 +90,32 @@ window.Assert = {
             right: right - x,
             bottom: bottom - y,
             left: left - x,
+        }
+    },
+    checkFrames(element, frameIndex, expected) {
+        const frame = window.ProjectionFrames[frameIndex]
+
+        if (!frame) showError(element, "No frame found for given index")
+
+        if (frame.totalNodes !== expected.totalNodes) {
+            showError(
+                element,
+                `Expected ${expected.totalNodes} nodes. Found ${frame.totalNodes}.`
+            )
+        }
+
+        if (frame.resolvedTargetDeltas !== expected.resolvedTargetDeltas) {
+            showError(
+                element,
+                `Expected ${expected.resolvedTargetDeltas} nodes to resolve target deltas. Found ${frame.resolvedTargetDeltas}.`
+            )
+        }
+
+        if (frame.totalNodes !== expected.totalNodes) {
+            showError(
+                element,
+                `Expected ${expected.totalNodes} nodes to recalculate projection transform. Found ${frame.totalNodes}.`
+            )
         }
     },
 }

--- a/dev/projection/script-assert.js
+++ b/dev/projection/script-assert.js
@@ -92,7 +92,7 @@ window.Assert = {
             left: left - x,
         }
     },
-    checkFrames(element, frameIndex, expected) {
+    checkFrame(element, frameIndex, expected) {
         const frame = window.ProjectionFrames[frameIndex]
 
         if (!frame) showError(element, "No frame found for given index")

--- a/packages/framer-motion/src/debug/record.ts
+++ b/packages/framer-motion/src/debug/record.ts
@@ -1,0 +1,7 @@
+import { RecordData } from "./types"
+
+export function record(data: RecordData) {
+    if (window.MotionDebug) {
+        window.MotionDebug.record(data)
+    }
+}

--- a/packages/framer-motion/src/debug/types.ts
+++ b/packages/framer-motion/src/debug/types.ts
@@ -1,0 +1,16 @@
+export interface ProjectionFrame {
+    type: "projectionFrame"
+    totalNodes: number
+    resolvedTargetDeltas: number
+    recalculatedProjection: number
+}
+
+export type RecordData = ProjectionFrame
+
+declare global {
+    interface Window {
+        MotionDebug?: {
+            record: (data: RecordData) => void
+        }
+    }
+}

--- a/packages/framer-motion/src/projection/node/__tests__/node.test.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/node.test.ts
@@ -127,102 +127,126 @@ describe("node", () => {
     })
 
     test("Subtrees with updated targets propagate isProjectionDirty to children", () => {
-        const parent = createTestNode(undefined, {})
+        const a = createTestNode(undefined, {})
 
-        const parentInstance = {
-            id: "parent",
+        const aInstance = {
+            id: "a",
             resetTransform: jest.fn(),
             box: {
                 x: { min: 0, max: 100 },
                 y: { min: 0, max: 100 },
             },
         }
-        parent.mount(parentInstance)
+        a.mount(aInstance)
 
-        const child = createTestNode(parent)
-        const childInstance = {
-            id: "child",
+        const b = createTestNode(a)
+        const bInstance = {
+            id: "b",
             resetTransform: jest.fn(),
             box: {
                 x: { min: 0, max: 50 },
                 y: { min: 0, max: 50 },
             },
         }
-        child.mount(childInstance)
+        b.mount(bInstance)
 
-        const grandChild = createTestNode(child)
-        const grandChildInstance = {
-            id: "grandchild",
+        const c = createTestNode(b)
+        const cInstance = {
+            id: "c",
             resetTransform: jest.fn(),
             box: {
                 x: { min: 0, max: 50 },
                 y: { min: 0, max: 50 },
             },
         }
-        grandChild.mount(childInstance)
+        c.mount(bInstance)
 
-        parent.willUpdate()
-        child.willUpdate()
-        grandChild.willUpdate()
+        const d = createTestNode(c)
+        const dInstance = {
+            id: "d",
+            resetTransform: jest.fn(),
+            box: {
+                x: { min: 0, max: 50 },
+                y: { min: 0, max: 50 },
+            },
+        }
+        d.mount(dInstance)
 
-        parentInstance.box = {
+        a.willUpdate()
+        b.willUpdate()
+        c.willUpdate()
+        d.willUpdate()
+
+        aInstance.box = {
             x: { min: 100, max: 200 },
             y: { min: 100, max: 200 },
         }
 
-        childInstance.box = {
+        bInstance.box = {
             x: { min: 150, max: 200 },
             y: { min: 150, max: 200 },
         }
 
-        grandChildInstance.box = {
+        cInstance.box = {
             x: { min: 150, max: 200 },
             y: { min: 150, max: 200 },
         }
 
-        child.root.didUpdate()
+        dInstance.box = {
+            x: { min: 100, max: 200 },
+            y: { min: 100, max: 200 },
+        }
 
-        child.setTargetDelta({
+        b.root.didUpdate()
+
+        b.setTargetDelta({
             x: { translate: 200, scale: 2, origin: 0.5, originPoint: 100 },
             y: { translate: 200, scale: 2, origin: 0.5, originPoint: 100 },
         })
 
-        propagateDirtyNodes(parent as IProjectionNode)
-        propagateDirtyNodes(child as IProjectionNode)
-        propagateDirtyNodes(grandChild as IProjectionNode)
+        // This hacks c into being considered "projecting" and propagation should stop here
+        c.relativeTarget = { x: { min: 0, max: 100 }, y: { min: 0, max: 100 } }
 
-        parent.resolveTargetDelta()
-        child.resolveTargetDelta()
-        grandChild.resolveTargetDelta()
+        propagateDirtyNodes(a as IProjectionNode)
+        propagateDirtyNodes(b as IProjectionNode)
+        propagateDirtyNodes(c as IProjectionNode)
+        propagateDirtyNodes(d as IProjectionNode)
 
         // Check isProjectionDirty is propagated from child to grandChild
-        expect(parent.isProjectionDirty).toEqual(false)
-        expect(parent.isSharedProjectionDirty).toEqual(false)
-        expect(child.isProjectionDirty).toEqual(true)
-        expect(child.isSharedProjectionDirty).toEqual(true)
-        expect(grandChild.isProjectionDirty).toEqual(false)
-        expect(grandChild.isSharedProjectionDirty).toEqual(true)
+        expect(a.isProjectionDirty).toEqual(false)
+        expect(a.isSharedProjectionDirty).toEqual(false)
+        expect(b.isProjectionDirty).toEqual(true)
+        expect(b.isSharedProjectionDirty).toEqual(true)
+        expect(c.isProjectionDirty).toEqual(false)
+        expect(c.isSharedProjectionDirty).toEqual(true)
+        expect(d.isProjectionDirty).toEqual(false)
+        expect(d.isSharedProjectionDirty).toEqual(true)
 
-        parent.calcProjection()
-        child.calcProjection()
-        grandChild.calcProjection()
+        a.resolveTargetDelta()
+        b.resolveTargetDelta()
+        c.resolveTargetDelta()
+        d.resolveTargetDelta()
 
-        parent.calcProjection()
-        child.calcProjection()
-        grandChild.calcProjection()
+        a.calcProjection()
+        b.calcProjection()
+        c.calcProjection()
+        d.calcProjection()
 
-        cleanDirtyNodes(parent as IProjectionNode)
-        cleanDirtyNodes(child as IProjectionNode)
-        cleanDirtyNodes(grandChild as IProjectionNode)
+        cleanDirtyNodes(a as IProjectionNode)
+        cleanDirtyNodes(b as IProjectionNode)
+        cleanDirtyNodes(c as IProjectionNode)
+        cleanDirtyNodes(d as IProjectionNode)
 
         // Check isProjectionDirty is cleaned up after projections are calculated
         expect(
-            parent.isProjectionDirty ||
-                parent.isSharedProjectionDirty ||
-                child.isProjectionDirty ||
-                child.isSharedProjectionDirty ||
-                grandChild.isProjectionDirty ||
-                grandChild.isSharedProjectionDirty
+            a.isProjectionDirty ||
+                a.isSharedProjectionDirty ||
+                b.isProjectionDirty ||
+                b.isSharedProjectionDirty ||
+                c.isProjectionDirty ||
+                c.isSharedProjectionDirty ||
+                d.isProjectionDirty ||
+                d.isSharedProjectionDirty
         ).toEqual(false)
     })
 })

--- a/packages/framer-motion/src/projection/node/__tests__/node.test.ts
+++ b/packages/framer-motion/src/projection/node/__tests__/node.test.ts
@@ -1,5 +1,5 @@
 import { createTestNode } from "./TestProjectionNode"
-import { propagateDirtyNodes } from "../create-projection-node"
+import { propagateDirtyNodes, cleanDirtyNodes } from "../create-projection-node"
 import { IProjectionNode } from "../types"
 
 describe("node", () => {
@@ -197,16 +197,32 @@ describe("node", () => {
 
         // Check isProjectionDirty is propagated from child to grandChild
         expect(parent.isProjectionDirty).toEqual(false)
+        expect(parent.isSharedProjectionDirty).toEqual(false)
         expect(child.isProjectionDirty).toEqual(true)
-        expect(grandChild.isProjectionDirty).toEqual(true)
+        expect(child.isSharedProjectionDirty).toEqual(true)
+        expect(grandChild.isProjectionDirty).toEqual(false)
+        expect(grandChild.isSharedProjectionDirty).toEqual(true)
 
         parent.calcProjection()
         child.calcProjection()
         grandChild.calcProjection()
 
+        parent.calcProjection()
+        child.calcProjection()
+        grandChild.calcProjection()
+
+        cleanDirtyNodes(parent as IProjectionNode)
+        cleanDirtyNodes(child as IProjectionNode)
+        cleanDirtyNodes(grandChild as IProjectionNode)
+
         // Check isProjectionDirty is cleaned up after projections are calculated
-        expect(parent.isProjectionDirty).toEqual(false)
-        expect(child.isProjectionDirty).toEqual(false)
-        expect(grandChild.isProjectionDirty).toEqual(false)
+        expect(
+            parent.isProjectionDirty ||
+                parent.isSharedProjectionDirty ||
+                child.isProjectionDirty ||
+                child.isSharedProjectionDirty ||
+                grandChild.isProjectionDirty ||
+                grandChild.isSharedProjectionDirty
+        ).toEqual(false)
     })
 })

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1875,7 +1875,7 @@ export function propagateDirtyNodes(node: IProjectionNode) {
     projectionFrameData.totalNodes++
 
     if (!node.parent) return
-
+    console.log(node.id, node.isProjecting())
     /**
      * If this node isn't projecting, propagate isProjectionDirty. It will have
      * no performance impact but it will allow the next child that *is* projecting

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1865,7 +1865,9 @@ export function propagateDirtyNodes(node: IProjectionNode) {
      * Propagate isSharedProjectionDirty throughout the whole tree.
      */
     node.isSharedProjectionDirty ||= Boolean(
-        node.isProjectionDirty || node.parent.isSharedProjectionDirty
+        node.isProjectionDirty ||
+            node.parent.isProjectionDirty ||
+            node.parent.isSharedProjectionDirty
     )
 }
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -699,7 +699,10 @@ export function createProjectionNode<I>({
          * the next step.
          */
         updateProjection = () => {
-            // Reset projection frame data
+            /**
+             * Reset debug counts. Manually resetting rather than creating a new
+             * object each frame.
+             */
             projectionFrameData.totalNodes =
                 projectionFrameData.resolvedTargetDeltas =
                 projectionFrameData.recalculatedProjection =
@@ -1122,6 +1125,9 @@ export function createProjectionNode<I>({
                 }
             }
 
+            /**
+             * Increase debug counter for resolved target deltas
+             */
             projectionFrameData.resolvedTargetDeltas++
         }
 
@@ -1258,6 +1264,9 @@ export function createProjectionNode<I>({
                 this.notifyListeners("projectionUpdate", target)
             }
 
+            /**
+             * Increase debug counter for recalculated projections
+             */
             projectionFrameData.recalculatedProjection++
         }
 
@@ -1904,6 +1913,9 @@ function notifyLayoutUpdate(node: IProjectionNode) {
 }
 
 export function propagateDirtyNodes(node: IProjectionNode) {
+    /**
+     * Increase debug counter for nodes encountered this frame
+     */
     projectionFrameData.totalNodes++
 
     if (!node.parent) return

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1869,7 +1869,7 @@ export function propagateDirtyNodes(node: IProjectionNode) {
     )
 }
 
-function cleanDirtyNodes(node: IProjectionNode) {
+export function cleanDirtyNodes(node: IProjectionNode) {
     node.isProjectionDirty = node.isSharedProjectionDirty = false
 }
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1919,7 +1919,9 @@ export function propagateDirtyNodes(node: IProjectionNode) {
     }
 
     /**
-     * Propagate isSharedProjectionDirty throughout the whole tree.
+     * Propagate isSharedProjectionDirty and isTransformDirty
+     * throughout the whole tree. A future revision can take another look at
+     * this but for safety we still recalcualte shared nodes.
      */
     node.isSharedProjectionDirty ||= Boolean(
         node.isProjectionDirty ||

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1004,14 +1004,12 @@ export function createProjectionNode<I>({
              * We don't use transform for this step of processing so we don't
              * need to check whether any nodes have changed transform.
              */
-            let canSkip = true
-
-            if (isShared && this.isSharedProjectionDirty) canSkip = false
-            if (this.isProjectionDirty || this.parent?.isProjectionDirty)
-                canSkip = false
-
-            if (this.attemptToResolveRelativeTarget) canSkip = false
-
+            const canSkip = !(
+                (isShared && this.isSharedProjectionDirty) ||
+                this.isProjectionDirty ||
+                this.parent?.isProjectionDirty ||
+                this.attemptToResolveRelativeTarget
+            )
             if (canSkip) return
 
             const { layout, layoutId } = this.options

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -996,6 +996,7 @@ export function createProjectionNode<I>({
              */
             const lead = this.getLead()
             this.isProjectionDirty ||= lead.isProjectionDirty
+            this.isTransformDirty ||= lead.isTransformDirty
             this.isSharedProjectionDirty ||= lead.isSharedProjectionDirty
 
             const isShared = Boolean(this.resumingFrom) || this !== lead

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -63,9 +63,8 @@ export interface IProjectionNode<I = unknown> {
     projectionDeltaWithTransform?: Delta
     latestValues: ResolvedValues
     isLayoutDirty: boolean
-    isTransformDirty: boolean
     isProjectionDirty: boolean
-    isParentProjectionDirty: boolean
+    isSharedProjectionDirty: boolean
     shouldResetTransform: boolean
     prevTransformTemplateValue: string | undefined
     isUpdateBlocked(): boolean

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -65,6 +65,7 @@ export interface IProjectionNode<I = unknown> {
     isLayoutDirty: boolean
     isProjectionDirty: boolean
     isSharedProjectionDirty: boolean
+    isTransformDirty: boolean
     shouldResetTransform: boolean
     prevTransformTemplateValue: string | undefined
     isUpdateBlocked(): boolean

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -65,6 +65,7 @@ export interface IProjectionNode<I = unknown> {
     isLayoutDirty: boolean
     isTransformDirty: boolean
     isProjectionDirty: boolean
+    isParentProjectionDirty: boolean
     shouldResetTransform: boolean
     prevTransformTemplateValue: string | undefined
     isUpdateBlocked(): boolean
@@ -107,6 +108,7 @@ export interface IProjectionNode<I = unknown> {
     clearMeasurements(): void
     resetTree(): void
 
+    isProjecting(): boolean
     animationValues?: ResolvedValues
     currentAnimation?: AnimationPlaybackControls
     isTreeAnimating?: boolean

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -451,7 +451,7 @@ export abstract class VisualElement<
                     sync.update(this.notifyUpdate, false, true)
 
                 if (valueIsTransform && this.projection) {
-                    this.projection.isSharedProjectionDirty = true
+                    this.projection.isTransformDirty = true
                 }
             }
         )

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -451,7 +451,7 @@ export abstract class VisualElement<
                     sync.update(this.notifyUpdate, false, true)
 
                 if (valueIsTransform && this.projection) {
-                    this.projection.isTransformDirty = true
+                    this.projection.isSharedProjectionDirty = true
                 }
             }
         )


### PR DESCRIPTION
This PR changes the propagation of "dirty" nodes to limit recalculation to:
1. Dirty nodes
2. Nearest **projecting** children of dirty nodes
3. Shared nodes where parent projections or transforms have been dirtied

In the included stress test this is a 90% reduction in executed JS per frame - this will vary per tree.

Closes https://github.com/framer/motion/pull/1798

