### PR TITLE
feat: add motionComponent prop to Reorder Group and Item components

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -7,6 +7,7 @@ import {
     useEffect,
     useRef,
 } from "react"
+import { m } from "render/dom/motion-minimal"
 import { ReorderContext } from "../../context/ReorderContext"
 import { motion } from "../../render/dom/motion"
 import { HTMLMotionProps } from "../../render/html/types"
@@ -58,6 +59,13 @@ export interface Props<V> {
      * @public
      */
     values: V[]
+
+    /**
+     * The motion component to use. Defaults to `motion`.
+     *
+     * @public
+     */
+    motionComponent?: typeof motion | typeof m
 }
 
 export function ReorderGroup<V>(
@@ -67,13 +75,14 @@ export function ReorderGroup<V>(
         axis = "y",
         onReorder,
         values,
+        motionComponent = motion,
         ...props
     }: Props<V> &
         Omit<HTMLMotionProps<any>, "values"> &
         React.PropsWithChildren<{}>,
     externalRef?: React.Ref<any>
 ) {
-    const Component = useConstant(() => motion(as)) as FunctionComponent<
+    const Component = useConstant(() => motionComponent(as)) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
     >
 

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -7,7 +7,6 @@ import {
     useEffect,
     useRef,
 } from "react"
-import { m } from "render/dom/motion-minimal"
 import { ReorderContext } from "../../context/ReorderContext"
 import { motion } from "../../render/dom/motion"
 import { HTMLMotionProps } from "../../render/html/types"
@@ -59,13 +58,6 @@ export interface Props<V> {
      * @public
      */
     values: V[]
-
-    /**
-     * The motion component to use. Defaults to `motion`.
-     *
-     * @public
-     */
-    motionComponent?: typeof motion | typeof m
 }
 
 export function ReorderGroup<V>(
@@ -75,14 +67,13 @@ export function ReorderGroup<V>(
         axis = "y",
         onReorder,
         values,
-        motionComponent = motion,
         ...props
     }: Props<V> &
         Omit<HTMLMotionProps<any>, "values"> &
         React.PropsWithChildren<{}>,
     externalRef?: React.Ref<any>
 ) {
-    const Component = useConstant(() => motionComponent(as)) as FunctionComponent<
+    const Component = useConstant(() => motion(as)) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
     >
 
@@ -126,7 +117,7 @@ export function ReorderGroup<V>(
     })
 
     return (
-        <Component {...props} ref={externalRef}>
+        <Component {...props} ref={externalRef} ignoreStrict>
             <ReorderContext.Provider value={context}>
                 {children}
             </ReorderContext.Provider>

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -11,6 +11,7 @@ import {
 import { ReorderContext } from "../../context/ReorderContext"
 import { Box } from "../../projection/geometry/types"
 import { motion } from "../../render/dom/motion"
+import { m } from "../../render/dom/motion-minimal"
 import { HTMLMotionProps } from "../../render/html/types"
 import { useConstant } from "../../utils/use-constant"
 import { useMotionValue } from "../../value/use-motion-value"
@@ -39,6 +40,13 @@ export interface Props<V> {
      * @default true
      */
     layout?: true | "position"
+
+    /**
+     * The motion component to use. Defaults to `motion`.
+     *
+     * @public
+     */
+    motionComponent?: typeof motion | typeof m
 }
 
 function useDefaultMotionValue(value: any, defaultValue: number = 0) {
@@ -53,11 +61,12 @@ export function ReorderItem<V>(
         as = "li",
         onDrag,
         layout = true,
+        motionComponent = motion,
         ...props
     }: Props<V> & HTMLMotionProps<any> & React.PropsWithChildren<{}>,
     externalRef?: React.Ref<any>
 ) {
-    const Component = useConstant(() => motion(as)) as FunctionComponent<
+    const Component = useConstant(() => motionComponent(as)) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
     >
 

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -11,7 +11,6 @@ import {
 import { ReorderContext } from "../../context/ReorderContext"
 import { Box } from "../../projection/geometry/types"
 import { motion } from "../../render/dom/motion"
-import { m } from "../../render/dom/motion-minimal"
 import { HTMLMotionProps } from "../../render/html/types"
 import { useConstant } from "../../utils/use-constant"
 import { useMotionValue } from "../../value/use-motion-value"
@@ -40,13 +39,6 @@ export interface Props<V> {
      * @default true
      */
     layout?: true | "position"
-
-    /**
-     * The motion component to use. Defaults to `motion`.
-     *
-     * @public
-     */
-    motionComponent?: typeof motion | typeof m
 }
 
 function useDefaultMotionValue(value: any, defaultValue: number = 0) {
@@ -61,12 +53,11 @@ export function ReorderItem<V>(
         as = "li",
         onDrag,
         layout = true,
-        motionComponent = motion,
         ...props
     }: Props<V> & HTMLMotionProps<any> & React.PropsWithChildren<{}>,
     externalRef?: React.Ref<any>
 ) {
-    const Component = useConstant(() => motionComponent(as)) as FunctionComponent<
+    const Component = useConstant(() => motion(as)) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
     >
 
@@ -108,6 +99,7 @@ export function ReorderItem<V>(
                 measuredLayout.current = measured
             }}
             ref={externalRef}
+            ignoreStrict
         >
             {children}
         </Component>

--- a/packages/framer-motion/src/motion/index.tsx
+++ b/packages/framer-motion/src/motion/index.tsx
@@ -106,7 +106,7 @@ export function createMotionComponent<Props extends {}, Instance, RenderState>({
                 features = context.visualElement.loadFeatures(
                     // Note: Pass the full new combined props to correctly re-render dynamic feature components.
                     configAndProps,
-                    lazyStrictMode,
+                    { isStrict: lazyStrictMode, warn: props.ignoreStrict },
                     preloadedFeatures,
                     projectionId,
                     projectionNodeConstructor ||

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -262,6 +262,12 @@ export interface MotionAdvancedProps {
      * Set to `false` to prevent inheriting variant changes from its parent.
      */
     inherit?: boolean
+
+    /**
+     * @public
+     * Set to `false` to prevent throwing an error when a `motion` component is used within a `LazyMotion` set to strict.
+     */
+    ignoreStrict?: boolean
 }
 
 type ExternalMotionValues = {

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -1,5 +1,5 @@
 import { sync, cancelSync } from "../frameloop"
-import { invariant } from "hey-listen"
+import { invariant, warning } from "hey-listen"
 import { createElement } from "react"
 import {
     MotionConfigContext,
@@ -472,7 +472,7 @@ export abstract class VisualElement<
 
     loadFeatures(
         { children, ...renderedProps }: MotionProps,
-        isStrict?: boolean,
+        { isStrict, warn }: { isStrict?: boolean, warn?: boolean },
         preloadedFeatures?: FeatureBundle,
         projectionId?: number,
         ProjectionNodeConstructor?: any,
@@ -489,10 +489,8 @@ export abstract class VisualElement<
             preloadedFeatures &&
             isStrict
         ) {
-            invariant(
-                false,
-                "You have rendered a `motion` component within a `LazyMotion` component. This will break tree shaking. Import and render a `m` component instead."
-            )
+            const strictMessage = "You have rendered a `motion` component within a `LazyMotion` component. This will break tree shaking. Import and render a `m` component instead.";
+            warn ? warning(false, strictMessage) : invariant(false, strictMessage)
         }
 
         for (let i = 0; i < numFeatures; i++) {


### PR DESCRIPTION
Resolves: https://github.com/framer/motion/issues/1930

I've tested this locally and it resolves the linked issue. I'm open to feedback/changes and can add tests/docs once the implementation details are good.

Edit: Changed this to add an `ignoreStrict` prop onto the `motion` component. When `ignoreStrict` is given, it will output a `warn` instead of throwing an error so that users are still aware of what using `motion` inside `LazyMotion` will do.