### PR TITLE
Ensure WAAPI animations are cancelled `onfinish`

### DIFF
--- a/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
@@ -96,7 +96,7 @@ export function createAcceleratedAnimation(
      * be removed from the element which would then revert to its old styles.
      */
     animation.onfinish = () => {
-        value.jump(getFinalKeyframe(keyframes, options))
+        value.set(getFinalKeyframe(keyframes, options))
         sync.update(() => animation.cancel())
         onComplete && onComplete()
     }
@@ -129,7 +129,6 @@ export function createAcceleratedAnimation(
                     sampleDelta
                 )
             }
-
             sync.update(() => animation.cancel())
         },
     }

--- a/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
@@ -97,6 +97,7 @@ export function createAcceleratedAnimation(
      */
     animation.onfinish = () => {
         value.set(getFinalKeyframe(keyframes, options))
+        sync.update(() => animation.cancel())
         onComplete && onComplete()
     }
 

--- a/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
@@ -96,7 +96,7 @@ export function createAcceleratedAnimation(
      * be removed from the element which would then revert to its old styles.
      */
     animation.onfinish = () => {
-        value.set(getFinalKeyframe(keyframes, options))
+        value.jump(getFinalKeyframe(keyframes, options))
         sync.update(() => animation.cancel())
         onComplete && onComplete()
     }


### PR DESCRIPTION
We persist the final state via `value.jump` so the WAAPI animation should be explicitly cancelled.