### PR TITLE
`stagger()`

### DIFF
--- a/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
@@ -23,25 +23,6 @@ describe("animate() with WAAPI", () => {
         )
     })
 
-    test("Can override transition options per-value with legacy default option", async () => {
-        const a = document.createElement("div")
-
-        animate(
-            a,
-            { opacity: [0, 1], transform: ["scale(0)", "scale(1)"] },
-            { default: { duration: 1 }, transform: { duration: 2 } }
-        )
-
-        expect(a.animate).toBeCalledWith(
-            { opacity: [0, 1], offset: undefined },
-            { ...defaultOptions, duration: 1000 }
-        )
-
-        expect(a.animate).toBeCalledWith(
-            { transform: ["scale(0)", "scale(1)"], offset: undefined },
-            { ...defaultOptions, duration: 2000 }
-        )
-    })
     test("Applies stagger", async () => {
         const a = document.createElement("div")
         const b = document.createElement("div")

--- a/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
@@ -1,5 +1,6 @@
 import { animate } from "../animate"
 import { defaultOptions } from "../animators/waapi/__tests__/setup"
+import { stagger } from "../utils/stagger"
 
 describe("animate() with WAAPI", () => {
     test("Can override transition options per-value", async () => {
@@ -40,5 +41,41 @@ describe("animate() with WAAPI", () => {
             { transform: ["scale(0)", "scale(1)"], offset: undefined },
             { ...defaultOptions, duration: 2000 }
         )
+    })
+    test("Applies stagger", async () => {
+        const a = document.createElement("div")
+        const b = document.createElement("div")
+        const animation = animate(
+            [a, b],
+            { opacity: [0.2, 0.5] },
+            { delay: stagger(0.2) }
+        )
+
+        await animation.then(() => {
+            expect(a.animate).toBeCalled()
+            expect(a.animate).toBeCalledWith(
+                { opacity: [0.2, 0.5], offset: undefined },
+                {
+                    delay: -0,
+                    duration: 300,
+                    easing: "cubic-bezier(0.25, 0.1, 0.35, 1)",
+                    iterations: 1,
+                    direction: "normal",
+                    fill: "both",
+                }
+            )
+            expect(b.animate).toBeCalled()
+            expect(b.animate).toBeCalledWith(
+                { opacity: [0.2, 0.5], offset: undefined },
+                {
+                    delay: 200,
+                    duration: 300,
+                    easing: "cubic-bezier(0.25, 0.1, 0.35, 1)",
+                    iterations: 1,
+                    direction: "normal",
+                    fill: "both",
+                }
+            )
+        })
     })
 })

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "../../../jest.setup"
 import * as React from "react"
 import { useEffect } from "react"
-import { motion } from "../.."
+import { motion, stagger } from "../.."
 import { animate } from "../animate"
 import { useMotionValue } from "../../value/use-motion-value"
 import { motionValue, MotionValue } from "../../value"
@@ -219,5 +219,15 @@ describe("animate", () => {
                 resolve()
             }, 50)
         })
+    })
+
+    test("Applies stagger", async () => {
+        const animation = animate(
+            [document.createElement("div"), document.createElement("div")],
+            { opacity: [0.2, 0.5] },
+            { delay: stagger(0.2) }
+        )
+
+        await animation.then(() => {})
     })
 })

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -220,4 +220,19 @@ describe("animate", () => {
             }, 50)
         })
     })
+
+    test("Is typed correctly", async () => {
+        const div = document.createElement("div")
+        animate(
+            div,
+            { "--css-var": 0 },
+            { duration: 1, "--css-var": { duration: 1 } }
+        )
+        animate(
+            div,
+            { pathLength: 0 },
+            { duration: 1, pathLength: { duration: 1 } }
+        )
+        animate(div, { r: 0 }, { duration: 1, r: { duration: 1 } })
+    })
 })

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -113,7 +113,11 @@ describe("animate", () => {
 
     test("Applies target keyframe when animation has finished", async () => {
         const div = document.createElement("div")
-        const animation = animate(div, { opacity: 0.6 }, { duration })
+        const animation = animate(
+            div,
+            { opacity: 0.6 },
+            { duration, x: {}, "--css-var": {} }
+        )
         return animation.then(() => {
             expect(div).toHaveStyle("opacity: 0.6")
         })
@@ -122,7 +126,11 @@ describe("animate", () => {
     test("Works with multiple elements", async () => {
         const div = document.createElement("div")
         const div2 = document.createElement("div")
-        const animation = animate([div, div2], { opacity: 0.6 }, { duration })
+        const animation = animate(
+            [div, div2],
+            { opacity: 0.6 },
+            { duration, x: {}, "--css-var": {} }
+        )
         await animation.then(() => {
             expect(div).toHaveStyle("opacity: 0.6")
             expect(div2).toHaveStyle("opacity: 0.6")

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -1,11 +1,10 @@
 import { render } from "../../../jest.setup"
 import * as React from "react"
 import { useEffect } from "react"
-import { motion, stagger } from "../.."
+import { motion } from "../.."
 import { animate } from "../animate"
 import { useMotionValue } from "../../value/use-motion-value"
 import { motionValue, MotionValue } from "../../value"
-import { restoreWaapi, setupWaapi } from "../animators/waapi/__tests__/setup"
 
 const duration = 0.001
 
@@ -211,53 +210,6 @@ describe("animate", () => {
                 expect(div).toHaveStyle("opacity: 0.5")
                 resolve()
             }, 50)
-        })
-    })
-})
-
-describe("animate() with WAAPI", () => {
-    beforeEach(() => {
-        setupWaapi()
-    })
-
-    afterEach(() => {
-        restoreWaapi()
-    })
-
-    test("Applies stagger", async () => {
-        const a = document.createElement("div")
-        const b = document.createElement("div")
-        const animation = animate(
-            [a, b],
-            { opacity: [0.2, 0.5] },
-            { delay: stagger(0.2) }
-        )
-
-        await animation.then(() => {
-            expect(a.animate).toBeCalled()
-            expect(a.animate).toBeCalledWith(
-                { opacity: [0.2, 0.5], offset: undefined },
-                {
-                    delay: -0,
-                    duration: 300,
-                    easing: "cubic-bezier(0.25, 0.1, 0.35, 1)",
-                    iterations: 1,
-                    direction: "normal",
-                    fill: "both",
-                }
-            )
-            expect(b.animate).toBeCalled()
-            expect(b.animate).toBeCalledWith(
-                { opacity: [0.2, 0.5], offset: undefined },
-                {
-                    delay: 200,
-                    duration: 300,
-                    easing: "cubic-bezier(0.25, 0.1, 0.35, 1)",
-                    iterations: 1,
-                    direction: "normal",
-                    fill: "both",
-                }
-            )
         })
     })
 })

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -17,8 +17,7 @@ import { GenericKeyframesTarget } from "../types"
 import { createVisualElement } from "./utils/create-visual-element"
 import { animateSingleValue } from "./interfaces/single-value"
 
-export interface DOMAnimationOptions
-    extends Omit<AnimateOptions<any>, "delay"> {
+export interface DOMAnimationOptions extends Omit<AnimateOptions, "delay"> {
     delay?: number | DynamicOption<number>
 }
 
@@ -65,7 +64,7 @@ function animateElements(
         animations.push(
             ...animateTarget(
                 visualElement,
-                { ...keyframes, transition } as any,
+                { ...keyframes, transition } as AnimateOptions,
                 {}
             )
         )

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -4,7 +4,7 @@ import { invariant } from "../utils/errors"
 import { MotionValue } from "../value"
 import { GroupPlaybackControls } from "./GroupPlaybackControls"
 import {
-    AnimateOptions,
+    AnimationOptionsWithValueOverrides,
     AnimationPlaybackControls,
     AnimationScope,
     DOMKeyframesDefinition,
@@ -17,7 +17,8 @@ import { GenericKeyframesTarget } from "../types"
 import { createVisualElement } from "./utils/create-visual-element"
 import { animateSingleValue } from "./interfaces/single-value"
 
-export interface DOMAnimationOptions extends Omit<AnimateOptions, "delay"> {
+export interface DOMAnimationOptions
+    extends Omit<AnimationOptionsWithValueOverrides, "delay"> {
     delay?: number | DynamicOption<number>
 }
 
@@ -80,12 +81,12 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate(
         from: string,
         to: string | GenericKeyframesTarget<string>,
-        options?: AnimateOptions<string>
+        options?: AnimationOptionsWithValueOverrides<string>
     ): AnimationPlaybackControls
     function scopedAnimate(
         from: number,
         to: number | GenericKeyframesTarget<number>,
-        options?: AnimateOptions<number>
+        options?: AnimationOptionsWithValueOverrides<number>
     ): AnimationPlaybackControls
     /**
      * Animate a MotionValue
@@ -93,12 +94,12 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate(
         value: MotionValue<string>,
         keyframes: string | GenericKeyframesTarget<string>,
-        options?: AnimateOptions<string>
+        options?: AnimationOptionsWithValueOverrides<string>
     ): AnimationPlaybackControls
     function scopedAnimate(
         value: MotionValue<number>,
         keyframes: number | GenericKeyframesTarget<number>,
-        options?: AnimateOptions<number>
+        options?: AnimationOptionsWithValueOverrides<number>
     ): AnimationPlaybackControls
     /**
      * Animate DOM
@@ -111,7 +112,9 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate<V>(
         valueOrElement: ElementOrSelector | MotionValue<V> | V,
         keyframes: DOMKeyframesDefinition | V | GenericKeyframesTarget<V>,
-        options: AnimateOptions<V> | DOMAnimationOptions = {}
+        options:
+            | AnimationOptionsWithValueOverrides<V>
+            | DOMAnimationOptions = {}
     ): AnimationPlaybackControls {
         let animation: AnimationPlaybackControls
 
@@ -126,7 +129,7 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
             animation = animateSingleValue(
                 valueOrElement,
                 keyframes,
-                options as AnimateOptions<V>
+                options as AnimationOptionsWithValueOverrides<V>
             )
         }
 

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -17,11 +17,12 @@ import { GenericKeyframesTarget } from "../types"
 import { createVisualElement } from "./utils/create-visual-element"
 import { animateSingleValue } from "./interfaces/single-value"
 
-export interface Stagger {
+export interface Stagger {}
+
+export interface DOMAnimationOptions
+    extends Omit<AnimateOptions<any>, "delay"> {
     delay?: number | DynamicOption<number>
 }
-
-export type DOMAnimationOptions = Omit<AnimateOptions<any>, "delay"> & Stagger
 
 function animateElements(
     elementOrSelector: ElementOrSelector,
@@ -54,17 +55,19 @@ function animateElements(
 
         const visualElement = visualElementStore.get(element)!
 
+        const transition = { ...options }
+
         /**
          * Resolve stagger function if provided.
          */
-        if (typeof options.delay === "function") {
-            options.delay = options.delay(i, numElements)
+        if (typeof transition.delay === "function") {
+            transition.delay = transition.delay(i, numElements)
         }
 
         animations.push(
             ...animateTarget(
                 visualElement,
-                { ...keyframes, transition: options } as any,
+                { ...keyframes, transition } as any,
                 {}
             )
         )
@@ -111,7 +114,7 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate<V>(
         valueOrElement: ElementOrSelector | MotionValue<V> | V,
         keyframes: DOMKeyframesDefinition | V | GenericKeyframesTarget<V>,
-        options?: AnimateOptions<V> | DOMAnimationOptions
+        options: AnimateOptions<V> | DOMAnimationOptions = {}
     ): AnimationPlaybackControls {
         let animation: AnimationPlaybackControls
 

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -10,14 +10,15 @@ import {
     DOMKeyframesDefinition,
     DynamicOption,
     ElementOrSelector,
+    ValueAnimationTransition,
 } from "./types"
 import { isDOMKeyframes } from "./utils/is-dom-keyframes"
 import { animateTarget } from "./interfaces/visual-element-target"
-import { GenericKeyframesTarget } from "../types"
+import { GenericKeyframesTarget, TargetAndTransition } from "../types"
 import { createVisualElement } from "./utils/create-visual-element"
 import { animateSingleValue } from "./interfaces/single-value"
 
-export interface DOMAnimationOptions
+export interface DynamicAnimationOptions
     extends Omit<AnimationOptionsWithValueOverrides, "delay"> {
     delay?: number | DynamicOption<number>
 }
@@ -25,7 +26,7 @@ export interface DOMAnimationOptions
 function animateElements(
     elementOrSelector: ElementOrSelector,
     keyframes: DOMKeyframesDefinition,
-    options: DOMAnimationOptions,
+    options?: DynamicAnimationOptions,
     scope?: AnimationScope
 ): AnimationPlaybackControls {
     const elements = resolveElements(elementOrSelector, scope)
@@ -65,7 +66,7 @@ function animateElements(
         animations.push(
             ...animateTarget(
                 visualElement,
-                { ...keyframes, transition } as AnimateOptions,
+                { ...keyframes, transition } as TargetAndTransition,
                 {}
             )
         )
@@ -81,12 +82,12 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate(
         from: string,
         to: string | GenericKeyframesTarget<string>,
-        options?: AnimationOptionsWithValueOverrides<string>
+        options?: ValueAnimationTransition<string>
     ): AnimationPlaybackControls
     function scopedAnimate(
         from: number,
         to: number | GenericKeyframesTarget<number>,
-        options?: AnimationOptionsWithValueOverrides<number>
+        options?: ValueAnimationTransition<number>
     ): AnimationPlaybackControls
     /**
      * Animate a MotionValue
@@ -94,12 +95,12 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate(
         value: MotionValue<string>,
         keyframes: string | GenericKeyframesTarget<string>,
-        options?: AnimationOptionsWithValueOverrides<string>
+        options?: ValueAnimationTransition<string>
     ): AnimationPlaybackControls
     function scopedAnimate(
         value: MotionValue<number>,
         keyframes: number | GenericKeyframesTarget<number>,
-        options?: AnimationOptionsWithValueOverrides<number>
+        options?: ValueAnimationTransition<number>
     ): AnimationPlaybackControls
     /**
      * Animate DOM
@@ -107,14 +108,12 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
     function scopedAnimate(
         value: ElementOrSelector,
         keyframes: DOMKeyframesDefinition,
-        options?: DOMAnimationOptions
+        options?: DynamicAnimationOptions
     ): AnimationPlaybackControls
     function scopedAnimate<V>(
         valueOrElement: ElementOrSelector | MotionValue<V> | V,
         keyframes: DOMKeyframesDefinition | V | GenericKeyframesTarget<V>,
-        options:
-            | AnimationOptionsWithValueOverrides<V>
-            | DOMAnimationOptions = {}
+        options?: ValueAnimationTransition<V> | DynamicAnimationOptions
     ): AnimationPlaybackControls {
         let animation: AnimationPlaybackControls
 
@@ -122,14 +121,14 @@ export const createScopedAnimate = (scope?: AnimationScope) => {
             animation = animateElements(
                 valueOrElement as ElementOrSelector,
                 keyframes,
-                options as DOMAnimationOptions,
+                options as DynamicAnimationOptions | undefined,
                 scope
             )
         } else {
             animation = animateSingleValue(
                 valueOrElement,
                 keyframes,
-                options as AnimationOptionsWithValueOverrides<V>
+                options as ValueAnimationTransition<V> | undefined
             )
         }
 

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -17,8 +17,6 @@ import { GenericKeyframesTarget } from "../types"
 import { createVisualElement } from "./utils/create-visual-element"
 import { animateSingleValue } from "./interfaces/single-value"
 
-export interface Stagger {}
-
 export interface DOMAnimationOptions
     extends Omit<AnimateOptions<any>, "delay"> {
     delay?: number | DynamicOption<number>

--- a/packages/framer-motion/src/animation/animators/instant.ts
+++ b/packages/framer-motion/src/animation/animators/instant.ts
@@ -1,6 +1,5 @@
-import { AnimationPlaybackControls } from "../types"
+import { AnimationPlaybackControls, ValueAnimationOptions } from "../types"
 import { animateValue } from "./js"
-import { AnimationOptions } from "../types"
 import { noop } from "../../utils/noop"
 
 export function createInstantAnimation<V>({
@@ -8,7 +7,7 @@ export function createInstantAnimation<V>({
     delay: delayBy,
     onUpdate,
     onComplete,
-}: AnimationOptions<V>): AnimationPlaybackControls {
+}: ValueAnimationOptions<V>): AnimationPlaybackControls {
     const setValue = (): AnimationPlaybackControls => {
         onUpdate && onUpdate(keyframes[keyframes.length - 1])
         onComplete && onComplete()

--- a/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
+++ b/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
@@ -2,13 +2,13 @@ import { animateValue } from "../"
 import { reverseEasing } from "../../../../easing/modifiers/reverse"
 import { nextFrame } from "../../../../gestures/__tests__/utils"
 import { noop } from "../../../../utils/noop"
-import { AnimationOptions } from "../../../types"
+import { ValueAnimationOptions } from "../../../types"
 import { syncDriver } from "./utils"
 
 const linear = noop
 
 function testAnimate<V>(
-    options: AnimationOptions<V>,
+    options: ValueAnimationOptions<V>,
     expected: V[],
     resolve: () => void
 ) {

--- a/packages/framer-motion/src/animation/animators/js/index.ts
+++ b/packages/framer-motion/src/animation/animators/js/index.ts
@@ -4,7 +4,7 @@ import { spring } from "../../generators/spring/index"
 import { inertia } from "../../generators/inertia"
 import { AnimationState, KeyframeGenerator } from "../../generators/types"
 import { DriverControls } from "./types"
-import { AnimationOptions } from "../../types"
+import { ValueAnimationOptions } from "../../types"
 import { frameloopDriver } from "./driver-frameloop"
 import { interpolate } from "../../../utils/interpolate"
 import { clamp } from "../../../utils/clamp"
@@ -14,7 +14,7 @@ import {
 } from "../../../utils/time-conversion"
 
 type GeneratorFactory = (
-    options: AnimationOptions<any>
+    options: ValueAnimationOptions<any>
 ) => KeyframeGenerator<any>
 
 const types: { [key: string]: GeneratorFactory } = {
@@ -67,7 +67,7 @@ export function animateValue<V = number>({
     onComplete,
     onUpdate,
     ...options
-}: AnimationOptions<V>): MainThreadAnimationControls<V> {
+}: ValueAnimationOptions<V>): MainThreadAnimationControls<V> {
     let speed = 1
 
     let hasStopped = false

--- a/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
@@ -2,7 +2,7 @@ import { EasingDefinition } from "../../../easing/types"
 import { sync } from "../../../frameloop"
 import type { VisualElement } from "../../../render/VisualElement"
 import type { MotionValue } from "../../../value"
-import { AnimationOptions, AnimationPlaybackControls } from "../../types"
+import { AnimationPlaybackControls, ValueAnimationOptions } from "../../types"
 import { animateStyle } from "."
 import { isWaapiSupportedEasing } from "./easing"
 import { supports } from "./supports"
@@ -39,7 +39,7 @@ const maxDuration = 20_000
 
 const requiresPregeneratedKeyframes = (
     valueName: string,
-    options: AnimationOptions
+    options: ValueAnimationOptions
 ) =>
     options.type === "spring" ||
     valueName === "backgroundColor" ||
@@ -48,7 +48,7 @@ const requiresPregeneratedKeyframes = (
 export function createAcceleratedAnimation(
     value: MotionValue,
     valueName: string,
-    { onUpdate, onComplete, ...options }: AnimationOptions
+    { onUpdate, onComplete, ...options }: ValueAnimationOptions
 ): AnimationPlaybackControls | false {
     const canAccelerateAnimation =
         supports.waapi() &&

--- a/packages/framer-motion/src/animation/generators/__tests__/spring.test.ts
+++ b/packages/framer-motion/src/animation/generators/__tests__/spring.test.ts
@@ -1,4 +1,4 @@
-import { AnimationOptions } from "../../types"
+import { ValueAnimationOptions } from "../../types"
 import { spring } from "../spring"
 import { animateSync } from "../../animators/js/__tests__/utils"
 
@@ -23,7 +23,7 @@ describe("spring", () => {
     })
 
     test("Velocity passed to underdamped spring", () => {
-        const settings: AnimationOptions<number> = {
+        const settings: ValueAnimationOptions<number> = {
             keyframes: [100, 1000],
             stiffness: 300,
             restSpeed: 10,

--- a/packages/framer-motion/src/animation/generators/inertia.ts
+++ b/packages/framer-motion/src/animation/generators/inertia.ts
@@ -1,6 +1,6 @@
 import { AnimationState, KeyframeGenerator } from "./types"
 import { spring as createSpring } from "./spring"
-import { AnimationOptions } from "../types"
+import { ValueAnimationOptions } from "../types"
 import { calcGeneratorVelocity } from "./utils/velocity"
 
 export function inertia({
@@ -15,7 +15,7 @@ export function inertia({
     max,
     restDelta = 0.5,
     restSpeed,
-}: AnimationOptions<number>): KeyframeGenerator<number> {
+}: ValueAnimationOptions<number>): KeyframeGenerator<number> {
     const origin = keyframes[0]
 
     const state: AnimationState<number> = {

--- a/packages/framer-motion/src/animation/generators/keyframes.ts
+++ b/packages/framer-motion/src/animation/generators/keyframes.ts
@@ -3,7 +3,7 @@ import { EasingFunction } from "../../easing/types"
 import { interpolate } from "../../utils/interpolate"
 import { defaultOffset } from "../../utils/offsets/default"
 import { convertOffsetToTimes } from "../../utils/offsets/time"
-import { AnimationOptions } from "../types"
+import { ValueAnimationOptions } from "../types"
 import { easingDefinitionToFunction, isEasingArray } from "../utils/easing"
 import { AnimationState, KeyframeGenerator } from "./types"
 
@@ -19,7 +19,7 @@ export function keyframes<T>({
     keyframes: keyframeValues,
     times,
     ease = "easeInOut",
-}: AnimationOptions<T>): KeyframeGenerator<T> {
+}: ValueAnimationOptions<T>): KeyframeGenerator<T> {
     /**
      * Easing functions can be externally defined as strings. Here we convert them
      * into actual functions.

--- a/packages/framer-motion/src/animation/generators/spring/index.ts
+++ b/packages/framer-motion/src/animation/generators/spring/index.ts
@@ -1,5 +1,5 @@
 import { millisecondsToSeconds } from "../../../utils/time-conversion"
-import { AnimationOptions, SpringOptions } from "../../types"
+import { ValueAnimationOptions, SpringOptions } from "../../types"
 import { AnimationState, KeyframeGenerator } from "../types"
 import { calcGeneratorVelocity } from "../utils/velocity"
 import { calcAngularFreq, findSpring } from "./find"
@@ -45,7 +45,7 @@ export function spring({
     restDelta,
     restSpeed,
     ...options
-}: AnimationOptions<number>): KeyframeGenerator<number> {
+}: ValueAnimationOptions<number>): KeyframeGenerator<number> {
     const origin = keyframes[0]
     const target = keyframes[keyframes.length - 1]
 

--- a/packages/framer-motion/src/animation/interfaces/motion-value.ts
+++ b/packages/framer-motion/src/animation/interfaces/motion-value.ts
@@ -5,13 +5,12 @@ import { instantAnimationState } from "../../utils/use-instant-transition-state"
 import type { MotionValue, StartAnimation } from "../../value"
 import { createAcceleratedAnimation } from "../animators/waapi/create-accelerated-animation"
 import { createInstantAnimation } from "../animators/instant"
-import { AnimationOptions } from "../types"
 import { getDefaultTransition } from "../utils/default-transitions"
 import { isAnimatable } from "../utils/is-animatable"
 import { getKeyframes } from "../utils/keyframes"
 import { getValueTransition, isTransitionDefined } from "../utils/transitions"
 import { animateValue } from "../animators/js"
-import { AnimationPlaybackControls } from "../types"
+import { AnimationPlaybackControls, ValueAnimationOptions } from "../types"
 
 export const animateMotionValue = (
     valueName: string,
@@ -58,7 +57,7 @@ export const animateMotionValue = (
             `You are trying to animate ${valueName} from "${originKeyframe}" to "${targetKeyframe}". ${originKeyframe} is not an animatable value - to enable this animation set ${originKeyframe} to a value animatable to ${targetKeyframe} via the \`style\` property.`
         )
 
-        let options: AnimationOptions = {
+        let options: ValueAnimationOptions = {
             keyframes,
             velocity: value.getVelocity(),
             ease: "easeOut",

--- a/packages/framer-motion/src/animation/interfaces/single-value.ts
+++ b/packages/framer-motion/src/animation/interfaces/single-value.ts
@@ -2,12 +2,12 @@ import { animateMotionValue } from "./motion-value"
 import { motionValue as createMotionValue, MotionValue } from "../../value"
 import { isMotionValue } from "../../value/utils/is-motion-value"
 import { GenericKeyframesTarget } from "../../types"
-import { AnimateOptions, AnimationPlaybackControls } from "../types"
+import { AnimationPlaybackControls, ValueAnimationTransition } from "../types"
 
 export function animateSingleValue<V>(
     value: MotionValue<V> | V,
     keyframes: V | GenericKeyframesTarget<V>,
-    options: AnimateOptions<V>
+    options?: ValueAnimationTransition
 ): AnimationPlaybackControls {
     const motionValue = isMotionValue(value) ? value : createMotionValue(value)
 

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -12,12 +12,27 @@ export interface AnimationPlaybackLifecycles<V> {
     onStop?: () => void
 }
 
+export interface AnimationOptions<V = any>
+    extends AnimationLifecycleOptions<V>,
+        AnimationPlaybackOptions,
+        Omit<SpringOptions, "keyframes">,
+        Omit<InertiaOptions, "keyframes">,
+        KeyframeOptions {
+    delay?: number
+    keyframes: V[]
+    elapsed?: number
+    driver?: Driver
+    type?: "decay" | "spring" | "keyframes" | "tween" | "inertia"
+    duration?: number
+    autoplay?: boolean
+}
+
 export interface AnimationScope<T = any> {
     readonly current: T
     animations: AnimationPlaybackControls[]
 }
 
-export type AnimateOptions<V = any> = Transition &
+export type AnimateOptions<V = any> = Omit<AnimationOptions<V>, "keyframes"> &
     AnimationPlaybackLifecycles<V>
 
 export type ElementOrSelector =
@@ -125,21 +140,6 @@ export interface InertiaOptions extends DecayOptions {
 export interface KeyframeOptions {
     ease?: Easing | Easing[]
     times?: number[]
-}
-
-export interface AnimationOptions<V = any>
-    extends AnimationLifecycleOptions<V>,
-        AnimationPlaybackOptions,
-        Omit<SpringOptions, "keyframes">,
-        Omit<InertiaOptions, "keyframes">,
-        KeyframeOptions {
-    delay?: number
-    keyframes: V[]
-    elapsed?: number
-    driver?: Driver
-    type?: "decay" | "spring" | "keyframes" | "tween" | "inertia"
-    duration?: number
-    autoplay?: boolean
 }
 
 export type AnimationDefinition =

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -2,7 +2,8 @@ import { TargetAndTransition, TargetResolver } from "../types"
 import type { VisualElement } from "../render/VisualElement"
 import { Easing } from "../easing/types"
 import { Driver } from "./animators/js/types"
-import { VariantLabels } from "../motion/types"
+import { SVGPathProperties, VariantLabels } from "../motion/types"
+import { SVGAttributes } from "../render/svg/types-attributes"
 
 export interface AnimationPlaybackLifecycles<V> {
     onUpdate?: (latest: V) => void
@@ -43,11 +44,21 @@ export type StyleTransitions = {
     [K in keyof CSSStyleDeclarationWithTransform]?: Transition
 }
 
+export type SVGPathTransitions = {
+    [K in keyof SVGPathProperties]: Transition
+}
+
+export type SVGTransitions = {
+    [K in keyof SVGAttributes]: Transition
+}
+
 export type VariableTransitions = {
     [key: `--${string}`]: Transition
 }
 
 export type AnimationOptionsWithValueOverrides<V = any> = StyleTransitions &
+    SVGPathTransitions &
+    SVGTransitions &
     VariableTransitions &
     ValueAnimationTransition<V>
 
@@ -101,11 +112,21 @@ export type StyleKeyframesDefinition = {
     [K in keyof CSSStyleDeclarationWithTransform]?: ValueKeyframesDefinition
 }
 
+export type SVGKeyframesDefinition = {
+    [K in keyof SVGAttributes]?: ValueKeyframesDefinition
+}
+
 export type VariableKeyframesDefinition = {
     [key: `--${string}`]: ValueKeyframesDefinition
 }
 
+export type SVGPathKeyframesDefinition = {
+    [K in keyof SVGPathProperties]?: ValueKeyframesDefinition
+}
+
 export type DOMKeyframesDefinition = StyleKeyframesDefinition &
+    SVGKeyframesDefinition &
+    SVGPathKeyframesDefinition &
     VariableKeyframesDefinition
 
 export interface VelocityOptions {

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -12,8 +12,8 @@ export interface AnimationPlaybackLifecycles<V> {
     onStop?: () => void
 }
 
-export interface AnimationOptions<V = any>
-    extends AnimationLifecycleOptions<V>,
+export interface ValueAnimationOptions<V = any>
+    extends AnimationPlaybackLifecycles<V>,
         AnimationPlaybackOptions,
         Omit<SpringOptions, "keyframes">,
         Omit<InertiaOptions, "keyframes">,
@@ -32,8 +32,16 @@ export interface AnimationScope<T = any> {
     animations: AnimationPlaybackControls[]
 }
 
-export type AnimateOptions<V = any> = Omit<AnimationOptions<V>, "keyframes"> &
-    AnimationPlaybackLifecycles<V>
+export type StyleAnimationOptions = {
+    [K in keyof CSSStyleDeclarationWithTransform]?: ValueAnimationOptions
+}
+
+export type VariableAnimationOptions = {
+    [key: `--${string}`]: ValueAnimationOptions
+}
+
+export type AnimationOptionsWithValueOverrides<V = any> =
+    StyleAnimationOptions & VariableAnimationOptions & ValueAnimationOptions<V>
 
 export type ElementOrSelector =
     | Element
@@ -96,14 +104,6 @@ export interface VelocityOptions {
     velocity?: number
     restSpeed?: number
     restDelta?: number
-}
-
-export interface AnimationLifecycleOptions<V> {
-    onUpdate?: (v: V) => void
-    onComplete?: VoidFunction
-    onPlay?: VoidFunction
-    onRepeat?: VoidFunction
-    onStop?: VoidFunction
 }
 
 export interface AnimationPlaybackOptions {

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -40,6 +40,8 @@ export interface AnimationPlaybackControls {
     then: (onResolve: VoidFunction, onReject?: VoidFunction) => Promise<void>
 }
 
+export type DynamicOption<T> = (i: number, total: number) => T
+
 export interface CSSStyleDeclarationWithTransform
     extends Omit<CSSStyleDeclaration, "direction" | "transition"> {
     x: number | string

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -1,4 +1,4 @@
-import { TargetAndTransition, TargetResolver, Transition } from "../types"
+import { TargetAndTransition, TargetResolver } from "../types"
 import type { VisualElement } from "../render/VisualElement"
 import { Easing } from "../easing/types"
 import { Driver } from "./animators/js/types"
@@ -12,14 +12,12 @@ export interface AnimationPlaybackLifecycles<V> {
     onStop?: () => void
 }
 
-export interface ValueAnimationOptions<V = any>
-    extends AnimationPlaybackLifecycles<V>,
-        AnimationPlaybackOptions,
+export interface Transition
+    extends AnimationPlaybackOptions,
         Omit<SpringOptions, "keyframes">,
         Omit<InertiaOptions, "keyframes">,
         KeyframeOptions {
     delay?: number
-    keyframes: V[]
     elapsed?: number
     driver?: Driver
     type?: "decay" | "spring" | "keyframes" | "tween" | "inertia"
@@ -27,21 +25,31 @@ export interface ValueAnimationOptions<V = any>
     autoplay?: boolean
 }
 
+export interface ValueAnimationTransition<V = any>
+    extends Transition,
+        AnimationPlaybackLifecycles<V> {}
+
+export interface ValueAnimationOptions<V = any>
+    extends ValueAnimationTransition {
+    keyframes: V[]
+}
+
 export interface AnimationScope<T = any> {
     readonly current: T
     animations: AnimationPlaybackControls[]
 }
 
-export type StyleAnimationOptions = {
-    [K in keyof CSSStyleDeclarationWithTransform]?: ValueAnimationOptions
+export type StyleTransitions = {
+    [K in keyof CSSStyleDeclarationWithTransform]?: Transition
 }
 
-export type VariableAnimationOptions = {
-    [key: `--${string}`]: ValueAnimationOptions
+export type VariableTransitions = {
+    [key: `--${string}`]: Transition
 }
 
-export type AnimationOptionsWithValueOverrides<V = any> =
-    StyleAnimationOptions & VariableAnimationOptions & ValueAnimationOptions<V>
+export type AnimationOptionsWithValueOverrides<V = any> = StyleTransitions &
+    VariableTransitions &
+    ValueAnimationTransition<V>
 
 export type ElementOrSelector =
     | Element

--- a/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
+++ b/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
@@ -7,9 +7,9 @@ describe("stagger", () => {
         expect(stagger(0.1)(2, 10)).toEqual(0.2)
     })
 
-    test("Accepts start", () => {
-        expect(stagger(0.1, { start: 0.2 })(0, 10)).toEqual(0.2)
-        expect(stagger(0.1, { start: 0.2 })(2, 10)).toEqual(0.4)
+    test("Accepts startDelay", () => {
+        expect(stagger(0.1, { startDelay: 0.2 })(0, 10)).toEqual(0.2)
+        expect(stagger(0.1, { startDelay: 0.2 })(2, 10)).toEqual(0.4)
     })
 
     test("Accepts from", () => {

--- a/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
+++ b/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
@@ -1,5 +1,5 @@
 import { easingDefinitionToFunction } from "../easing"
-import { stagger, getFromIndex } from "../stagger"
+import { stagger, getOriginIndex } from "../stagger"
 
 describe("stagger", () => {
     test("Creates a stagger function", () => {
@@ -13,37 +13,33 @@ describe("stagger", () => {
     })
 
     test("Accepts from", () => {
-        expect(stagger(0.1, { from: 2 })(0, 10)).toEqual(0.2)
-        expect(stagger(0.1, { from: "first" })(2, 10)).toEqual(0.2)
-        expect(stagger(0.1, { from: "last" })(9, 10)).toEqual(0)
-        expect(stagger(0.1, { from: "last" })(5, 10)).toEqual(0.4)
-        expect(stagger(0.1, { from: "center" })(2, 10)).toEqual(0.25)
+        expect(stagger(0.1, { origin: 2 })(0, 10)).toEqual(0.2)
+        expect(stagger(0.1, { origin: "first" })(2, 10)).toEqual(0.2)
+        expect(stagger(0.1, { origin: "last" })(9, 10)).toEqual(0)
+        expect(stagger(0.1, { origin: "last" })(5, 10)).toEqual(0.4)
+        expect(stagger(0.1, { origin: "center" })(2, 10)).toEqual(0.25)
     })
 
     test("Accepts easing", () => {
-        expect(stagger(0.1, { easing: "linear" })(5, 10)).toEqual(0.5)
+        expect(stagger(0.1, { ease: "linear" })(5, 10)).toEqual(0.5)
 
         const expectedEaseIn = easingDefinitionToFunction("easeIn")(0.5)
-        expect(stagger(0.1, { easing: "easeIn" })(5, 10)).toEqual(
-            expectedEaseIn
-        )
+        expect(stagger(0.1, { ease: "easeIn" })(5, 10)).toEqual(expectedEaseIn)
 
         const expectedEaseOut = easingDefinitionToFunction("easeOut")(0.5)
-        expect(stagger(0.1, { easing: "easeOut" })(5, 10)).toEqual(
+        expect(stagger(0.1, { ease: "easeOut" })(5, 10)).toEqual(
             expectedEaseOut
         )
 
-        expect(stagger(0.1, { easing: (v: number) => v / 2 })(4, 10)).toEqual(
-            0.2
-        )
+        expect(stagger(0.1, { ease: (v: number) => v / 2 })(4, 10)).toEqual(0.2)
     })
 })
 
-describe("getFromIndex", () => {
+describe("getOriginIndex", () => {
     test("Returns correct index", () => {
-        expect(getFromIndex("first", 9)).toEqual(0)
-        expect(getFromIndex("last", 9)).toEqual(8)
-        expect(getFromIndex("center", 9)).toEqual(4)
-        expect(getFromIndex("center", 10)).toEqual(4.5)
+        expect(getOriginIndex("first", 9)).toEqual(0)
+        expect(getOriginIndex("last", 9)).toEqual(8)
+        expect(getOriginIndex("center", 9)).toEqual(4)
+        expect(getOriginIndex("center", 10)).toEqual(4.5)
     })
 })

--- a/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
+++ b/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
@@ -1,0 +1,49 @@
+import { easingDefinitionToFunction } from "../easing"
+import { stagger, getFromIndex } from "../stagger"
+
+describe("stagger", () => {
+    test("Creates a stagger function", () => {
+        expect(stagger(0.1)(0, 10)).toEqual(0)
+        expect(stagger(0.1)(2, 10)).toEqual(0.2)
+    })
+
+    test("Accepts start", () => {
+        expect(stagger(0.1, { start: 0.2 })(0, 10)).toEqual(0.2)
+        expect(stagger(0.1, { start: 0.2 })(2, 10)).toEqual(0.4)
+    })
+
+    test("Accepts from", () => {
+        expect(stagger(0.1, { from: 2 })(0, 10)).toEqual(0.2)
+        expect(stagger(0.1, { from: "first" })(2, 10)).toEqual(0.2)
+        expect(stagger(0.1, { from: "last" })(9, 10)).toEqual(0)
+        expect(stagger(0.1, { from: "last" })(5, 10)).toEqual(0.4)
+        expect(stagger(0.1, { from: "center" })(2, 10)).toEqual(0.25)
+    })
+
+    test("Accepts easing", () => {
+        expect(stagger(0.1, { easing: "linear" })(5, 10)).toEqual(0.5)
+
+        const expectedEaseIn = easingDefinitionToFunction("easeIn")(0.5)
+        expect(stagger(0.1, { easing: "easeIn" })(5, 10)).toEqual(
+            expectedEaseIn
+        )
+
+        const expectedEaseOut = easingDefinitionToFunction("easeOut")(0.5)
+        expect(stagger(0.1, { easing: "easeOut" })(5, 10)).toEqual(
+            expectedEaseOut
+        )
+
+        expect(stagger(0.1, { easing: (v: number) => v / 2 })(4, 10)).toEqual(
+            0.2
+        )
+    })
+})
+
+describe("getFromIndex", () => {
+    test("Returns correct index", () => {
+        expect(getFromIndex("first", 9)).toEqual(0)
+        expect(getFromIndex("last", 9)).toEqual(8)
+        expect(getFromIndex("center", 9)).toEqual(4)
+        expect(getFromIndex("center", 10)).toEqual(4.5)
+    })
+})

--- a/packages/framer-motion/src/animation/utils/default-transitions.ts
+++ b/packages/framer-motion/src/animation/utils/default-transitions.ts
@@ -1,7 +1,7 @@
 import { transformProps } from "../../render/html/utils/transform"
-import { AnimationOptions } from "../types"
+import { ValueAnimationOptions } from "../types"
 
-const underDampedSpring: Partial<AnimationOptions> = {
+const underDampedSpring: Partial<ValueAnimationOptions> = {
     type: "spring",
     stiffness: 500,
     damping: 25,
@@ -10,14 +10,14 @@ const underDampedSpring: Partial<AnimationOptions> = {
 
 const criticallyDampedSpring = (
     target: unknown
-): Partial<AnimationOptions> => ({
+): Partial<ValueAnimationOptions> => ({
     type: "spring",
     stiffness: 550,
     damping: target === 0 ? 2 * Math.sqrt(550) : 30,
     restSpeed: 10,
 })
 
-const keyframesTransition: Partial<AnimationOptions> = {
+const keyframesTransition: Partial<ValueAnimationOptions> = {
     type: "keyframes",
     duration: 0.8,
 }
@@ -26,7 +26,7 @@ const keyframesTransition: Partial<AnimationOptions> = {
  * Default easing curve is a slightly shallower version of
  * the default browser easing curve.
  */
-const ease: Partial<AnimationOptions> = {
+const ease: Partial<ValueAnimationOptions> = {
     type: "keyframes",
     ease: [0.25, 0.1, 0.35, 1],
     duration: 0.3,
@@ -34,8 +34,8 @@ const ease: Partial<AnimationOptions> = {
 
 export const getDefaultTransition = (
     valueKey: string,
-    { keyframes }: AnimationOptions
-): Partial<AnimationOptions> => {
+    { keyframes }: ValueAnimationOptions
+): Partial<ValueAnimationOptions> => {
     if (keyframes.length > 2) {
         return keyframesTransition
     } else if (transformProps.has(valueKey)) {

--- a/packages/framer-motion/src/animation/utils/stagger.ts
+++ b/packages/framer-motion/src/animation/utils/stagger.ts
@@ -1,0 +1,40 @@
+import { Easing } from "../../easing/types"
+import { DynamicOption } from "../types"
+import { easingDefinitionToFunction } from "./easing"
+
+export type From = "first" | "last" | "center" | number
+
+export type StaggerOptions = {
+    start?: number
+    from?: From
+    easing?: Easing
+}
+
+export function getFromIndex(from: From, total: number) {
+    if (from === "first") {
+        return 0
+    } else {
+        const lastIndex = total - 1
+        return from === "last" ? lastIndex : lastIndex / 2
+    }
+}
+
+export function stagger(
+    duration: number = 0.1,
+    { start = 0, from = 0, easing }: StaggerOptions = {}
+): DynamicOption<number> {
+    return (i: number, total: number) => {
+        const fromIndex =
+            typeof from === "number" ? from : getFromIndex(from, total)
+        const distance = Math.abs(fromIndex - i)
+        let delay = duration * distance
+
+        if (easing) {
+            const maxDelay = total * duration
+            const easingFunction = easingDefinitionToFunction(easing)
+            delay = easingFunction(delay / maxDelay) * maxDelay
+        }
+
+        return start + delay
+    }
+}

--- a/packages/framer-motion/src/animation/utils/stagger.ts
+++ b/packages/framer-motion/src/animation/utils/stagger.ts
@@ -2,36 +2,36 @@ import { Easing } from "../../easing/types"
 import { DynamicOption } from "../types"
 import { easingDefinitionToFunction } from "./easing"
 
-export type From = "first" | "last" | "center" | number
+export type StaggerOrigin = "first" | "last" | "center" | number
 
 export type StaggerOptions = {
     start?: number
-    from?: From
-    easing?: Easing
+    origin?: StaggerOrigin
+    ease?: Easing
 }
 
-export function getFromIndex(from: From, total: number) {
-    if (from === "first") {
+export function getOriginIndex(origin: StaggerOrigin, total: number) {
+    if (origin === "first") {
         return 0
     } else {
         const lastIndex = total - 1
-        return from === "last" ? lastIndex : lastIndex / 2
+        return origin === "last" ? lastIndex : lastIndex / 2
     }
 }
 
 export function stagger(
     duration: number = 0.1,
-    { start = 0, from = 0, easing }: StaggerOptions = {}
+    { start = 0, origin = 0, ease }: StaggerOptions = {}
 ): DynamicOption<number> {
     return (i: number, total: number) => {
-        const fromIndex =
-            typeof from === "number" ? from : getFromIndex(from, total)
-        const distance = Math.abs(fromIndex - i)
+        const originIndex =
+            typeof origin === "number" ? origin : getOriginIndex(origin, total)
+        const distance = Math.abs(originIndex - i)
         let delay = duration * distance
 
-        if (easing) {
+        if (ease) {
             const maxDelay = total * duration
-            const easingFunction = easingDefinitionToFunction(easing)
+            const easingFunction = easingDefinitionToFunction(ease)
             delay = easingFunction(delay / maxDelay) * maxDelay
         }
 

--- a/packages/framer-motion/src/animation/utils/stagger.ts
+++ b/packages/framer-motion/src/animation/utils/stagger.ts
@@ -5,7 +5,7 @@ import { easingDefinitionToFunction } from "./easing"
 export type StaggerOrigin = "first" | "last" | "center" | number
 
 export type StaggerOptions = {
-    start?: number
+    startDelay?: number
     origin?: StaggerOrigin
     ease?: Easing
 }
@@ -21,7 +21,7 @@ export function getOriginIndex(origin: StaggerOrigin, total: number) {
 
 export function stagger(
     duration: number = 0.1,
-    { start = 0, origin = 0, ease }: StaggerOptions = {}
+    { startDelay = 0, origin = 0, ease }: StaggerOptions = {}
 ): DynamicOption<number> {
     return (i: number, total: number) => {
         const originIndex =
@@ -35,6 +35,6 @@ export function stagger(
             delay = easingFunction(delay / maxDelay) * maxDelay
         }
 
-        return start + delay
+        return startDelay + delay
     }
 }

--- a/packages/framer-motion/src/dom-entry.ts
+++ b/packages/framer-motion/src/dom-entry.ts
@@ -15,6 +15,7 @@ export * from "./easing/cubic-bezier"
 /**
  * Utils
  */
+export { stagger } from "./animation/utils/stagger"
 export { transform } from "./utils/transform"
 export { clamp } from "./utils/clamp"
 export * from "./utils/delay"

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -43,7 +43,7 @@ import { mix } from "../../utils/mix"
 import { Process } from "../../frameloop/types"
 import { ProjectionFrame } from "../../debug/types"
 import { record } from "../../debug/record"
-import { AnimationOptions } from "../../animation/types"
+import { ValueAnimationOptions } from "../../animation/types"
 import { frameData } from "../../dom-entry"
 import { isSVGElement } from "../../render/dom/utils/is-svg-element"
 import { animateSingleValue } from "../../animation/interfaces/single-value"
@@ -1425,7 +1425,7 @@ export function createProjectionNode<I>({
             this.mixTargetDelta(this.options.layoutRoot ? 1000 : 0)
         }
 
-        startAnimation(options: AnimationOptions<number>) {
+        startAnimation(options: ValueAnimationOptions<number>) {
             this.notifyListeners("animationStart")
 
             this.currentAnimation && this.currentAnimation.stop()

--- a/packages/framer-motion/src/render/svg/types-attributes.ts
+++ b/packages/framer-motion/src/render/svg/types-attributes.ts
@@ -1,0 +1,263 @@
+export interface SVGAttributes {
+    accentHeight?: number | string | undefined
+    accumulate?: "none" | "sum" | undefined
+    additive?: "replace" | "sum" | undefined
+    alignmentBaseline?:
+        | "auto"
+        | "baseline"
+        | "before-edge"
+        | "text-before-edge"
+        | "middle"
+        | "central"
+        | "after-edge"
+        | "text-after-edge"
+        | "ideographic"
+        | "alphabetic"
+        | "hanging"
+        | "mathematical"
+        | "inherit"
+        | undefined
+    allowReorder?: "no" | "yes" | undefined
+    alphabetic?: number | string | undefined
+    amplitude?: number | string | undefined
+    arabicForm?: "initial" | "medial" | "terminal" | "isolated" | undefined
+    ascent?: number | string | undefined
+    attributeName?: string | undefined
+    attributeType?: string | undefined
+    autoReverse?: boolean | undefined
+    azimuth?: number | string | undefined
+    baseFrequency?: number | string | undefined
+    baselineShift?: number | string | undefined
+    baseProfile?: number | string | undefined
+    bbox?: number | string | undefined
+    begin?: number | string | undefined
+    bias?: number | string | undefined
+    by?: number | string | undefined
+    calcMode?: number | string | undefined
+    capHeight?: number | string | undefined
+    clip?: number | string | undefined
+    clipPath?: string | undefined
+    clipPathUnits?: number | string | undefined
+    clipRule?: number | string | undefined
+    colorInterpolation?: number | string | undefined
+    colorInterpolationFilters?:
+        | "auto"
+        | "sRGB"
+        | "linearRGB"
+        | "inherit"
+        | undefined
+    colorProfile?: number | string | undefined
+    colorRendering?: number | string | undefined
+    contentScriptType?: number | string | undefined
+    contentStyleType?: number | string | undefined
+    cursor?: number | string | undefined
+    cx?: number | string | undefined
+    cy?: number | string | undefined
+    d?: string | undefined
+    decelerate?: number | string | undefined
+    descent?: number | string | undefined
+    diffuseConstant?: number | string | undefined
+    direction?: number | string | undefined
+    display?: number | string | undefined
+    divisor?: number | string | undefined
+    dominantBaseline?: number | string | undefined
+    dur?: number | string | undefined
+    dx?: number | string | undefined
+    dy?: number | string | undefined
+    edgeMode?: number | string | undefined
+    elevation?: number | string | undefined
+    enableBackground?: number | string | undefined
+    end?: number | string | undefined
+    exponent?: number | string | undefined
+    externalResourcesRequired?: boolean | undefined
+    fill?: string | undefined
+    fillOpacity?: number | string | undefined
+    fillRule?: "nonzero" | "evenodd" | "inherit" | undefined
+    filter?: string | undefined
+    filterRes?: number | string | undefined
+    filterUnits?: number | string | undefined
+    floodColor?: number | string | undefined
+    floodOpacity?: number | string | undefined
+    focusable?: boolean | "auto" | undefined
+    fontFamily?: string | undefined
+    fontSize?: number | string | undefined
+    fontSizeAdjust?: number | string | undefined
+    fontStretch?: number | string | undefined
+    fontStyle?: number | string | undefined
+    fontVariant?: number | string | undefined
+    fontWeight?: number | string | undefined
+    format?: number | string | undefined
+    fr?: number | string | undefined
+    from?: number | string | undefined
+    fx?: number | string | undefined
+    fy?: number | string | undefined
+    g1?: number | string | undefined
+    g2?: number | string | undefined
+    glyphName?: number | string | undefined
+    glyphOrientationHorizontal?: number | string | undefined
+    glyphOrientationVertical?: number | string | undefined
+    glyphRef?: number | string | undefined
+    gradientTransform?: string | undefined
+    gradientUnits?: string | undefined
+    hanging?: number | string | undefined
+    horizAdvX?: number | string | undefined
+    horizOriginX?: number | string | undefined
+    href?: string | undefined
+    ideographic?: number | string | undefined
+    imageRendering?: number | string | undefined
+    in2?: number | string | undefined
+    in?: string | undefined
+    intercept?: number | string | undefined
+    k1?: number | string | undefined
+    k2?: number | string | undefined
+    k3?: number | string | undefined
+    k4?: number | string | undefined
+    k?: number | string | undefined
+    kernelMatrix?: number | string | undefined
+    kernelUnitLength?: number | string | undefined
+    kerning?: number | string | undefined
+    keyPoints?: number | string | undefined
+    keySplines?: number | string | undefined
+    keyTimes?: number | string | undefined
+    lengthAdjust?: number | string | undefined
+    letterSpacing?: number | string | undefined
+    lightingColor?: number | string | undefined
+    limitingConeAngle?: number | string | undefined
+    local?: number | string | undefined
+    markerEnd?: string | undefined
+    markerHeight?: number | string | undefined
+    markerMid?: string | undefined
+    markerStart?: string | undefined
+    markerUnits?: number | string | undefined
+    markerWidth?: number | string | undefined
+    mask?: string | undefined
+    maskContentUnits?: number | string | undefined
+    maskUnits?: number | string | undefined
+    mathematical?: number | string | undefined
+    mode?: number | string | undefined
+    numOctaves?: number | string | undefined
+    offset?: number | string | undefined
+    opacity?: number | string | undefined
+    operator?: number | string | undefined
+    order?: number | string | undefined
+    orient?: number | string | undefined
+    orientation?: number | string | undefined
+    origin?: number | string | undefined
+    overflow?: number | string | undefined
+    overlinePosition?: number | string | undefined
+    overlineThickness?: number | string | undefined
+    paintOrder?: number | string | undefined
+    panose1?: number | string | undefined
+    path?: string | undefined
+    pathLength?: number | string | undefined
+    patternContentUnits?: string | undefined
+    patternTransform?: number | string | undefined
+    patternUnits?: string | undefined
+    pointerEvents?: number | string | undefined
+    points?: string | undefined
+    pointsAtX?: number | string | undefined
+    pointsAtY?: number | string | undefined
+    pointsAtZ?: number | string | undefined
+    preserveAlpha?: boolean | undefined
+    preserveAspectRatio?: string | undefined
+    primitiveUnits?: number | string | undefined
+    r?: number | string | undefined
+    radius?: number | string | undefined
+    refX?: number | string | undefined
+    refY?: number | string | undefined
+    renderingIntent?: number | string | undefined
+    repeatCount?: number | string | undefined
+    repeatDur?: number | string | undefined
+    requiredExtensions?: number | string | undefined
+    requiredFeatures?: number | string | undefined
+    restart?: number | string | undefined
+    result?: string | undefined
+    rotate?: number | string | undefined
+    rx?: number | string | undefined
+    ry?: number | string | undefined
+    scale?: number | string | undefined
+    seed?: number | string | undefined
+    shapeRendering?: number | string | undefined
+    slope?: number | string | undefined
+    spacing?: number | string | undefined
+    specularConstant?: number | string | undefined
+    specularExponent?: number | string | undefined
+    speed?: number | string | undefined
+    spreadMethod?: string | undefined
+    startOffset?: number | string | undefined
+    stdDeviation?: number | string | undefined
+    stemh?: number | string | undefined
+    stemv?: number | string | undefined
+    stitchTiles?: number | string | undefined
+    stopColor?: string | undefined
+    stopOpacity?: number | string | undefined
+    strikethroughPosition?: number | string | undefined
+    strikethroughThickness?: number | string | undefined
+    string?: number | string | undefined
+    stroke?: string | undefined
+    strokeDasharray?: string | number | undefined
+    strokeDashoffset?: string | number | undefined
+    strokeLinecap?: "butt" | "round" | "square" | "inherit" | undefined
+    strokeLinejoin?: "miter" | "round" | "bevel" | "inherit" | undefined
+    strokeMiterlimit?: number | string | undefined
+    strokeOpacity?: number | string | undefined
+    strokeWidth?: number | string | undefined
+    surfaceScale?: number | string | undefined
+    systemLanguage?: number | string | undefined
+    tableValues?: number | string | undefined
+    targetX?: number | string | undefined
+    targetY?: number | string | undefined
+    textAnchor?: string | undefined
+    textDecoration?: number | string | undefined
+    textLength?: number | string | undefined
+    textRendering?: number | string | undefined
+    to?: number | string | undefined
+    transform?: string | undefined
+    u1?: number | string | undefined
+    u2?: number | string | undefined
+    underlinePosition?: number | string | undefined
+    underlineThickness?: number | string | undefined
+    unicode?: number | string | undefined
+    unicodeBidi?: number | string | undefined
+    unicodeRange?: number | string | undefined
+    unitsPerEm?: number | string | undefined
+    vAlphabetic?: number | string | undefined
+    values?: string | undefined
+    vectorEffect?: number | string | undefined
+    version?: string | undefined
+    vertAdvY?: number | string | undefined
+    vertOriginX?: number | string | undefined
+    vertOriginY?: number | string | undefined
+    vHanging?: number | string | undefined
+    vIdeographic?: number | string | undefined
+    viewBox?: string | undefined
+    viewTarget?: number | string | undefined
+    visibility?: number | string | undefined
+    vMathematical?: number | string | undefined
+    widths?: number | string | undefined
+    wordSpacing?: number | string | undefined
+    writingMode?: number | string | undefined
+    x1?: number | string | undefined
+    x2?: number | string | undefined
+    x?: number | string | undefined
+    xChannelSelector?: string | undefined
+    xHeight?: number | string | undefined
+    xlinkActuate?: string | undefined
+    xlinkArcrole?: string | undefined
+    xlinkHref?: string | undefined
+    xlinkRole?: string | undefined
+    xlinkShow?: string | undefined
+    xlinkTitle?: string | undefined
+    xlinkType?: string | undefined
+    xmlBase?: string | undefined
+    xmlLang?: string | undefined
+    xmlns?: string | undefined
+    xmlnsXlink?: string | undefined
+    xmlSpace?: string | undefined
+    y1?: number | string | undefined
+    y2?: number | string | undefined
+    y?: number | string | undefined
+    yChannelSelector?: string | undefined
+    z?: number | string | undefined
+    zoomAndPan?: string | undefined
+}


### PR DESCRIPTION
This PR adds a `stagger()` function for use with `animate()`.

When multiple elements are provided/selected, `stagger` will increase the `delay` for each.

```javascript
animate("div", { opacity: 1 }, { delay: stagger(0.1) })
```

Additional options can be provided.

### `ease`

Redistributes stagger duration based on easing.

```javascript
stagger(0.1, { ease: "easeIn" })
```

### `start`

A base delay to start staggering from - naming suggestions welcome. 

```javascript
stagger(0.1, { start: 1 })
```

### `origin`

Define an element in the set to stagger out from. 

```
from: "first" | "last" | "center" | number
```

```javascript
stagger(0.1, { from: "last" })
```