### PR TITLE
Animation sequencing

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 src/animation/__tests__/animate.test.ts",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 src/animation/sequence/__tests__/",
+        "test-client": "jest --config jest.config.json --max-workers=2 src/animation/__tests__/animate-waapi.test.tsx",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",
@@ -101,7 +101,7 @@
         },
         {
             "path": "./dist/size-rollup-animate.js",
-            "maxSize": "15 kB"
+            "maxSize": "15.5 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 src/animation/sequence/__tests__/",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 src/animation/__tests__/animate-waapi.test.tsx",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 src/animation/__tests__/animate.test.ts",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
@@ -117,7 +117,8 @@ describe("animate() with WAAPI", () => {
             }
         )
     })
-    test("Can accept timeline sequences", async () => {
+
+    test.only("Can accept timeline sequences", async () => {
         const a = document.createElement("div")
 
         animate([
@@ -129,12 +130,12 @@ describe("animate() with WAAPI", () => {
         ])
 
         expect(a.animate).toBeCalledWith(
-            { opacity: [0, 1], offset: undefined },
-            { ...defaultOptions, duration: 1000 }
+            { opacity: [0, 1, 1], offset: [0, 0.5, 1] },
+            { ...defaultOptions, duration: 2000 }
         )
 
         expect(a.animate).toBeCalledWith(
-            { transform: ["scale(0)", "scale(1)"], offset: undefined },
+            { transform: ["scale(0)", "scale(1)"], offset: [0, 1] },
             { ...defaultOptions, duration: 2000 }
         )
     })

--- a/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
@@ -118,25 +118,52 @@ describe("animate() with WAAPI", () => {
         )
     })
 
-    test.only("Can accept timeline sequences", async () => {
+    test("Can accept timeline sequences", async () => {
         const a = document.createElement("div")
+        const b = document.createElement("div")
 
         animate([
             [
-                a,
+                [a, b],
                 { opacity: [0, 1], transform: ["scale(0)", "scale(1)"] },
                 { duration: 1, transform: { duration: 2 } },
             ],
         ])
 
         expect(a.animate).toBeCalledWith(
-            { opacity: [0, 1, 1], offset: [0, 0.5, 1] },
-            { ...defaultOptions, duration: 2000 }
+            {
+                opacity: [0, 1, 1],
+                offset: [0, 0.5, 1],
+                easing: ["ease-out", "ease-out"],
+            },
+            { ...defaultOptions, duration: 2000, easing: "linear" }
         )
 
         expect(a.animate).toBeCalledWith(
-            { transform: ["scale(0)", "scale(1)"], offset: [0, 1] },
-            { ...defaultOptions, duration: 2000 }
+            {
+                transform: ["scale(0)", "scale(1)"],
+                offset: [0, 1],
+                easing: ["ease-out", "ease-out"],
+            },
+            { ...defaultOptions, duration: 2000, easing: "linear" }
+        )
+
+        expect(b.animate).toBeCalledWith(
+            {
+                opacity: [0, 1, 1],
+                offset: [0, 0.5, 1],
+                easing: ["ease-out", "ease-out"],
+            },
+            { ...defaultOptions, duration: 2000, easing: "linear" }
+        )
+
+        expect(b.animate).toBeCalledWith(
+            {
+                transform: ["scale(0)", "scale(1)"],
+                offset: [0, 1],
+                easing: ["ease-out", "ease-out"],
+            },
+            { ...defaultOptions, duration: 2000, easing: "linear" }
         )
     })
 })

--- a/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
@@ -117,4 +117,25 @@ describe("animate() with WAAPI", () => {
             }
         )
     })
+    test("Can accept timeline sequences", async () => {
+        const a = document.createElement("div")
+
+        animate([
+            [
+                a,
+                { opacity: [0, 1], transform: ["scale(0)", "scale(1)"] },
+                { duration: 1, transform: { duration: 2 } },
+            ],
+        ])
+
+        expect(a.animate).toBeCalledWith(
+            { opacity: [0, 1], offset: undefined },
+            { ...defaultOptions, duration: 1000 }
+        )
+
+        expect(a.animate).toBeCalledWith(
+            { transform: ["scale(0)", "scale(1)"], offset: undefined },
+            { ...defaultOptions, duration: 2000 }
+        )
+    })
 })

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -112,7 +112,7 @@ describe("animate", () => {
         animate(motionValue("#fff"), ["#fff", "#000"])
     })
 
-    test.only("animates motion values in sequence", async () => {
+    test("animates motion values in sequence", async () => {
         const a = motionValue(0)
         const b = motionValue(100)
 

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -5,6 +5,7 @@ import { motion } from "../.."
 import { animate } from "../animate"
 import { useMotionValue } from "../../value/use-motion-value"
 import { motionValue, MotionValue } from "../../value"
+import { syncDriver } from "../animators/js/__tests__/utils"
 
 const duration = 0.001
 
@@ -118,8 +119,8 @@ describe("animate", () => {
         const aOutput: number[] = []
         const bOutput: number[] = []
 
-        a.on("change", (v) => aOutput.push(v))
-        b.on("change", (v) => bOutput.push(v))
+        a.on("change", (v) => aOutput.push(Math.round(v)))
+        b.on("change", (v) => bOutput.push(Math.round(v)))
 
         const animation = animate(
             [
@@ -127,13 +128,17 @@ describe("animate", () => {
                 [b, 0],
             ],
             {
-                defaultTransition: { ease: "linear", duration: 1 },
+                defaultTransition: {
+                    ease: "linear",
+                    duration: 0.05,
+                    driver: syncDriver(20),
+                },
             }
         )
 
-        animation.then(() => {
-            expect(aOutput).toEqual([50, 100])
-            expect(bOutput).toEqual([100, 50, 0])
+        return animation.then(() => {
+            expect(aOutput).toEqual([50, 70, 90, 100])
+            expect(bOutput).toEqual([60, 20, 0])
         })
     })
 

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -111,6 +111,32 @@ describe("animate", () => {
         animate(motionValue("#fff"), ["#fff", "#000"])
     })
 
+    test.only("animates motion values in sequence", async () => {
+        const a = motionValue(0)
+        const b = motionValue(100)
+
+        const aOutput: number[] = []
+        const bOutput: number[] = []
+
+        a.on("change", (v) => aOutput.push(v))
+        b.on("change", (v) => bOutput.push(v))
+
+        const animation = animate(
+            [
+                [a, [50, 100]],
+                [b, 0],
+            ],
+            {
+                defaultTransition: { ease: "linear", duration: 1 },
+            }
+        )
+
+        animation.then(() => {
+            expect(aOutput).toEqual([50, 100])
+            expect(bOutput).toEqual([100, 50, 0])
+        })
+    })
+
     test("Applies target keyframe when animation has finished", async () => {
         const div = document.createElement("div")
         const animation = animate(

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -19,6 +19,7 @@ import { createVisualElement } from "./utils/create-visual-element"
 import { animateSingleValue } from "./interfaces/single-value"
 import { AnimationSequence, SequenceOptions } from "./sequence/types"
 import { createAnimationsFromSequence } from "./sequence/create"
+import { isMotionValue } from "../value/utils/is-motion-value"
 
 export interface DynamicAnimationOptions
     extends Omit<AnimationOptionsWithValueOverrides, "delay"> {
@@ -87,8 +88,20 @@ function animateSequence(
     const animations: AnimationPlaybackControls[] = []
     const animationDefinitions = createAnimationsFromSequence(sequence, options)
 
-    animationDefinitions.forEach(({ keyframes, transition }, element) => {
-        animations.push(animateElements(element, keyframes, transition))
+    animationDefinitions.forEach(({ keyframes, transition }, subject) => {
+        let animation: AnimationPlaybackControls
+
+        if (isMotionValue(subject)) {
+            animation = animateSingleValue(
+                subject,
+                keyframes.default,
+                transition.default
+            )
+        } else {
+            animation = animateElements(subject, keyframes, transition)
+        }
+
+        animations.push(animation)
     })
 
     return new GroupPlaybackControls(animations)

--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -78,7 +78,7 @@ function animateElements(
 }
 
 const isSequence = (value: unknown): value is AnimationSequence =>
-    Array.isArray(value)
+    Array.isArray(value) && Array.isArray(value[0])
 
 function animateSequence(
     sequence: AnimationSequence,

--- a/packages/framer-motion/src/animation/generators/keyframes.ts
+++ b/packages/framer-motion/src/animation/generators/keyframes.ts
@@ -1,10 +1,11 @@
 import { easeInOut } from "../../easing/ease"
 import { EasingFunction } from "../../easing/types"
+import { isEasingArray } from "../../easing/utils/is-easing-array"
+import { easingDefinitionToFunction } from "../../easing/utils/map"
 import { interpolate } from "../../utils/interpolate"
 import { defaultOffset } from "../../utils/offsets/default"
 import { convertOffsetToTimes } from "../../utils/offsets/time"
 import { ValueAnimationOptions } from "../types"
-import { easingDefinitionToFunction, isEasingArray } from "../utils/easing"
 import { AnimationState, KeyframeGenerator } from "./types"
 
 export function defaultEasing(

--- a/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
+++ b/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { motionValue } from "../../../value"
 import { stagger } from "../../utils/stagger"
 import { createAnimationsFromSequence } from "../create"
 
@@ -5,6 +6,7 @@ describe("createAnimationsFromSequence", () => {
     const a = document.createElement("div")
     const b = document.createElement("div")
     const c = document.createElement("div")
+    const value = motionValue(0)
 
     test("It creates a single animation", () => {
         const animations = createAnimationsFromSequence([
@@ -91,6 +93,32 @@ describe("createAnimationsFromSequence", () => {
             duration: 2,
             ease: ["linear", "easeOut", "easeOut"],
             times: [0, 0.25, 0.5, 1],
+        })
+    })
+
+    test("It accepts motion values", () => {
+        const animations = createAnimationsFromSequence([
+            [value, 100, { duration: 0.5 }],
+        ])
+
+        expect(animations.get(value)!.keyframes.default).toEqual([null, 100])
+        expect(animations.get(value)!.transition.default).toEqual({
+            duration: 0.5,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
+        })
+    })
+
+    test("It accepts motion values keyframes", () => {
+        const animations = createAnimationsFromSequence([
+            [value, [50, 100], { duration: 0.5 }],
+        ])
+
+        expect(animations.get(value)!.keyframes.default).toEqual([50, 100])
+        expect(animations.get(value)!.transition.default).toEqual({
+            duration: 0.5,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
         })
     })
 

--- a/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
+++ b/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
@@ -1,0 +1,399 @@
+import { stagger } from "../../utils/stagger"
+import { createAnimationsFromSequence } from "../create"
+
+describe("createAnimationsFromSequence", () => {
+    const a = document.createElement("div")
+    const b = document.createElement("div")
+    const c = document.createElement("div")
+
+    test("It creates a single animation", () => {
+        const animations = createAnimationsFromSequence([
+            [
+                a,
+                { opacity: 1 },
+                { duration: 1, ease: [0, 1, 2, 3], times: [0, 1] },
+            ],
+        ])
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 1,
+            ease: [
+                [0, 1, 2, 3],
+                [0, 1, 2, 3],
+            ],
+            times: [0, 1],
+        })
+    })
+
+    test("It creates a single animation with defaults", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { opacity: 1 }, { duration: 1 }],
+        ])
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 1,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
+        })
+    })
+
+    test("It creates a single animation with defaults - 2", () => {
+        const animations = createAnimationsFromSequence([
+            [
+                a,
+                { x: [100, 100, 200, 300] },
+                { duration: 0.5, times: [0, 0.5, 0.7, 1], ease: "linear" },
+            ],
+        ])
+        expect(animations.get(a)!.keyframes.x).toEqual([100, 100, 200, 300])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 0.5,
+            ease: ["linear", "linear", "linear", "linear"],
+            times: [0, 0.5, 0.7, 1],
+        })
+    })
+
+    test("It sequences one animation after another", () => {
+        const animations = createAnimationsFromSequence([
+            [
+                a,
+                { x: [100, 200, 300], opacity: 1 },
+                { duration: 0.5, ease: "linear" },
+            ],
+            [b, { y: 500 }, { duration: 0.5 }],
+            [a, { x: 400 }, { duration: 1 }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([
+            100,
+            200,
+            300,
+            null,
+            400,
+        ])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 2,
+            ease: ["linear", "linear", "linear", "easeOut", "easeOut"],
+            times: [0, 0.125, 0.25, 0.5, 1],
+        })
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1, null])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: ["linear", "linear"],
+            times: [0, 0.25, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, null, 500, null])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.25, 0.5, 1],
+        })
+    })
+
+    test("It adds relative time to another animation", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 0.5, at: "+0.5" }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100, null])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, null, 500])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.75, 1],
+        })
+    })
+
+    test("It adds moves the playhead back to the previous animation", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 0.5, at: "<" }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 1,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, 500, null])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 1,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+    })
+
+    test("It adds subtracts time to another animation", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 0.5, at: "-1" }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 1,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, 500, null])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 1,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+    })
+
+    test("It sets another animation at a specific time", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 0.5, at: 1.5 }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100, null])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, null, 500])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.75, 1],
+        })
+    })
+
+    test("It sets labels from strings", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            "my label",
+            [a, { opacity: 0 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 1, at: "my label" }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100, null])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, null, 0])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, null, 500])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+    })
+
+    test("It sets annotated labels with absolute at times", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            { name: "my label", at: 0 },
+            [a, { opacity: 0 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 1, at: "my label" }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100, null])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, null, 0])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, 500, null])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+    })
+
+    test("It sets annotated labels with relative at times", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 100 }, { duration: 1 }],
+            { name: "my label", at: "-1" },
+            [a, { opacity: 0 }, { duration: 1 }],
+            [b, { y: 500 }, { duration: 1, at: "my label" }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 100, null])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, null, 0])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.y).toEqual([null, 500, null])
+        expect(animations.get(b)!.transition.y).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.5, 1],
+        })
+    })
+
+    test("It advances time by the maximum defined in individual value options", () => {
+        const animations = createAnimationsFromSequence([
+            [a, { x: 1, y: 1 }, { duration: 1, y: { duration: 2 } }],
+            [b, { y: 1 }, { duration: 0.5 }],
+        ])
+
+        expect(animations.get(a)!.transition.x.duration).toBe(2.5)
+        expect(animations.get(b)!.transition.y.times?.[1]).toBe(0.8)
+    })
+
+    test("It creates multiple animations for multiple targets", () => {
+        const animations = createAnimationsFromSequence([[[a, b, c], { x: 1 }]])
+
+        expect(animations.get(a)).toBeTruthy()
+        expect(animations.get(b)).toBeTruthy()
+        expect(animations.get(c)).toBeTruthy()
+    })
+
+    test("It creates multiple animations, staggered", () => {
+        const animations = createAnimationsFromSequence([
+            [[a, b, c], { x: 1 }, { delay: stagger(1), duration: 1 }],
+            [a, { opacity: 1 }, { duration: 1 }],
+        ])
+
+        expect(animations.get(a)!.keyframes.x).toEqual([null, 1, null])
+        expect(animations.get(a)!.transition.x).toEqual({
+            duration: 4,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 0.25, 1],
+        })
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 4,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.75, 1],
+        })
+
+        expect(animations.get(b)!.keyframes.x).toEqual([null, null, 1, null])
+        expect(animations.get(b)!.transition.x).toEqual({
+            duration: 4,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.25, 0.5, 1],
+        })
+
+        expect(animations.get(c)!.keyframes.x).toEqual([null, null, 1, null])
+        expect(animations.get(c)!.transition.x).toEqual({
+            duration: 4,
+            ease: ["linear", "easeOut", "easeOut"],
+            times: [0, 0.5, 0.75, 1],
+        })
+    })
+
+    test("It scales the whole animation based on the provided duration", () => {
+        const animations = createAnimationsFromSequence(
+            [
+                [
+                    a,
+                    { opacity: 1 },
+                    { duration: 1, ease: ["easeOut"], times: [0, 1] },
+                ],
+            ],
+            { duration: 2 }
+        )
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
+        })
+    })
+
+    test("It passes timeline options to children", () => {
+        const animations = createAnimationsFromSequence(
+            [
+                [
+                    a,
+                    { opacity: 1 },
+                    { duration: 1, ease: ["easeOut"], times: [0, 1] },
+                ],
+            ],
+            {
+                duration: 2,
+                repeat: Infinity,
+                delay: 1,
+            }
+        )
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            repeat: Infinity,
+            delay: 1,
+            ease: ["easeOut", "easeOut"],
+            times: [0, 1],
+        })
+    })
+
+    test("It passes default options to children", () => {
+        const animations = createAnimationsFromSequence(
+            [[a, { opacity: 1 }, { times: [0, 1] }]],
+            { defaultTransition: { duration: 2, ease: "easeInOut" } }
+        )
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: ["easeInOut", "easeInOut"],
+            times: [0, 1],
+        })
+    })
+
+    test("It correctly passes easing cubic bezier array to children", () => {
+        const animations = createAnimationsFromSequence(
+            [[a, { opacity: 1 }, { times: [0, 1] }]],
+            { defaultTransition: { duration: 2, ease: [0, 1, 2, 3] } }
+        )
+
+        expect(animations.get(a)!.keyframes.opacity).toEqual([null, 1])
+        expect(animations.get(a)!.transition.opacity).toEqual({
+            duration: 2,
+            ease: [
+                [0, 1, 2, 3],
+                [0, 1, 2, 3],
+            ],
+            times: [0, 1],
+        })
+    })
+})

--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -1,0 +1,278 @@
+import { Easing } from "../../easing/types"
+import { resolveElements } from "../../render/dom/utils/resolve-element"
+import { defaultOffset } from "../../utils/offsets/default"
+import { fillOffset } from "../../utils/offsets/fill"
+import { progress } from "../../utils/progress"
+import { isMotionValue } from "../../value/utils/is-motion-value"
+import { DynamicAnimationOptions } from "../animate"
+import {
+    AnimationScope,
+    DOMKeyframesDefinition,
+    UnresolvedValueKeyframe,
+} from "../types"
+import {
+    AnimationSequence,
+    At,
+    ElementSequence,
+    ResolvedAnimationDefinitions,
+    SequenceOptions,
+    ValueSequence,
+} from "./types"
+import { calcNextTime } from "./utils/calc-time"
+import { addKeyframes } from "./utils/edit"
+import { compareByTime } from "./utils/sort"
+
+export function createAnimationsFromSequence(
+    sequence: AnimationSequence,
+    { defaultTransition = {}, ...sequenceTransition }: SequenceOptions = {},
+    scope?: AnimationScope
+): ResolvedAnimationDefinitions {
+    const animationDefinitions: ResolvedAnimationDefinitions = new Map()
+    const elementSequences = new Map<Element, ElementSequence>()
+    const elementCache = {}
+    const timeLabels = new Map<string, number>()
+
+    let prevTime = 0
+    let currentTime = 0
+    let totalDuration = 0
+
+    /**
+     * Build the timeline by mapping over the sequence array and converting
+     * the definitions into keyframes and offsets with absolute time values.
+     * These will later get converted into relative offsets in a second pass.
+     */
+    for (let i = 0; i < sequence.length; i++) {
+        const segment = sequence[i]
+
+        /**
+         * If this is a timeline label, mark it and skip the rest of this iteration.
+         */
+        if (typeof segment === "string") {
+            timeLabels.set(segment, currentTime)
+            continue
+        } else if (!Array.isArray(segment)) {
+            timeLabels.set(
+                segment.name,
+                calcNextTime(currentTime, segment.at, prevTime, timeLabels)
+            )
+            continue
+        }
+
+        let [subject, keyframes, transition = {}] = segment
+
+        /**
+         * If a relative or absolute time value has been specified we need to resolve
+         * it in relation to the currentTime.
+         */
+        if (transition.at !== undefined) {
+            currentTime = calcNextTime(
+                currentTime,
+                transition.at,
+                prevTime,
+                timeLabels
+            )
+        }
+
+        /**
+         * Keep track of the maximum duration in this definition. This will be
+         * applied to currentTime once the definition has been parsed.
+         */
+        let maxDuration = 0
+
+        if (isMotionValue(subject)) {
+            // TODO: Implement in later release
+        } else {
+            /**
+             * Find all the elements specified in the definition and parse value
+             * keyframes from their timeline definitions.
+             */
+            const elements = resolveElements(subject, scope, elementCache)
+            const numElements = elements.length
+
+            /**
+             * For every element in this segment, process the defined values.
+             */
+            for (
+                let elementIndex = 0;
+                elementIndex < numElements;
+                elementIndex++
+            ) {
+                /**
+                 * Cast necessary, but we know these are of this type
+                 */
+                keyframes = keyframes as DOMKeyframesDefinition
+                transition = transition as DynamicAnimationOptions
+
+                const element = elements[elementIndex]
+                const elementSequence = getElementSequence(
+                    element,
+                    elementSequences
+                )
+
+                for (const key in keyframes) {
+                    const valueSequence = getValueSequence(key, elementSequence)
+                    const valueKeyframes = keyframesAsList(keyframes[key]!)
+                    const valueTransition = getValueTransition(transition, key)
+
+                    const {
+                        duration = defaultTransition.duration || 0.3,
+                        ease = defaultTransition.ease || "easeOut",
+                    } = valueTransition
+
+                    const delay =
+                        typeof valueTransition.delay === "function"
+                            ? valueTransition.delay(elementIndex, numElements)
+                            : valueTransition.delay || 0
+
+                    const startTime = currentTime + delay
+                    const targetTime = startTime + duration
+
+                    const { times = defaultOffset(valueKeyframes) } =
+                        valueTransition
+
+                    /**
+                     * If there's only one time offset of 0, fill in a second with length 1
+                     */
+                    if (times.length === 1 && times[0] === 0) {
+                        times[1] = 1
+                    }
+
+                    /**
+                     * Fill out if offset if fewer offsets than keyframes
+                     */
+                    const remainder = times.length - valueKeyframes.length
+                    remainder > 0 && fillOffset(times, remainder)
+
+                    /**
+                     * If only one value has been set, ie [1], push a null to the start of
+                     * the keyframe array. This will let us mark a keyframe at this point
+                     * that will later be hydrated with the previous value.
+                     */
+                    valueKeyframes.length === 1 && valueKeyframes.unshift(null)
+
+                    /**
+                     * Add keyframes, mapping offsets to absolute time.
+                     */
+                    addKeyframes(
+                        valueSequence,
+                        valueKeyframes,
+                        ease as Easing | Easing[],
+                        times,
+                        startTime,
+                        targetTime
+                    )
+
+                    maxDuration = Math.max(delay + duration, maxDuration)
+                    totalDuration = Math.max(targetTime, totalDuration)
+                }
+            }
+
+            prevTime = currentTime
+            currentTime += maxDuration
+        }
+    }
+
+    /**
+     * For every element and value combination create a new animation.
+     */
+    elementSequences.forEach((valueSequences, element) => {
+        for (const key in valueSequences) {
+            const valueSequence = valueSequences[key]
+
+            /**
+             * Arrange all the keyframes in ascending time order.
+             */
+            valueSequence.sort(compareByTime)
+
+            const keyframes: UnresolvedValueKeyframe[] = []
+            const valueOffset: number[] = []
+            const valueEasing: Easing[] = []
+
+            /**
+             * For each keyframe, translate absolute times into
+             * relative offsets based on the total duration of the timeline.
+             */
+            for (let i = 0; i < valueSequence.length; i++) {
+                const { at, value, easing } = valueSequence[i]
+                keyframes.push(value)
+                valueOffset.push(progress(0, totalDuration, at))
+                valueEasing.push(easing || "easeOut")
+            }
+
+            /**
+             * If the first keyframe doesn't land on offset: 0
+             * provide one by duplicating the initial keyframe. This ensures
+             * it snaps to the first keyframe when the animation starts.
+             */
+            if (valueOffset[0] !== 0) {
+                valueOffset.unshift(0)
+                keyframes.unshift(keyframes[0])
+                valueEasing.unshift("linear")
+            }
+
+            /**
+             * If the last keyframe doesn't land on offset: 1
+             * provide one with a null wildcard value. This will ensure it
+             * stays static until the end of the animation.
+             */
+            if (valueOffset[valueOffset.length - 1] !== 1) {
+                valueOffset.push(1)
+                keyframes.push(null)
+            }
+
+            if (!animationDefinitions.has(element)) {
+                animationDefinitions.set(element, {
+                    keyframes: {},
+                    transition: {},
+                })
+            }
+
+            const definition = animationDefinitions.get(element)!
+
+            definition.keyframes[key] = keyframes
+            definition.transition[key] = {
+                ...defaultTransition,
+                duration: totalDuration,
+                ease: valueEasing,
+                times: valueOffset,
+                ...sequenceTransition,
+            }
+        }
+    })
+
+    return animationDefinitions
+}
+
+function getElementSequence(
+    element: Element,
+    sequences: Map<Element, ElementSequence>
+): ElementSequence {
+    !sequences.has(element) && sequences.set(element, {})
+    return sequences.get(element)!
+}
+
+function getValueSequence(
+    name: string,
+    sequences: ElementSequence
+): ValueSequence {
+    if (!sequences[name]) sequences[name] = []
+    return sequences[name]
+}
+
+function keyframesAsList(
+    keyframes: UnresolvedValueKeyframe | UnresolvedValueKeyframe[]
+): UnresolvedValueKeyframe[] {
+    return Array.isArray(keyframes) ? keyframes : [keyframes]
+}
+
+/**
+ * TODO: Consolidate with other implementations
+ */
+export function getValueTransition(
+    transition: DynamicAnimationOptions & At,
+    key: string
+): DynamicAnimationOptions {
+    return transition[key]
+        ? { ...transition, ...transition[key] }
+        : { ...transition }
+}

--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -279,9 +279,6 @@ function keyframesAsList(
     return Array.isArray(keyframes) ? keyframes : [keyframes]
 }
 
-/**
- * TODO: Consolidate with other implementations
- */
 export function getValueTransition(
     transition: DynamicAnimationOptions & At,
     key: string

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -29,7 +29,7 @@ export interface At {
 
 export type MotionValueSegment = [
     MotionValue,
-    string | number,
+    UnresolvedValueKeyframe | UnresolvedValueKeyframe[],
     (Transition & At)?
 ]
 
@@ -39,7 +39,11 @@ export type DOMSegment = [
     (DynamicAnimationOptions & At)?
 ]
 
-export type Segment = DOMSegment | SequenceLabel | SequenceLabelWithTime
+export type Segment =
+    | MotionValueSegment
+    | DOMSegment
+    | SequenceLabel
+    | SequenceLabelWithTime
 
 export type AnimationSequence = Segment[]
 
@@ -57,7 +61,7 @@ export interface AbsoluteKeyframe {
 
 export type ValueSequence = AbsoluteKeyframe[]
 
-export interface ElementSequence {
+export interface SequenceMap {
     [key: string]: ValueSequence
 }
 
@@ -67,6 +71,6 @@ export type ResolvedAnimationDefinition = {
 }
 
 export type ResolvedAnimationDefinitions = Map<
-    Element,
+    Element | MotionValue,
     ResolvedAnimationDefinition
 >

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -1,0 +1,72 @@
+import { Easing } from "../../easing/types"
+import type { MotionValue } from "../../value"
+import { DynamicAnimationOptions } from "../animate"
+import {
+    DOMKeyframesDefinition,
+    ElementOrSelector,
+    Transition,
+    AnimationPlaybackOptions,
+    UnresolvedValueKeyframe,
+} from "../types"
+
+export type SequenceTime =
+    | number
+    | "<"
+    | `+${number}`
+    | `-${number}`
+    | `${string}`
+
+export type SequenceLabel = string
+
+export interface SequenceLabelWithTime {
+    name: SequenceLabel
+    at: SequenceTime
+}
+
+export interface At {
+    at?: SequenceTime
+}
+
+export type MotionValueSegment = [
+    MotionValue,
+    string | number,
+    (Transition & At)?
+]
+
+export type DOMSegment = [
+    ElementOrSelector,
+    DOMKeyframesDefinition,
+    (DynamicAnimationOptions & At)?
+]
+
+export type Segment = DOMSegment | SequenceLabel | SequenceLabelWithTime
+
+export type AnimationSequence = Segment[]
+
+export interface SequenceOptions extends AnimationPlaybackOptions {
+    delay?: number
+    duration?: number
+    defaultTransition?: Transition
+}
+
+export interface AbsoluteKeyframe {
+    value: string | number | null
+    at: number
+    easing?: Easing
+}
+
+export type ValueSequence = AbsoluteKeyframe[]
+
+export interface ElementSequence {
+    [key: string]: ValueSequence
+}
+
+export type ResolvedAnimationDefinition = {
+    keyframes: { [key: string]: UnresolvedValueKeyframe[] }
+    transition: { [key: string]: DynamicAnimationOptions }
+}
+
+export type ResolvedAnimationDefinitions = Map<
+    Element,
+    ResolvedAnimationDefinition
+>

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -63,7 +63,7 @@ export interface ElementSequence {
 
 export type ResolvedAnimationDefinition = {
     keyframes: { [key: string]: UnresolvedValueKeyframe[] }
-    transition: { [key: string]: DynamicAnimationOptions }
+    transition: { [key: string]: Transition }
 }
 
 export type ResolvedAnimationDefinitions = Map<

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -29,19 +29,28 @@ export interface At {
 
 export type MotionValueSegment = [
     MotionValue,
-    UnresolvedValueKeyframe | UnresolvedValueKeyframe[],
-    (Transition & At)?
+    UnresolvedValueKeyframe | UnresolvedValueKeyframe[]
 ]
 
-export type DOMSegment = [
+export type MotionValueSegmentWithTransition = [
+    MotionValue,
+    UnresolvedValueKeyframe | UnresolvedValueKeyframe[],
+    Transition & At
+]
+
+export type DOMSegment = [ElementOrSelector, DOMKeyframesDefinition]
+
+export type DOMSegmentWithTransition = [
     ElementOrSelector,
     DOMKeyframesDefinition,
-    (DynamicAnimationOptions & At)?
+    DynamicAnimationOptions & At
 ]
 
 export type Segment =
     | MotionValueSegment
+    | MotionValueSegmentWithTransition
     | DOMSegment
+    | DOMSegmentWithTransition
     | SequenceLabel
     | SequenceLabelWithTime
 

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-time.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-time.test.ts
@@ -1,0 +1,17 @@
+import { calcNextTime } from "../calc-time"
+
+describe("calcNextTime", () => {
+    test("Correctly returns a new time based on the past arguments", () => {
+        const labels = new Map()
+        labels.set("foo", 2)
+
+        expect(calcNextTime(1, 0.2, 100, labels)).toBe(0.2)
+        expect(calcNextTime(2, 0.2, 100, labels)).toBe(0.2)
+        expect(calcNextTime(4, "foo", 100, labels)).toBe(2)
+        expect(calcNextTime(4, "bar", 100, labels)).toBe(4)
+        expect(calcNextTime(5, "-1", 100, labels)).toBe(4)
+        expect(calcNextTime(5, "+1", 100, labels)).toBe(6)
+        expect(calcNextTime(5, "-7", 100, labels)).toBe(0)
+        expect(calcNextTime(5, "<", 100, labels)).toBe(100)
+    })
+})

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-time.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/calc-time.test.ts
@@ -5,13 +5,20 @@ describe("calcNextTime", () => {
         const labels = new Map()
         labels.set("foo", 2)
 
+        // Absolute time
         expect(calcNextTime(1, 0.2, 100, labels)).toBe(0.2)
         expect(calcNextTime(2, 0.2, 100, labels)).toBe(0.2)
+
+        // Label
         expect(calcNextTime(4, "foo", 100, labels)).toBe(2)
         expect(calcNextTime(4, "bar", 100, labels)).toBe(4)
+
+        // Relative time
         expect(calcNextTime(5, "-1", 100, labels)).toBe(4)
         expect(calcNextTime(5, "+1", 100, labels)).toBe(6)
         expect(calcNextTime(5, "-7", 100, labels)).toBe(0)
+
+        // Previous
         expect(calcNextTime(5, "<", 100, labels)).toBe(100)
     })
 })

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/edit.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/edit.test.ts
@@ -1,0 +1,65 @@
+import { ValueSequence } from "../../types"
+import { addKeyframes, eraseKeyframes } from "../edit"
+
+describe("eraseKeyframes", () => {
+    test("Erase keyframes between the specified time range", () => {
+        const sequence: ValueSequence = [
+            { value: 1, at: 50 },
+            { value: 2, at: 300 },
+            { value: 3, at: 299 },
+            { value: 4, at: 101 },
+            { value: 5, at: 100 },
+            { value: 6, at: 350 },
+        ]
+
+        eraseKeyframes(sequence, 100, 300)
+
+        expect(sequence).toEqual([
+            { value: 1, at: 50 },
+            { value: 2, at: 300 },
+            { value: 5, at: 100 },
+            { value: 6, at: 350 },
+        ])
+    })
+})
+
+describe("addKeyframes", () => {
+    test("Adds keyframes to sequence", () => {
+        const sequence: ValueSequence = [{ value: 1, at: 50 }]
+
+        addKeyframes(
+            sequence,
+            [1, 2, 3, 4],
+            [0, 1, 2, 3],
+            [0, 0.1, 0.5, 1],
+            500,
+            1000
+        )
+
+        expect(sequence).toEqual([
+            { value: 1, at: 50 },
+            { value: 1, at: 500, easing: [0, 1, 2, 3] },
+            { value: 2, at: 550, easing: [0, 1, 2, 3] },
+            { value: 3, at: 750, easing: [0, 1, 2, 3] },
+            { value: 4, at: 1000, easing: [0, 1, 2, 3] },
+        ])
+
+        addKeyframes(
+            sequence,
+            [5, 6, 7],
+            ["easeIn", "easeInOut"],
+            [0, 0.5, 1],
+            400,
+            600
+        )
+
+        expect(sequence).toEqual([
+            { value: 1, at: 50 },
+            { value: 3, at: 750, easing: [0, 1, 2, 3] },
+            { value: 4, at: 1000, easing: [0, 1, 2, 3] },
+            { value: 5, at: 400, easing: "easeIn" },
+            { value: 6, at: 500, easing: "easeInOut" },
+            { value: 7, at: 600, easing: "easeIn" },
+        ])
+    })
+})

--- a/packages/framer-motion/src/animation/sequence/utils/__tests__/sort.test.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/__tests__/sort.test.ts
@@ -1,0 +1,40 @@
+import { ValueSequence } from "../../types"
+import { compareByTime } from "../sort"
+
+describe("compareByTime", () => {
+    test("Can be used to sort values by at time", () => {
+        const sequence: ValueSequence = [
+            { value: 0, at: 300 },
+            { value: 1, at: 0 },
+            { value: 2, at: 301 },
+            { value: 3, at: 299 },
+            { value: 4, at: 40 },
+        ]
+
+        expect(sequence.sort(compareByTime)).toEqual([
+            { value: 1, at: 0 },
+            { value: 4, at: 40 },
+            { value: 3, at: 299 },
+            { value: 0, at: 300 },
+            { value: 2, at: 301 },
+        ])
+    })
+
+    test("Will correctly swap values so null comes second if at time the same", () => {
+        const sequence: ValueSequence = [
+            { value: null, at: 300 },
+            { value: 1, at: 0 },
+            { value: 2, at: 300 },
+            { value: 3, at: 299 },
+            { value: 4, at: 40 },
+        ]
+
+        expect(sequence.sort(compareByTime)).toEqual([
+            { value: 1, at: 0 },
+            { value: 4, at: 40 },
+            { value: 3, at: 299 },
+            { value: 2, at: 300 },
+            { value: null, at: 300 },
+        ])
+    })
+})

--- a/packages/framer-motion/src/animation/sequence/utils/calc-time.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/calc-time.ts
@@ -1,5 +1,9 @@
 import { SequenceTime } from "../types"
 
+/**
+ * Given a absolute or relative time definition and current/prev time state of the sequence,
+ * calculate an absolute time for the next keyframes.
+ */
 export function calcNextTime(
     current: number,
     next: SequenceTime,

--- a/packages/framer-motion/src/animation/sequence/utils/calc-time.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/calc-time.ts
@@ -1,0 +1,18 @@
+import { SequenceTime } from "../types"
+
+export function calcNextTime(
+    current: number,
+    next: SequenceTime,
+    prev: number,
+    labels: Map<string, number>
+): number {
+    if (typeof next === "number") {
+        return next
+    } else if (next.startsWith("-") || next.startsWith("+")) {
+        return Math.max(0, current + parseFloat(next))
+    } else if (next === "<") {
+        return prev
+    } else {
+        return labels.get(next) ?? current
+    }
+}

--- a/packages/framer-motion/src/animation/sequence/utils/edit.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/edit.ts
@@ -1,0 +1,47 @@
+import { Easing } from "../../../easing/types"
+import { getEasingForSegment } from "../../../easing/utils/get-easing-for-segment"
+import { removeItem } from "../../../utils/array"
+import { mix } from "../../../utils/mix"
+import { UnresolvedValueKeyframe } from "../../types"
+import type { ValueSequence } from "../types"
+
+export function eraseKeyframes(
+    sequence: ValueSequence,
+    startTime: number,
+    endTime: number
+): void {
+    for (let i = 0; i < sequence.length; i++) {
+        const keyframe = sequence[i]
+
+        if (keyframe.at > startTime && keyframe.at < endTime) {
+            removeItem(sequence, keyframe)
+
+            // If we remove this item we have to push the pointer back one
+            i--
+        }
+    }
+}
+
+export function addKeyframes(
+    sequence: ValueSequence,
+    keyframes: UnresolvedValueKeyframe[],
+    easing: Easing | Easing[],
+    offset: number[],
+    startTime: number,
+    endTime: number
+): void {
+    /**
+     * Erase every existing value between currentTime and targetTime,
+     * this will essentially splice this timeline into any currently
+     * defined ones.
+     */
+    eraseKeyframes(sequence, startTime, endTime)
+
+    for (let i = 0; i < keyframes.length; i++) {
+        sequence.push({
+            value: keyframes[i],
+            at: mix(startTime, endTime, offset[i]),
+            easing: getEasingForSegment(easing, i),
+        })
+    }
+}

--- a/packages/framer-motion/src/animation/sequence/utils/sort.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/sort.ts
@@ -5,7 +5,7 @@ export function compareByTime(
     b: AbsoluteKeyframe
 ): number {
     if (a.at === b.at) {
-        return a.value === null ? 1 : 0
+        return a.value === null ? 0 : -1
     } else {
         return a.at - b.at
     }

--- a/packages/framer-motion/src/animation/sequence/utils/sort.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/sort.ts
@@ -5,7 +5,7 @@ export function compareByTime(
     b: AbsoluteKeyframe
 ): number {
     if (a.at === b.at) {
-        return a.value === null ? 0 : -1
+        return a.value === null ? 1 : 0
     } else {
         return a.at - b.at
     }

--- a/packages/framer-motion/src/animation/sequence/utils/sort.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/sort.ts
@@ -5,7 +5,7 @@ export function compareByTime(
     b: AbsoluteKeyframe
 ): number {
     if (a.at === b.at) {
-        return a.value === null ? 1 : -1
+        return a.value === null ? 0 : -1
     } else {
         return a.at - b.at
     }

--- a/packages/framer-motion/src/animation/sequence/utils/sort.ts
+++ b/packages/framer-motion/src/animation/sequence/utils/sort.ts
@@ -1,0 +1,12 @@
+import { AbsoluteKeyframe } from "../types"
+
+export function compareByTime(
+    a: AbsoluteKeyframe,
+    b: AbsoluteKeyframe
+): number {
+    if (a.at === b.at) {
+        return a.value === null ? 1 : -1
+    } else {
+        return a.at - b.at
+    }
+}

--- a/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
+++ b/packages/framer-motion/src/animation/utils/__tests__/stagger.test.ts
@@ -1,4 +1,4 @@
-import { easingDefinitionToFunction } from "../easing"
+import { easingDefinitionToFunction } from "../../../easing/utils/map"
 import { stagger, getOriginIndex } from "../stagger"
 
 describe("stagger", () => {

--- a/packages/framer-motion/src/animation/utils/keyframes.ts
+++ b/packages/framer-motion/src/animation/utils/keyframes.ts
@@ -38,7 +38,7 @@ export function getKeyframes(
          */
         for (let i = 0; i < target.length; i++) {
             if (target[i] === null) {
-                target[i] = i ? target[i - 1] : origin
+                target[i] = i === 0 ? origin : target[i - 1]
             }
         }
 

--- a/packages/framer-motion/src/animation/utils/keyframes.ts
+++ b/packages/framer-motion/src/animation/utils/keyframes.ts
@@ -34,11 +34,12 @@ export function getKeyframes(
      */
     if (Array.isArray(target)) {
         /**
-         * Ensure an initial wildcard keyframe is hydrated by the origin.
-         * TODO: Support extra wildcard keyframes i.e [1, null, 0]
+         * Ensure an wildcard keyframes are hydrated by the origin.
          */
-        if (target[0] === null) {
-            target[0] = origin
+        for (let i = 0; i < target.length; i++) {
+            if (target[i] === null) {
+                target[i] = i ? target[i - 1] : origin
+            }
         }
 
         return target

--- a/packages/framer-motion/src/animation/utils/stagger.ts
+++ b/packages/framer-motion/src/animation/utils/stagger.ts
@@ -1,6 +1,6 @@
 import { Easing } from "../../easing/types"
+import { easingDefinitionToFunction } from "../../easing/utils/map"
 import { DynamicOption } from "../types"
-import { easingDefinitionToFunction } from "./easing"
 
 export type StaggerOrigin = "first" | "last" | "center" | number
 

--- a/packages/framer-motion/src/easing/utils/__tests__/map.test.ts
+++ b/packages/framer-motion/src/easing/utils/__tests__/map.test.ts
@@ -2,7 +2,7 @@ import { backIn } from "../../../easing/back"
 import { cubicBezier } from "../../../easing/cubic-bezier"
 import { easeInOut } from "../../../easing/ease"
 import { noop } from "../../../utils/noop"
-import { easingDefinitionToFunction } from "../easing"
+import { easingDefinitionToFunction } from "../map"
 
 describe("easingDefinitionToFunction", () => {
     test("Maps easing to lookup", () => {

--- a/packages/framer-motion/src/easing/utils/get-easing-for-segment.ts
+++ b/packages/framer-motion/src/easing/utils/get-easing-for-segment.ts
@@ -1,6 +1,10 @@
 import { wrap } from "../../utils/wrap"
+import { Easing } from "../types"
 import { isEasingArray } from "./is-easing-array"
 
-export function getEasingForSegment<T>(easing: T | T[], i: number) {
+export function getEasingForSegment(
+    easing: Easing | Easing[],
+    i: number
+): Easing {
     return isEasingArray(easing) ? easing[wrap(0, easing.length, i)] : easing
 }

--- a/packages/framer-motion/src/easing/utils/get-easing-for-segment.ts
+++ b/packages/framer-motion/src/easing/utils/get-easing-for-segment.ts
@@ -1,0 +1,8 @@
+import { wrap } from "../../utils/wrap"
+import { isEasingArray } from "./is-easing-array"
+
+export function getEasingForSegment<T>(easing: T | T[], i: number) {
+    return isEasingArray(easing as any)
+        ? easing[wrap(0, (easing as T[]).length, i)]
+        : easing
+}

--- a/packages/framer-motion/src/easing/utils/get-easing-for-segment.ts
+++ b/packages/framer-motion/src/easing/utils/get-easing-for-segment.ts
@@ -2,7 +2,5 @@ import { wrap } from "../../utils/wrap"
 import { isEasingArray } from "./is-easing-array"
 
 export function getEasingForSegment<T>(easing: T | T[], i: number) {
-    return isEasingArray(easing as any)
-        ? easing[wrap(0, (easing as T[]).length, i)]
-        : easing
+    return isEasingArray(easing) ? easing[wrap(0, easing.length, i)] : easing
 }

--- a/packages/framer-motion/src/easing/utils/is-easing-array.ts
+++ b/packages/framer-motion/src/easing/utils/is-easing-array.ts
@@ -1,0 +1,5 @@
+import { Easing } from "../types"
+
+export const isEasingArray = (ease: any): ease is Easing[] => {
+    return Array.isArray(ease) && typeof ease[0] !== "number"
+}

--- a/packages/framer-motion/src/easing/utils/map.ts
+++ b/packages/framer-motion/src/easing/utils/map.ts
@@ -42,7 +42,3 @@ export const easingDefinitionToFunction = (definition: Easing) => {
 
     return definition
 }
-
-export const isEasingArray = (ease: any): ease is Easing[] => {
-    return Array.isArray(ease) && typeof ease[0] !== "number"
-}

--- a/packages/framer-motion/src/utils/interpolate.ts
+++ b/packages/framer-motion/src/utils/interpolate.ts
@@ -91,10 +91,12 @@ export function interpolate<T>(
         "Both input and output ranges must be the same length"
     )
 
-    invariant(
-        !ease || !Array.isArray(ease) || ease.length === inputLength - 1,
-        "Array of easing functions must be of length `input.length - 1`, as it applies to the transitions **between** the defined values."
-    )
+    // TODO FILL OUT EASING
+
+    // invariant(
+    //     !ease || !Array.isArray(ease) || ease.length === inputLength - 1,
+    //     "Array of easing functions must be of length `input.length - 1`, as it applies to the transitions **between** the defined values."
+    // )
 
     /**
      * If we're only provided a single input, we can just make a function

--- a/packages/framer-motion/src/utils/interpolate.ts
+++ b/packages/framer-motion/src/utils/interpolate.ts
@@ -7,6 +7,8 @@ import { mixColor } from "./mix-color"
 import { mixArray, mixComplex, mixObject } from "./mix-complex"
 import { pipe } from "./pipe"
 import { progress } from "./progress"
+import { easeInOut } from "../easing/ease"
+import { noop } from "./noop"
 
 type Mix<T> = (v: number) => T
 export type MixerFactory<T> = (from: T, to: T) => Mix<T>
@@ -50,7 +52,7 @@ function createMixers<T>(
         let mixer = mixerFactory(output[i], output[i + 1])
 
         if (ease) {
-            const easingFunction = Array.isArray(ease) ? ease[i] : ease
+            const easingFunction = Array.isArray(ease) ? ease[i] || noop : ease
             mixer = pipe(easingFunction, mixer) as Mix<T>
         }
 
@@ -90,13 +92,6 @@ export function interpolate<T>(
         inputLength === output.length,
         "Both input and output ranges must be the same length"
     )
-
-    // TODO FILL OUT EASING
-
-    // invariant(
-    //     !ease || !Array.isArray(ease) || ease.length === inputLength - 1,
-    //     "Array of easing functions must be of length `input.length - 1`, as it applies to the transitions **between** the defined values."
-    // )
 
     /**
      * If we're only provided a single input, we can just make a function

--- a/packages/framer-motion/src/utils/interpolate.ts
+++ b/packages/framer-motion/src/utils/interpolate.ts
@@ -7,7 +7,6 @@ import { mixColor } from "./mix-color"
 import { mixArray, mixComplex, mixObject } from "./mix-complex"
 import { pipe } from "./pipe"
 import { progress } from "./progress"
-import { easeInOut } from "../easing/ease"
 import { noop } from "./noop"
 
 type Mix<T> = (v: number) => T


### PR DESCRIPTION
This PR adds animation sequencing to `animate()`.

```javascript
const progress = motionValue(0)

animate([
  // Can animate elements
  ["ul", { clipPath: "inset(0%)" }, { duration: 1 }],
  ["li", { opacity: 1 }, { delay: stagger(.1) }],
  // And/or motion values
  [progress, 100, { at: 0 }]
])
```

Currently sequence segments only support duration-based keyframes and elements, with MotionValue and spring support to be added in subsequent versions.