### PR TITLE
Adding support for React client components

### DIFF
--- a/packages/framer-motion-3d/src/index.ts
+++ b/packages/framer-motion-3d/src/index.ts
@@ -1,3 +1,5 @@
+"use client"
+
 export { motion } from "./render/motion"
 export { MotionCanvas, MotionCanvasProps } from "./components/MotionCanvas"
 export { LayoutCamera } from "./components/LayoutCamera"

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -1,3 +1,5 @@
+"use client"
+
 /**
  * Components
  */


### PR DESCRIPTION
This PR adds the `"use client"` directive in our entrypoints. This will mark to React that the code contained within is for [Client Components](https://beta.nextjs.org/docs/rendering/server-and-client-components#client-components) only.

Fixes https://github.com/framer/motion/issues/1924