### PR TITLE
Add `.complete()` method to `animate()`

### DIFF
--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -51,4 +51,8 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
     cancel() {
         this.runAll("cancel")
     }
+
+    complete() {
+        this.runAll("complete")
+    }
 }

--- a/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
+++ b/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
@@ -12,6 +12,7 @@ function createTestAnimationControls(
         then: (resolve: VoidFunction) => {
             return Promise.resolve().then(resolve)
         },
+        complete: () => {},
         cancel: () => {},
         ...partialControls,
     }
@@ -164,5 +165,21 @@ describe("GroupPlaybackControls", () => {
 
         expect(a.cancel).toBeCalled()
         expect(b.cancel).toBeCalled()
+    })
+
+    test("Calls complete on all animations", async () => {
+        const a = createTestAnimationControls({
+            complete: jest.fn(),
+        })
+        const b = createTestAnimationControls({
+            complete: jest.fn(),
+        })
+
+        const controls = new GroupPlaybackControls([a, b])
+
+        controls.complete()
+
+        expect(a.complete).toBeCalled()
+        expect(b.complete).toBeCalled()
     })
 })

--- a/packages/framer-motion/src/animation/animators/instant.ts
+++ b/packages/framer-motion/src/animation/animators/instant.ts
@@ -22,6 +22,7 @@ export function createInstantAnimation<V>({
                 resolve()
                 return Promise.resolve()
             },
+            complete: noop<void>,
             cancel: noop<void>,
         }
     }

--- a/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
+++ b/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
@@ -113,6 +113,27 @@ describe("animate", () => {
         expect(output).toEqual([0, 20, 40, 0])
     })
 
+    test("Correctly completes an animation", async () => {
+        const output: number[] = []
+
+        const animation = animateValue({
+            keyframes: [0, 100],
+            driver: syncDriver(20),
+            duration: 100,
+            ease: linear,
+            onUpdate: (v) => {
+                output.push(v)
+                if (v === 40) {
+                    animation.complete()
+                }
+            },
+        })
+
+        await animation
+
+        expect(output).toEqual([0, 20, 40, 100])
+    })
+
     test("Correctly interpolates a string-based keyframes", async () => {
         return new Promise<void>((resolve) => {
             const numeric: number[] = []

--- a/packages/framer-motion/src/animation/animators/js/index.ts
+++ b/packages/framer-motion/src/animation/animators/js/index.ts
@@ -312,6 +312,10 @@ export function animateValue<V = number>({
             onStop && onStop()
             cancel()
         },
+        complete: () => {
+            playState = "finished"
+            holdTime === null
+        },
         cancel: () => {
             if (cancelTime !== null) tick(cancelTime)
             cancel()

--- a/packages/framer-motion/src/animation/animators/js/index.ts
+++ b/packages/framer-motion/src/animation/animators/js/index.ts
@@ -219,12 +219,6 @@ export function animateValue<V = number>({
         const state = frameGenerator.next(elapsed)
         let { value, done } = state
 
-        if (onUpdate) {
-            onUpdate(
-                mapNumbersToKeyframes ? mapNumbersToKeyframes(value) : value
-            )
-        }
-
         if (calculatedDuration !== null) {
             done = time >= totalDuration
         }
@@ -232,6 +226,12 @@ export function animateValue<V = number>({
         const isAnimationFinished =
             holdTime === null &&
             (playState === "finished" || (playState === "running" && done))
+
+        if (onUpdate) {
+            onUpdate(
+                mapNumbersToKeyframes ? mapNumbersToKeyframes(value) : value
+            )
+        }
 
         if (isAnimationFinished) {
             finish()

--- a/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
@@ -168,6 +168,7 @@ export function createAcceleratedAnimation(
         },
         play: () => animation.play(),
         pause: () => animation.pause(),
+        complete: () => animation.finish(),
         cancel: safeCancel,
         stop: () => {
             /**

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -30,6 +30,7 @@ export interface AnimationPlaybackControls {
     play: () => void
     pause: () => void
     cancel: () => void
+    complete: () => void
     then: (onResolve: VoidFunction, onReject?: VoidFunction) => Promise<void>
 }
 


### PR DESCRIPTION
This PR adds a `.complete()` method to `animate()`.

When called, animations will skip to the end.

```javascript
animation.complete()
```