### PR TITLE
Renaming `currentTime` to `time`

### DIFF
--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -16,25 +16,22 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
     /**
      * TODO: Filter out cancelled or stopped animations before returning
      */
-    get currentTime() {
-        return this.animations[0].currentTime
+    get time() {
+        return this.animations[0].time
     }
 
     /**
-     * currentTime assignment could reasonably run every frame, so
+     * time assignment could reasonably run every frame, so
      * we iterate using a normal loop to avoid function creation.
      */
-    set currentTime(time: number) {
+    set time(time: number) {
         for (let i = 0; i < this.animations.length; i++) {
-            this.animations[i].currentTime = time
+            this.animations[i].time = time
         }
     }
 
     private runAll(
-        methodName: keyof Omit<
-            AnimationPlaybackControls,
-            "currentTime" | "then"
-        >
+        methodName: keyof Omit<AnimationPlaybackControls, "time" | "then">
     ) {
         this.animations.forEach((controls) => controls[methodName]())
     }

--- a/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
+++ b/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
@@ -5,7 +5,7 @@ function createTestAnimationControls(
     partialControls?: Partial<AnimationPlaybackControls>
 ) {
     return {
-        currentTime: 1,
+        time: 1,
         stop: () => {},
         play: () => {},
         pause: () => {},
@@ -25,41 +25,41 @@ describe("GroupPlaybackControls", () => {
         expect(controls.animations[0]).toBe(a)
     })
 
-    test("Gets currentTime", () => {
+    test("Gets time", () => {
         const a: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
         })
 
         const controls = new GroupPlaybackControls([a])
 
-        expect(controls.currentTime).toBe(5)
+        expect(controls.time).toBe(5)
     })
 
-    test("Sets currentTime", () => {
+    test("Sets time", () => {
         const a: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
         })
 
         const b: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
         })
 
         const controls = new GroupPlaybackControls([a, b])
 
-        controls.currentTime = 1
+        controls.time = 1
 
-        expect(a.currentTime).toBe(1)
-        expect(b.currentTime).toBe(1)
+        expect(a.time).toBe(1)
+        expect(b.time).toBe(1)
     })
 
     test("Calls play on all animations", () => {
         const a: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
             play: jest.fn(),
         })
 
         const b: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
             play: jest.fn(),
         })
 
@@ -73,12 +73,12 @@ describe("GroupPlaybackControls", () => {
 
     test("Calls pause on all animations", () => {
         const a: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
             pause: jest.fn(),
         })
 
         const b: AnimationPlaybackControls = createTestAnimationControls({
-            currentTime: 5,
+            time: 5,
             pause: jest.fn(),
         })
 

--- a/packages/framer-motion/src/animation/create-instant-animation.ts
+++ b/packages/framer-motion/src/animation/create-instant-animation.ts
@@ -14,7 +14,7 @@ export function createInstantAnimation<V>({
         onComplete && onComplete()
 
         return {
-            currentTime: 0,
+            time: 0,
             play: noop<void>,
             pause: noop<void>,
             stop: noop<void>,

--- a/packages/framer-motion/src/animation/js/__tests__/animate.test.ts
+++ b/packages/framer-motion/src/animation/js/__tests__/animate.test.ts
@@ -843,7 +843,7 @@ describe("animate", () => {
         expect(animation.sample(4100).value).toEqual(96.10257237444083)
     })
 
-    test("Correctly sets and gets currentTime", async () => {
+    test("Correctly sets and gets time", async () => {
         const driver = syncDriver(20)
         const output: number[] = []
 
@@ -856,7 +856,7 @@ describe("animate", () => {
                     output.push(Math.round(v))
 
                     if (output.length === 4) {
-                        animation.currentTime = 0.02
+                        animation.time = 0.02
                     }
                 },
                 onComplete: () => resolve(),
@@ -919,7 +919,7 @@ describe("animate", () => {
         expect(output).toEqual([0, 20, 20, 20, 20, 20, 40, 60, 80])
     })
 
-    test("Correctly resumes after currentTime is set", async () => {
+    test("Correctly resumes after time is set", async () => {
         const driver = syncDriver(20)
         const output: number[] = []
 
@@ -933,7 +933,7 @@ describe("animate", () => {
                     if (output.length === 2) {
                         animation.pause()
                     } else if (output.length === 6) {
-                        animation.currentTime = 0.05
+                        animation.time = 0.05
                         animation.play()
                     } else if (output.length === 8) {
                         animation.stop()
@@ -947,7 +947,7 @@ describe("animate", () => {
         expect(output).toEqual([0, 20, 20, 20, 20, 20, 70, 90])
     })
 
-    test("Correctly sets currentTime during pause", async () => {
+    test("Correctly sets time during pause", async () => {
         const driver = syncDriver(20)
         const output: number[] = []
 
@@ -961,7 +961,7 @@ describe("animate", () => {
 
                     if (output.length === 2) {
                         animation.pause()
-                        animation.currentTime = 0.05
+                        animation.time = 0.05
                     } else if (output.length === 8) {
                         animation.stop()
                     }

--- a/packages/framer-motion/src/animation/js/index.ts
+++ b/packages/framer-motion/src/animation/js/index.ts
@@ -135,28 +135,28 @@ export function animateValue<V = number>({
         totalDuration = resolvedDuration * (repeat + 1) - repeatDelay
     }
 
-    let currentTime = 0
+    let time = 0
     const tick = (timestamp: number) => {
         if (startTime === null) return
 
         if (holdTime !== null) {
-            currentTime = holdTime
+            time = holdTime
         } else {
-            currentTime = timestamp - startTime
+            time = timestamp - startTime
         }
 
         // Rebase on delay
-        currentTime = Math.max(currentTime - delay, 0)
+        time = Math.max(time - delay, 0)
 
         /**
          * If this animation has finished, set the current time
          * to the total duration.
          */
         if (playState === "finished" && holdTime === null) {
-            currentTime = totalDuration
+            time = totalDuration
         }
 
-        let elapsed = currentTime
+        let elapsed = time
 
         let frameGenerator = generator
 
@@ -166,7 +166,7 @@ export function animateValue<V = number>({
              * than duration we'll get values like 2.5 (midway through the
              * third iteration)
              */
-            const progress = currentTime / resolvedDuration
+            const progress = time / resolvedDuration
 
             /**
              * Get the current iteration (0 indexed). For instance the floor of
@@ -205,7 +205,7 @@ export function animateValue<V = number>({
             }
 
             const p =
-                currentTime >= totalDuration
+                time >= totalDuration
                     ? repeatType === "reverse" && iterationIsOdd
                         ? 0
                         : 1
@@ -224,7 +224,7 @@ export function animateValue<V = number>({
         }
 
         if (calculatedDuration !== null) {
-            done = currentTime >= totalDuration
+            done = time >= totalDuration
         }
 
         const isAnimationFinished =
@@ -276,10 +276,10 @@ export function animateValue<V = number>({
         then(resolve: VoidFunction, reject?: VoidFunction) {
             return currentFinishedPromise.then(resolve, reject)
         },
-        get currentTime() {
-            return millisecondsToSeconds(currentTime)
+        get time() {
+            return millisecondsToSeconds(time)
         },
-        set currentTime(newTime: number) {
+        set time(newTime: number) {
             const timeInMs = secondsToMilliseconds(newTime)
             if (holdTime !== null || !animationDriver) {
                 holdTime = timeInMs
@@ -290,7 +290,7 @@ export function animateValue<V = number>({
         play,
         pause: () => {
             playState = "paused"
-            holdTime = currentTime
+            holdTime = time
         },
         stop: () => {
             onStop && onStop()

--- a/packages/framer-motion/src/animation/optimized-appear/handoff.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/handoff.ts
@@ -56,7 +56,7 @@ export function handoffOptimizedAppearAnimation(
          */
         sync.update(() => {
             if (value.animation) {
-                value.animation.currentTime =
+                value.animation.time =
                     performance.now() - millisecondsToSeconds(sampledTime)
             }
         })

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -7,7 +7,7 @@ import { Driver } from "./js/types"
  * @public
  */
 export interface AnimationPlaybackControls {
-    currentTime: number
+    time: number
     stop: () => void
     play: () => void
     pause: () => void

--- a/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/waapi/create-accelerated-animation.ts
@@ -130,10 +130,10 @@ export function createAcceleratedAnimation(
         then(resolve: VoidFunction, reject?: VoidFunction) {
             return animation.finished.then(resolve, reject)
         },
-        get currentTime() {
+        get time() {
             return millisecondsToSeconds(animation.currentTime || 0)
         },
-        set currentTime(newTime: number) {
+        set time(newTime: number) {
             animation.currentTime = secondsToMilliseconds(newTime)
         },
         play: () => animation.play(),


### PR DESCRIPTION
`currentTime` hasn't been published yet making this a safe change.

```javascript
animation.time = 0.5

console.log(animation.time) // 0.5
```