### PR TITLE
Removing `enum`s

### DIFF
--- a/packages/framer-motion-3d/src/render/gestures/use-hover.ts
+++ b/packages/framer-motion-3d/src/render/gestures/use-hover.ts
@@ -1,7 +1,6 @@
 import type { VisualElement } from "framer-motion"
 import type { ThreeMotionProps } from "../../types"
 import { MeshProps, ThreeEvent } from "@react-three/fiber"
-import { AnimationType } from "framer-motion"
 
 export function useHover(
     isStatic: boolean,
@@ -20,11 +19,11 @@ export function useHover(
 
     return {
         onPointerOver: (event: ThreeEvent<any>) => {
-            visualElement.animationState?.setActive(AnimationType.Hover, true)
+            visualElement.animationState?.setActive("whileHover", true)
             onPointerOver && onPointerOver(event)
         },
         onPointerOut: (event: ThreeEvent<any>) => {
-            visualElement.animationState?.setActive(AnimationType.Hover, false)
+            visualElement.animationState?.setActive("whileHover", false)
             onPointerOut && onPointerOut(event)
         },
     }

--- a/packages/framer-motion-3d/src/render/gestures/use-tap.ts
+++ b/packages/framer-motion-3d/src/render/gestures/use-tap.ts
@@ -4,7 +4,6 @@ import {
     addPointerEvent,
     isDragActive,
     addPointerInfo,
-    AnimationType,
     pipe,
 } from "framer-motion"
 import type { VisualElement, EventInfo } from "framer-motion"
@@ -35,7 +34,7 @@ export function useTap(
     function checkPointerEnd() {
         removePointerEndListener()
         isPressing.current = false
-        visualElement!.animationState?.setActive(AnimationType.Tap, false)
+        visualElement!.animationState?.setActive("whileTap", false)
         return !isDragActive()
     }
 
@@ -78,7 +77,7 @@ export function useTap(
                 )
             )
 
-            visualElement.animationState?.setActive(AnimationType.Tap, true)
+            visualElement.animationState?.setActive("whileTap", true)
 
             onPointerDown?.(event)
 

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -70,7 +70,11 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
+<<<<<<< HEAD
             "maxSize": "29.94 kB"
+=======
+            "maxSize": "29.76 kB"
+>>>>>>> 4819ef50 (Removing unused exports)
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -78,23 +82,31 @@
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
+<<<<<<< HEAD
             "maxSize": "14.81 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
             "maxSize": "25.68 kB"
+=======
+            "maxSize": "14.85 kB"
+        },
+        {
+            "path": "./dist/size-rollup-dom-max.js",
+            "maxSize": "25.49 kB"
+>>>>>>> 4819ef50 (Removing unused exports)
         },
         {
             "path": "./dist/size-webpack-m.js",
-            "maxSize": "4.88 kB"
+            "maxSize": "4.8 kB"
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "18.91 kB"
+            "maxSize": "18.86 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "30.64 kB"
+            "maxSize": "30.36 kB"
         }
     ],
     "gitHead": "79675ba44230ae86bfb212be8bd903fc68524976"

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -70,11 +70,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-<<<<<<< HEAD
-            "maxSize": "29.94 kB"
-=======
             "maxSize": "29.76 kB"
->>>>>>> 4819ef50 (Removing unused exports)
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -82,19 +78,11 @@
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-<<<<<<< HEAD
-            "maxSize": "14.81 kB"
-        },
-        {
-            "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "25.68 kB"
-=======
             "maxSize": "14.85 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
             "maxSize": "25.49 kB"
->>>>>>> 4819ef50 (Removing unused exports)
         },
         {
             "path": "./dist/size-webpack-m.js",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -70,7 +70,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "29.76 kB"
+            "maxSize": "29.92 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -82,7 +82,7 @@
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "25.49 kB"
+            "maxSize": "25.67 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
@@ -90,11 +90,11 @@
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "18.86 kB"
+            "maxSize": "18.81 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "30.36 kB"
+            "maxSize": "30.52 kB"
         }
     ],
     "gitHead": "79675ba44230ae86bfb212be8bd903fc68524976"

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -13,7 +13,6 @@ import {
     defaultElastic,
     calcOrigin,
 } from "./utils/constraints"
-import { AnimationType } from "../../render/utils/types"
 import type { VisualElement } from "../../render/VisualElement"
 import { MotionProps } from "../../motion/types"
 import { Point } from "../../projection/geometry/types"
@@ -152,7 +151,7 @@ export class VisualElementDragControls {
             // Fire onDragStart event
             onDragStart && onDragStart(event, info)
             const { animationState } = this.visualElement
-            animationState && animationState.setActive(AnimationType.Drag, true)
+            animationState && animationState.setActive("whileDrag", true)
         }
 
         const onMove = (event: PointerEvent, info: PanInfo) => {
@@ -242,7 +241,7 @@ export class VisualElementDragControls {
             this.openGlobalLock = null
         }
 
-        animationState && animationState.setActive(AnimationType.Drag, false)
+        animationState && animationState.setActive("whileDrag", false)
     }
 
     private updateAxis(axis: DragDirection, _point: Point, offset?: Point) {

--- a/packages/framer-motion/src/gestures/focus.ts
+++ b/packages/framer-motion/src/gestures/focus.ts
@@ -1,6 +1,5 @@
 import { addDomEvent } from "../events/add-dom-event"
 import { Feature } from "../motion/features/Feature"
-import { AnimationType } from "../render/utils/types"
 import { pipe } from "../utils/pipe"
 
 export class FocusGesture extends Feature<Element> {
@@ -23,13 +22,13 @@ export class FocusGesture extends Feature<Element> {
 
         if (!isFocusVisible || !this.node.animationState) return
 
-        this.node.animationState.setActive(AnimationType.Focus, true)
+        this.node.animationState.setActive("whileFocus", true)
         this.isActive = true
     }
 
     onBlur() {
         if (!this.isActive || !this.node.animationState) return
-        this.node.animationState.setActive(AnimationType.Focus, false)
+        this.node.animationState.setActive("whileFocus", false)
         this.isActive = false
     }
 

--- a/packages/framer-motion/src/gestures/hover.ts
+++ b/packages/framer-motion/src/gestures/hover.ts
@@ -1,5 +1,4 @@
 import { addPointerEvent } from "../events/add-pointer-event"
-import { AnimationType } from "../render/utils/types"
 import { pipe } from "../utils/pipe"
 import { isDragActive } from "./drag/utils/lock"
 import { EventInfo } from "../events/types"
@@ -16,7 +15,7 @@ function addHoverEvent(node: VisualElement<Element>, isActive: boolean) {
         const props = node.getProps()
 
         if (node.animationState && props.whileHover) {
-            node.animationState.setActive(AnimationType.Hover, isActive)
+            node.animationState.setActive("whileHover", isActive)
         }
 
         if (props[callbackName]) {

--- a/packages/framer-motion/src/gestures/press.ts
+++ b/packages/framer-motion/src/gestures/press.ts
@@ -6,7 +6,6 @@ import { EventInfo } from "../events/types"
 import { addDomEvent } from "../events/add-dom-event"
 import { addPointerEvent } from "../events/add-pointer-event"
 import { Feature } from "../motion/features/Feature"
-import { AnimationType } from "../render/utils/types"
 import { pipe } from "../utils/pipe"
 import { isDragActive } from "./drag/utils/lock"
 import { isNodeOrChild } from "./utils/is-node-or-child"
@@ -37,7 +36,7 @@ export class PressGesture extends Feature<Element> {
          * Ensure we trigger animations before firing event callback
          */
         if (whileTap && this.node.animationState) {
-            this.node.animationState.setActive(AnimationType.Tap, true)
+            this.node.animationState.setActive("whileTap", true)
         }
 
         onTapStart && onTapStart(event, info)
@@ -50,7 +49,7 @@ export class PressGesture extends Feature<Element> {
         const props = this.node.getProps()
 
         if (props.whileTap && this.node.animationState) {
-            this.node.animationState.setActive(AnimationType.Tap, false)
+            this.node.animationState.setActive("whileTap", false)
         }
 
         return !isDragActive()

--- a/packages/framer-motion/src/motion/features/animation/exit.ts
+++ b/packages/framer-motion/src/motion/features/animation/exit.ts
@@ -1,4 +1,3 @@
-import { AnimationType } from "../../../render/utils/types"
 import { Feature } from "../Feature"
 
 let id = 0
@@ -17,7 +16,7 @@ export class ExitAnimationFeature extends Feature<unknown> {
         }
 
         const exitAnimation = this.node.animationState.setActive(
-            AnimationType.Exit,
+            "exit",
             !isPresent,
             { custom: custom ?? this.node.getProps().custom }
         )

--- a/packages/framer-motion/src/motion/features/viewport/index.ts
+++ b/packages/framer-motion/src/motion/features/viewport/index.ts
@@ -1,4 +1,3 @@
-import { AnimationType } from "../../../render/utils/types"
 import { MotionProps } from "../../types"
 import { Feature } from "../Feature"
 import { observeIntersection } from "./observers"
@@ -27,7 +26,7 @@ export class InViewFeature extends Feature<Element> {
             const { onViewportEnter } = this.node.getProps()
             onViewportEnter && onViewportEnter(null)
             if (this.node.animationState) {
-                this.node.animationState.setActive(AnimationType.InView, true)
+                this.node.animationState.setActive("whileInView", true)
             }
         })
     }
@@ -78,7 +77,7 @@ export class InViewFeature extends Feature<Element> {
 
             if (this.node.animationState) {
                 this.node.animationState.setActive(
-                    AnimationType.InView,
+                    "whileInView",
                     isIntersecting
                 )
             }

--- a/packages/framer-motion/src/render/utils/__tests__/animation-state.test.ts
+++ b/packages/framer-motion/src/render/utils/__tests__/animation-state.test.ts
@@ -1,5 +1,4 @@
 import { AnimationState, createAnimationState } from "../animation-state"
-import { AnimationType } from "../types"
 import { MotionProps } from "../../../motion/types"
 import { createHtmlRenderState } from "../../html/utils/create-render-state"
 import { VisualElement } from "../../VisualElement"
@@ -65,9 +64,7 @@ describe("Animation state - Initiating props", () => {
             animate: { opacity: 1 },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).toBeCalledWith([{ opacity: 1 }])
     })
 
@@ -82,9 +79,7 @@ describe("Animation state - Initiating props", () => {
             },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).toBeCalledWith(["test"])
     })
 
@@ -99,9 +94,7 @@ describe("Animation state - Initiating props", () => {
             },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).toBeCalledWith(["test", "heyoo"])
     })
 
@@ -119,9 +112,7 @@ describe("Animation state - Initiating props", () => {
             },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).not.toBeCalled()
     })
 
@@ -134,9 +125,7 @@ describe("Animation state - Initiating props", () => {
             animate: { opacity: 1 },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).not.toBeCalled()
     })
 
@@ -152,9 +141,7 @@ describe("Animation state - Initiating props", () => {
             },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).not.toBeCalled()
     })
 
@@ -170,9 +157,7 @@ describe("Animation state - Initiating props", () => {
             },
         })
 
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
         expect(animate).not.toBeCalled()
     })
 })
@@ -192,7 +177,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+        expect(state.getState()["animate"].protectedKeys).toEqual({
             opacity: true,
         })
     })
@@ -210,7 +195,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+        expect(state.getState()["animate"].protectedKeys).toEqual({
             opacity: true,
         })
     })
@@ -235,7 +220,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+        expect(state.getState()["animate"].protectedKeys).toEqual({
             opacity: true,
         })
     })
@@ -260,7 +245,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).not.toBeCalled()
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+        expect(state.getState()["animate"].protectedKeys).toEqual({
             opacity: true,
         })
     })
@@ -279,9 +264,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ opacity: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Change single value, keyframes", () => {
@@ -298,9 +281,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ opacity: [0.5, 1] }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Change single value, variant", () => {
@@ -325,9 +306,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith(["b"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Change single value, variant list", () => {
@@ -352,9 +331,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith(["b"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Swap between value in target and transitionEnd, target", () => {
@@ -373,9 +350,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ transitionEnd: { opacity: 0.3 } }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
 
         animate = mockAnimate(state)
 
@@ -384,9 +359,7 @@ describe("Animation state - Setting props", () => {
             animate: { opacity: 0.2 },
         })
         expect(animate).toBeCalledWith([{ opacity: 0.2 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Change single value, target, with unchanging values", () => {
@@ -403,7 +376,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ opacity: 0, x: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+        expect(state.getState()["animate"].protectedKeys).toEqual({
             x: true,
         })
 
@@ -414,7 +387,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ opacity: 0, x: 100 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual({
+        expect(state.getState()["animate"].protectedKeys).toEqual({
             opacity: true,
         })
     })
@@ -434,9 +407,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ opacity: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Removing values, target undefined", () => {
@@ -454,9 +425,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith([{ opacity: 0 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Removing values, variant changed", () => {
@@ -482,9 +451,7 @@ describe("Animation state - Setting props", () => {
         })
 
         expect(animate).toBeCalledWith(["b", { opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Removing values, inherited variant changed", () => {
@@ -512,9 +479,7 @@ describe("Animation state - Setting props", () => {
         )
 
         expect(animate).toBeCalledWith([{ opacity: 1 }])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
     })
 
     test("Removing values, inherited variant changed from starting at empty variant", () => {
@@ -557,9 +522,7 @@ describe("Animation state - Setting props", () => {
 
         expect(parentAnimate).toBeCalledWith(["a"])
         expect(childAnimate).not.toBeCalled()
-        expect(
-            childState.getState()[AnimationType.Animate].protectedKeys
-        ).toEqual({})
+        expect(childState.getState()["animate"].protectedKeys).toEqual({})
 
         parentAnimate = mockAnimate(parentState)
         childAnimate = mockAnimate(childState)
@@ -582,9 +545,7 @@ describe("Animation state - Setting props", () => {
         parent.animationState!.animateChanges()
         expect(parentAnimate).toBeCalledWith(["b"])
         expect(childAnimate).not.toBeCalled()
-        expect(
-            childState.getState()[AnimationType.Animate].protectedKeys
-        ).toEqual({})
+        expect(childState.getState()["animate"].protectedKeys).toEqual({})
 
         parentAnimate = mockAnimate(parentState)
         childAnimate = mockAnimate(childState)
@@ -607,9 +568,7 @@ describe("Animation state - Setting props", () => {
         parent.animationState!.animateChanges()
         expect(parentAnimate).toBeCalledWith([""])
         expect(childAnimate).toBeCalledWith([{ opacity: 0 }])
-        expect(
-            childState.getState()[AnimationType.Animate].protectedKeys
-        ).toEqual({})
+        expect(childState.getState()["animate"].protectedKeys).toEqual({})
     })
 })
 
@@ -626,42 +585,42 @@ describe("Animation state - Set active", () => {
 
         // Set hover to true
         let animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
+        state.setActive("whileHover", true)
         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
 
         // Set hover to false
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
+        state.setActive("whileHover", false)
         expect(animate).toBeCalledWith([{ opacity: 1 }])
 
         // Set hover to true
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
+        state.setActive("whileHover", true)
         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
 
         // Set hover to false
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
+        state.setActive("whileHover", false)
         expect(animate).toBeCalledWith([{ opacity: 1 }])
 
         // Set hover to true
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
+        state.setActive("whileHover", true)
         expect(animate).toBeCalledWith([{ opacity: 0.5 }])
 
         // Set press to true
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Tap, true)
+        state.setActive("whileTap", true)
         expect(animate).toBeCalledWith([{ opacity: 0.8 }])
 
         // Set hover to false
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
+        state.setActive("whileHover", false)
         expect(animate).not.toBeCalled()
 
         // Set press to false
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Tap, false)
+        state.setActive("whileTap", false)
         expect(animate).toBeCalledWith([{ opacity: 1 }])
     })
 
@@ -678,20 +637,16 @@ describe("Animation state - Set active", () => {
 
         // Set hover to true
         let animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, true)
+        state.setActive("whileHover", true)
         expect(animate).toBeCalledWith(["b"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
+        expect(state.getState()["whileHover"].protectedKeys).toEqual({})
 
         // Set hover to false
         animate = mockAnimate(state)
-        state.setActive(AnimationType.Hover, false)
+        state.setActive("whileHover", false)
         expect(animate).toBeCalledWith(["a"])
-        expect(state.getState()[AnimationType.Animate].protectedKeys).toEqual(
-            {}
-        )
-        expect(state.getState()[AnimationType.Hover].protectedKeys).toEqual({})
+        expect(state.getState()["animate"].protectedKeys).toEqual({})
+        expect(state.getState()["whileHover"].protectedKeys).toEqual({})
     })
 })

--- a/packages/framer-motion/src/render/utils/animation-state.ts
+++ b/packages/framer-motion/src/render/utils/animation-state.ts
@@ -12,6 +12,7 @@ import {
 import { isVariantLabel } from "./is-variant-label"
 import { AnimationType } from "./types"
 import { resolveVariant } from "./resolve-dynamic-variants"
+import { variantPriorityOrder } from "./variant-props"
 
 export interface AnimationState {
     animateChanges: (
@@ -33,16 +34,6 @@ interface DefinitionAndOptions {
 }
 
 export type AnimationList = string[] | TargetAndTransition[]
-
-export const variantPriorityOrder = [
-    AnimationType.Animate,
-    AnimationType.InView,
-    AnimationType.Focus,
-    AnimationType.Hover,
-    AnimationType.Tap,
-    AnimationType.Drag,
-    AnimationType.Exit,
-]
 
 const reversePriorityOrder = [...variantPriorityOrder].reverse()
 const numAnimationTypes = variantPriorityOrder.length
@@ -425,12 +416,12 @@ function createTypeState(isActive = false): AnimationTypeState {
 
 function createState() {
     return {
-        [AnimationType.Animate]: createTypeState(true),
-        [AnimationType.InView]: createTypeState(),
-        [AnimationType.Hover]: createTypeState(),
-        [AnimationType.Tap]: createTypeState(),
-        [AnimationType.Drag]: createTypeState(),
-        [AnimationType.Focus]: createTypeState(),
-        [AnimationType.Exit]: createTypeState(),
+        animate: createTypeState(true),
+        whileInView: createTypeState(),
+        whileHover: createTypeState(),
+        whileTap: createTypeState(),
+        whileDrag: createTypeState(),
+        whileFocus: createTypeState(),
+        exit: createTypeState(),
     }
 }

--- a/packages/framer-motion/src/render/utils/types.ts
+++ b/packages/framer-motion/src/render/utils/types.ts
@@ -1,9 +1,8 @@
-export const enum AnimationType {
-    Animate = "animate",
-    Hover = "whileHover",
-    Tap = "whileTap",
-    Drag = "whileDrag",
-    Focus = "whileFocus",
-    InView = "whileInView",
-    Exit = "exit",
-}
+export type AnimationType =
+    | "animate"
+    | "whileHover"
+    | "whileTap"
+    | "whileDrag"
+    | "whileFocus"
+    | "whileInView"
+    | "exit"

--- a/packages/framer-motion/src/render/utils/variant-props.ts
+++ b/packages/framer-motion/src/render/utils/variant-props.ts
@@ -1,13 +1,13 @@
 import { AnimationType } from "./types"
 
-export const variantPriorityOrder = [
-    AnimationType.Animate,
-    AnimationType.InView,
-    AnimationType.Focus,
-    AnimationType.Hover,
-    AnimationType.Tap,
-    AnimationType.Drag,
-    AnimationType.Exit,
+export const variantPriorityOrder: AnimationType[] = [
+    "animate",
+    "whileInView",
+    "whileFocus",
+    "whileHover",
+    "whileTap",
+    "whileDrag",
+    "exit",
 ]
 
 export const variantProps = ["initial", ...variantPriorityOrder]


### PR DESCRIPTION
`enum` doesn't transpile well and offers no type safety over union types. Likewise maintability improvements were close to nil as these prop names never change.

Edit: Using this branch to replace `const enum` approach to 

Fixes https://github.com/framer/motion/issues/1976