### PR TITLE
Fixing projection tree optimisation

### DIFF
--- a/dev/projection/animate-relative-nested-deep.html
+++ b/dev/projection/animate-relative-nested-deep.html
@@ -1,0 +1,144 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                position: relative;
+                width: 200px;
+                height: 200px;
+                background-color: #00cc88;
+                display: flex;
+                align-items: flex-start;
+                justify-content: flex-start;
+            }
+
+            #mid {
+                width: 100px;
+                height: 100px;
+                background-color: white;
+                display: flex;
+                align-items: flex-start;
+                justify-content: flex-start;
+            }
+
+            #parent.b {
+                top: 100px;
+                left: 100px;
+            }
+
+            #child {
+                width: 80px;
+                height: 80px;
+                background-color: #0077ff;
+            }
+
+            #grandchild {
+                width: 20px;
+                height: 20px;
+                background-color: black;
+                position: relative;
+            }
+
+            .b #grandchild {
+                top: 1px;
+                left: 1px;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent">
+            <div id="mid">
+                <div id="child"><div id="grandchild"></div></div>
+            </div>
+        </div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { frameData } = window.Projection
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const mid = document.getElementById("mid")
+            const child = document.getElementById("child")
+            const grandchild = document.getElementById("grandchild")
+
+            const childOrigin = child.getBoundingClientRect()
+
+            let prevTimestamp = 0
+            let count = 0
+            const frameEasing = (t) => {
+                // Increment ease if new frame
+                if (prevTimestamp !== frameData.timestamp) {
+                    count++
+                }
+
+                prevTimestamp = frameData.timestamp
+
+                return count < 2 ? t : 0.5
+            }
+
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 200, ease: frameEasing }
+            )
+            const midProjection = createNode(
+                mid,
+                parentProjection,
+                {},
+                { duration: 200, ease: frameEasing }
+            )
+            const childProjection = createNode(
+                child,
+                midProjection,
+                {},
+                { duration: 200, ease: frameEasing }
+            )
+            const grandchildProjection = createNode(
+                grandchild,
+                childProjection,
+                {},
+                { duration: 200, ease: frameEasing }
+            )
+
+            parentProjection.willUpdate()
+            midProjection.willUpdate()
+            childProjection.willUpdate()
+            grandchildProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            sync.postRender(() => {
+                sync.postRender(() => {
+                    matchViewportBox(
+                        grandchild,
+                        {
+                            bottom: 71,
+                            height: 20,
+                            left: 51,
+                            right: 71,
+                            top: 51,
+                            width: 20,
+                        },
+                        2
+                    )
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/dev/projection/script-assert.js
+++ b/dev/projection/script-assert.js
@@ -25,6 +25,7 @@ window.MotionDebug = {
 window.Assert = {
     matchViewportBox: (element, expected, threshold = 0.01) => {
         const bbox = element.getBoundingClientRect()
+
         if (
             Math.abs(expected.top - bbox.top) > threshold ||
             Math.abs(expected.right - bbox.right) > threshold ||

--- a/dev/projection/script-assert.js
+++ b/dev/projection/script-assert.js
@@ -25,7 +25,6 @@ window.MotionDebug = {
 window.Assert = {
     matchViewportBox: (element, expected, threshold = 0.01) => {
         const bbox = element.getBoundingClientRect()
-
         if (
             Math.abs(expected.top - bbox.top) > threshold ||
             Math.abs(expected.right - bbox.right) > threshold ||

--- a/packages/framer-motion/src/projection/index.ts
+++ b/packages/framer-motion/src/projection/index.ts
@@ -6,9 +6,10 @@ export { calcBoxDelta } from "./geometry/delta-calc"
  * For debugging purposes
  */
 import { sync } from "../frameloop"
+import { frameData } from "../frameloop/data"
 import { mix } from "../utils/mix"
 import { animateValue } from "../animation/js"
-export { sync, animateValue as animate, mix }
+export { sync, animateValue as animate, mix, frameData }
 export { buildTransform } from "../render/html/utils/build-transform"
 export { addScaleCorrector } from "./styles/scale-correction"
 export { correctBorderRadius } from "./styles/scale-border-radius"

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -45,6 +45,7 @@ import { Process } from "../../frameloop/types"
 import { ProjectionFrame } from "../../debug/types"
 import { record } from "../../debug/record"
 import { AnimationOptions } from "../../animation/types"
+import { frameData } from "../../dom-entry"
 
 const transformAxes = ["", "X", "Y", "Z"]
 
@@ -985,7 +986,7 @@ export function createProjectionNode<I>({
             this.target = undefined
             this.isLayoutDirty = false
         }
-
+        resolvedTargetDeltaAt: number
         /**
          * Frame calculations
          */
@@ -1020,6 +1021,8 @@ export function createProjectionNode<I>({
              * If we have no layout, we can't perform projection, so early return
              */
             if (!this.layout || !(layout || layoutId)) return
+
+            this.resolvedTargetDeltaAt = frameData.timestamp
 
             /**
              * If we don't have a targetDelta but do have a layout, we can attempt to resolve
@@ -1066,7 +1069,9 @@ export function createProjectionNode<I>({
                 this.relativeTarget &&
                 this.relativeTargetOrigin &&
                 this.relativeParent &&
-                this.relativeParent.target
+                this.relativeParent.target &&
+                (this.relativeParent as any).resolvedTargetDeltaAt ===
+                    frameData.timestamp
             ) {
                 calcRelativeBox(
                     this.target,

--- a/packages/framer-motion/src/projection/node/types.ts
+++ b/packages/framer-motion/src/projection/node/types.ts
@@ -66,6 +66,7 @@ export interface IProjectionNode<I = unknown> {
     isProjectionDirty: boolean
     isSharedProjectionDirty: boolean
     isTransformDirty: boolean
+    resolvedRelativeTargetAt?: number
     shouldResetTransform: boolean
     prevTransformTemplateValue: string | undefined
     isUpdateBlocked(): boolean
@@ -102,7 +103,7 @@ export interface IProjectionNode<I = unknown> {
     resetTransform(): void
     resetRotation(): void
     applyTransform(box: Box, transformOnly?: boolean): Box
-    resolveTargetDelta(): void
+    resolveTargetDelta(force?: boolean): void
     calcProjection(): void
     getProjectionStyles(styles?: MotionStyle): MotionStyle | undefined
     clearMeasurements(): void


### PR DESCRIPTION
The recent projection tree optimisation introduced a bug where a deeply nested relative projection can only resolve against an up-to-date target. 

This PR ensures that if the parent target wasn't updated this frame, we force it to recalculate during the frame before calculating the relative offset.