### PR TITLE
Making tap events keyboard accessible

### DIFF
--- a/dev/examples/Events-onTap.tsx
+++ b/dev/examples/Events-onTap.tsx
@@ -13,11 +13,22 @@ const style = {
 
 export const App = () => {
     return (
-        <motion.div
-            style={style}
-            onTapStart={() => console.log("onTapStart")}
-            onTap={() => console.log("onTap")}
-            onTapCancel={() => console.log("onTapCancel")}
-        />
+        <>
+            <motion.div
+                style={style}
+                onTapStart={() => console.log("onTapStart")}
+                onTap={() => console.log("onTap")}
+                onTapCancel={() => console.log("onTapCancel")}
+                whileTap={{ scale: 0.6 }}
+                whileFocus={{ outline: "5px solid blue" }}
+                initial={{ outline: "0px solid blue" }}
+            />
+            <motion.input
+                type="text"
+                whileTap={{ scale: 0.6 }}
+                whileFocus={{ outline: "5px solid blue" }}
+                initial={{ outline: "0px solid blue" }}
+            />
+        </>
     )
 }

--- a/packages/framer-motion/jest.setup.tsx
+++ b/packages/framer-motion/jest.setup.tsx
@@ -12,6 +12,7 @@ const pointerEventProps = ["isPrimary"]
 class PointerEventFake extends Event {
     constructor(type: any, props: any) {
         super(type, props)
+        if (!props) return
         pointerEventProps.forEach((prop) => {
             if (props[prop] !== null) {
                 this[prop] = props[prop]

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -72,31 +72,31 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "29.6 kB"
+            "maxSize": "29.8 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "4.75 kB"
+            "maxSize": "4.78 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "14.80 kB"
+            "maxSize": "14.92kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "25.58 kB"
+            "maxSize": "25.71 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
-            "maxSize": "4.97 kB"
+            "maxSize": "4.98 kB"
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "18.84 kB"
+            "maxSize": "18.99 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "30.47 kB"
+            "maxSize": "30.65 kB"
         }
     ],
     "gitHead": "439ad7a9979d53ef624754f7a277c9c30a39b726"

--- a/packages/framer-motion/src/gestures/__tests__/focus.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/focus.test.tsx
@@ -8,8 +8,10 @@ describe("focus", () => {
     test("whileFocus applied", async () => {
         const promise = new Promise((resolve) => {
             const opacity = motionValue(1)
+            const ref = React.createRef<HTMLAnchorElement>()
             const Component = () => (
                 <motion.a
+                    ref={ref}
                     data-testid="myAnchorElement"
                     href="#"
                     whileFocus={{ opacity: 0.1 }}
@@ -20,6 +22,70 @@ describe("focus", () => {
 
             const { container, rerender } = render(<Component />)
             rerender(<Component />)
+
+            ref.current!.matches = () => true
+
+            focus(container, "myAnchorElement")
+
+            resolve(opacity.get())
+        })
+
+        return expect(promise).resolves.toBe(0.1)
+    })
+
+    test("whileFocus not applied when :focus-visible is false", async () => {
+        const promise = new Promise((resolve) => {
+            const opacity = motionValue(1)
+            const ref = React.createRef<HTMLAnchorElement>()
+            const Component = () => (
+                <motion.a
+                    ref={ref}
+                    data-testid="myAnchorElement"
+                    href="#"
+                    whileFocus={{ opacity: 0.1 }}
+                    transition={{ type: false }}
+                    style={{ opacity }}
+                ></motion.a>
+            )
+
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+
+            ref.current!.matches = () => false
+
+            focus(container, "myAnchorElement")
+
+            resolve(opacity.get())
+        })
+
+        return expect(promise).resolves.toBe(1)
+    })
+
+    test("whileFocus applied if focus-visible selector throws unsupported", async () => {
+        const promise = new Promise((resolve) => {
+            const opacity = motionValue(1)
+            const ref = React.createRef<HTMLAnchorElement>()
+            const Component = () => (
+                <motion.a
+                    ref={ref}
+                    data-testid="myAnchorElement"
+                    href="#"
+                    whileFocus={{ opacity: 0.1 }}
+                    transition={{ type: false }}
+                    style={{ opacity }}
+                ></motion.a>
+            )
+
+            const { container, rerender } = render(<Component />)
+            rerender(<Component />)
+
+            ref.current!.matches = () => {
+                /**
+                 * Explicitly throw as while Jest throws we want to ensure this
+                 * behaviour isn't silently fixed should it fix this in the future.
+                 */
+                throw new Error("this selector not supported")
+            }
 
             focus(container, "myAnchorElement")
 
@@ -35,9 +101,11 @@ describe("focus", () => {
             const variant = {
                 hidden: { opacity: target },
             }
+            const ref = React.createRef<HTMLAnchorElement>()
             const opacity = motionValue(1)
             const Component = () => (
                 <motion.a
+                    ref={ref}
                     data-testid="myAnchorElement"
                     href="#"
                     whileFocus="hidden"
@@ -50,6 +118,8 @@ describe("focus", () => {
             const { container, rerender } = render(<Component />)
             rerender(<Component />)
 
+            ref.current!.matches = () => true
+
             focus(container, "myAnchorElement")
 
             resolve(opacity.get())
@@ -60,6 +130,7 @@ describe("focus", () => {
 
     test("whileFocus is unapplied when blur", () => {
         const promise = new Promise((resolve) => {
+            const ref = React.createRef<HTMLAnchorElement>()
             const variant = {
                 hidden: { opacity: 0.5, transitionEnd: { opacity: 0.75 } },
             }
@@ -70,6 +141,7 @@ describe("focus", () => {
 
             const Component = ({ onAnimationComplete }: any) => (
                 <motion.a
+                    ref={ref}
                     data-testid="myAnchorElement"
                     href="#"
                     whileFocus="hidden"
@@ -83,6 +155,8 @@ describe("focus", () => {
             const { container } = render(
                 <Component onAnimationComplete={onComplete} />
             )
+
+            ref.current!.matches = () => true
 
             focus(container, "myAnchorElement")
             setTimeout(() => {
@@ -99,9 +173,11 @@ describe("focus", () => {
             const variant = {
                 hidden: { size: 50 },
             }
+            const ref = React.createRef<HTMLAnchorElement>()
 
             const Component = () => (
                 <motion.a
+                    ref={ref}
                     transformValues={transformValues}
                     data-testid="myAnchorElement"
                     href="#"
@@ -114,6 +190,8 @@ describe("focus", () => {
 
             const { container, rerender } = render(<Component />)
             rerender(<Component />)
+
+            ref.current!.matches = () => true
 
             focus(container, "myAnchorElement")
 

--- a/packages/framer-motion/src/gestures/use-focus-gesture.ts
+++ b/packages/framer-motion/src/gestures/use-focus-gesture.ts
@@ -1,26 +1,40 @@
 import { AnimationType } from "../render/utils/types"
 import { useDomEvent } from "../events/use-dom-event"
 import { FeatureProps } from "../motion/features/types"
-import { useCallback } from "react"
+import { useCallback, useRef } from "react"
 
-/**
- *
- * @param props
- * @param ref
- * @internal
- */
 export function useFocusGesture({
     whileFocus,
     visualElement,
-}: FeatureProps<EventTarget>) {
+}: FeatureProps<Element>) {
+    const isFocusActive = useRef(false)
     const { animationState } = visualElement
 
     const onFocus = useCallback(() => {
-        animationState && animationState.setActive(AnimationType.Focus, true)
+        let isFocusVisible = false
+
+        /**
+         * If this element doesn't match focus-visible then don't
+         * apply whileHover. But, if matches throws that focus-visible
+         * is not a valid selector then in that browser outline styles will be applied
+         * to the element by default and we want to match that behaviour with whileFocus.
+         */
+        try {
+            isFocusVisible = visualElement.current!.matches(":focus-visible")
+        } catch (e) {
+            isFocusVisible = true
+        }
+
+        if (!isFocusVisible || !animationState) return
+
+        animationState.setActive(AnimationType.Focus, true)
+        isFocusActive.current = true
     }, [animationState])
 
     const onBlur = useCallback(() => {
-        animationState && animationState.setActive(AnimationType.Focus, false)
+        if (!isFocusActive.current || !animationState) return
+        animationState.setActive(AnimationType.Focus, false)
+        isFocusActive.current = false
     }, [animationState])
 
     useDomEvent(visualElement, "focus", whileFocus ? onFocus : undefined)

--- a/packages/framer-motion/src/gestures/use-tap-gesture.ts
+++ b/packages/framer-motion/src/gestures/use-tap-gesture.ts
@@ -8,9 +8,15 @@ import { isDragActive } from "./drag/utils/lock"
 import { FeatureProps } from "../motion/features/types"
 import { pipe } from "../utils/pipe"
 import { addDomEvent, useDomEvent } from "../events/use-dom-event"
-import { extractEventInfo } from "../events/event-info"
+import {
+    EventListenerWithPointInfo,
+    extractEventInfo,
+} from "../events/event-info"
 
-function fireSyntheticPointerEvent(name: string, handler?: any) {
+function fireSyntheticPointerEvent(
+    name: string,
+    handler?: EventListenerWithPointInfo
+) {
     if (!handler) return
     const syntheticPointerEvent = new PointerEvent("pointer" + name)
     handler(syntheticPointerEvent, extractEventInfo(syntheticPointerEvent))

--- a/packages/framer-motion/src/gestures/use-tap-gesture.ts
+++ b/packages/framer-motion/src/gestures/use-tap-gesture.ts
@@ -37,6 +37,7 @@ export function useTapGesture({
     const hasPressListeners = onTap || onTapStart || onTapCancel || whileTap
     const isPressing = useRef(false)
     const cancelPointerEndListeners = useRef<Function | null>(null)
+    const suspendedTabIndex = useRef<string | null>(null)
 
     /**
      * Only set listener to passive if there are no external listeners.
@@ -63,6 +64,14 @@ export function useTapGesture({
         if (latestProps.whileTap && visualElement.animationState) {
             visualElement.animationState.setActive(AnimationType.Tap, false)
         }
+
+        if (suspendedTabIndex.current !== null) {
+            visualElement.current!.setAttribute(
+                "tabindex",
+                suspendedTabIndex.current
+            )
+        }
+
         return !isDragActive()
     }
 
@@ -109,6 +118,11 @@ export function useTapGesture({
 
         if (isPressing.current) return
         isPressing.current = true
+
+        suspendedTabIndex.current =
+            visualElement.current!.getAttribute("tabindex")
+
+        visualElement.current!.setAttribute("tabindex", "-1")
 
         cancelPointerEndListeners.current = pipe(
             addPointerEvent(window, "pointerup", onPointerUp, eventOptions),

--- a/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
@@ -108,6 +108,18 @@ function runTests(render: (components: any) => string) {
         )
     })
 
+    test("sets tabindex='0' if onTap is set", () => {
+        const div = render(<motion.div onTap={() => {}} />)
+
+        expect(div).toBe(`<div tabindex="0"></div>`)
+    })
+
+    test("sets tabindex='0' if onTapStart is set", () => {
+        const div = render(<motion.div onTap={() => {}} />)
+
+        expect(div).toBe(`<div tabindex="0"></div>`)
+    })
+
     test("initial correctly overrides style with keyframes and initial={false}", () => {
         const div = render(
             <motion.div

--- a/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
@@ -120,6 +120,18 @@ function runTests(render: (components: any) => string) {
         expect(div).toBe(`<div tabindex="0"></div>`)
     })
 
+    test("sets tabindex='0' if whileTap is set", () => {
+        const div = render(<motion.div whileTap={{ scale: 2 }} />)
+
+        expect(div).toBe(`<div tabindex="0"></div>`)
+    })
+
+    test("doesn't override tabindex", () => {
+        const div = render(<motion.div tabIndex={2} whileTap={{ scale: 2 }} />)
+
+        expect(div).toBe(`<div tabindex="2"></div>`)
+    })
+
     test("initial correctly overrides style with keyframes and initial={false}", () => {
         const div = render(
             <motion.div

--- a/packages/framer-motion/src/render/dom/use-render.ts
+++ b/packages/framer-motion/src/render/dom/use-render.ts
@@ -18,7 +18,7 @@ export function createUseRender(forwardMotionProps = false) {
             : useHTMLProps
 
         const visualProps = useVisualProps(
-            props,
+            props as any,
             latestValues,
             isStatic,
             Component

--- a/packages/framer-motion/src/render/html/use-props.ts
+++ b/packages/framer-motion/src/render/html/use-props.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { HTMLProps, useMemo } from "react"
 import { MotionProps } from "../../motion/types"
 import { isForcedMotionValue } from "../../motion/utils/is-forced-motion-value"
 import { MotionValue } from "../../value"
@@ -57,7 +57,7 @@ function useStyle(
 }
 
 export function useHTMLProps(
-    props: MotionProps,
+    props: MotionProps & HTMLProps<HTMLElement>,
     visualState: ResolvedValues,
     isStatic: boolean
 ) {
@@ -82,7 +82,10 @@ export function useHTMLProps(
                 : `pan-${props.drag === "x" ? "y" : "x"}`
     }
 
-    if (props.onTap || props.onTapStart) {
+    if (
+        props.tabIndex === undefined &&
+        (props.onTap || props.onTapStart || props.whileTap)
+    ) {
         htmlProps.tabIndex = 0
     }
 

--- a/packages/framer-motion/src/render/html/use-props.ts
+++ b/packages/framer-motion/src/render/html/use-props.ts
@@ -82,6 +82,10 @@ export function useHTMLProps(
                 : `pan-${props.drag === "x" ? "y" : "x"}`
     }
 
+    if (props.onTap || props.onTapStart) {
+        htmlProps.tabIndex = 0
+    }
+
     htmlProps.style = style
 
     return htmlProps


### PR DESCRIPTION
- Add `tabindex` if an element has tap events to allow element to receive focus.
- Fires `onTapStart` if Enter is pressed on a focussed element.
- Fires `onTap` if Enter is released on a focussed element.
- Fires `onTapCancel` is `blur`ed before Enter is released.
- Starts/stops `whileTap` as appropriate.