### PR TITLE
Adding `.duration` to `animate()`

### DIFF
--- a/packages/framer-motion-3d/src/render/__tests__/index.test.tsx
+++ b/packages/framer-motion-3d/src/render/__tests__/index.test.tsx
@@ -240,7 +240,7 @@ describe("motion for three", () => {
             }
 
             ReactThreeTestRenderer.create(<Component />)
-            sync.update(() => resolve([x.get(), y.get()]), 5)
+            sync.update(() => resolve([x.get(), y.get()]))
         })
 
         expect(result[0]).toEqual(100)

--- a/packages/framer-motion-3d/src/render/__tests__/index.test.tsx
+++ b/packages/framer-motion-3d/src/render/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { ResolvedValues } from "framer-motion"
+import { ResolvedValues, sync } from "framer-motion"
 import * as React from "react"
 import { useEffect, useRef } from "react"
 import { Euler, Vector3 } from "three"
@@ -240,7 +240,7 @@ describe("motion for three", () => {
             }
 
             ReactThreeTestRenderer.create(<Component />)
-            setTimeout(() => resolve([x.get(), y.get()]), 5)
+            sync.update(() => resolve([x.get(), y.get()]), 5)
         })
 
         expect(result[0]).toEqual(100)

--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -1,6 +1,6 @@
 import { AnimationPlaybackControls } from "./types"
 
-type PropNames = "time" | "speed"
+type PropNames = "time" | "speed" | "duration"
 
 export class GroupPlaybackControls implements AnimationPlaybackControls {
     animations: AnimationPlaybackControls[]
@@ -42,6 +42,14 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
 
     set speed(speed: number) {
         this.setAll("speed", speed)
+    }
+
+    get duration() {
+        let max = 0
+        for (let i = 0; i < this.animations.length; i++) {
+            max = Math.max(max, this.animations[i].duration)
+        }
+        return max
     }
 
     private runAll(

--- a/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
+++ b/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
@@ -7,6 +7,7 @@ function createTestAnimationControls(
     return {
         time: 1,
         speed: 1,
+        duration: 10,
         stop: () => {},
         play: () => {},
         pause: () => {},
@@ -192,5 +193,21 @@ describe("GroupPlaybackControls", () => {
         controls.speed = -1
         expect(a.speed).toEqual(-1)
         expect(b.speed).toEqual(-1)
+    })
+
+    test("Gets max duration", async () => {
+        const a = createTestAnimationControls({
+            duration: 3,
+        })
+        const b = createTestAnimationControls({
+            duration: 2,
+        })
+        const c = createTestAnimationControls({
+            duration: 1,
+        })
+
+        const controls = new GroupPlaybackControls([a, b, c])
+
+        expect(controls.duration).toEqual(3)
     })
 })

--- a/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
+++ b/packages/framer-motion/src/animation/__tests__/GroupPlaybackControls.test.ts
@@ -210,4 +210,10 @@ describe("GroupPlaybackControls", () => {
 
         expect(controls.duration).toEqual(3)
     })
+
+    test("Returns zero for no animations", async () => {
+        const controls = new GroupPlaybackControls([])
+
+        expect(controls.duration).toEqual(0)
+    })
 })

--- a/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate-waapi.test.tsx
@@ -118,6 +118,15 @@ describe("animate() with WAAPI", () => {
         )
     })
 
+    test("Returns duration correctly", async () => {
+        const animation = animate(
+            document.createElement("div"),
+            { opacity: 1 },
+            { duration: 2, opacity: { duration: 3 } }
+        )
+        expect(animation.duration).toEqual(3)
+    })
+
     test("Can accept timeline sequences", async () => {
         const a = document.createElement("div")
         const b = document.createElement("div")

--- a/packages/framer-motion/src/animation/animators/__tests__/instant.test.ts
+++ b/packages/framer-motion/src/animation/animators/__tests__/instant.test.ts
@@ -74,4 +74,18 @@ describe("instantAnimation", () => {
         expect(onUpdate).toBeCalledWith(1)
         expect(onComplete).toBeCalled()
     })
+
+    test("Returns duration: 0", async () => {
+        const animation = createInstantAnimation({
+            delay: 0,
+            keyframes: [0, 1],
+        })
+        expect(animation.duration).toEqual(0)
+
+        const animationWithDelay = createInstantAnimation({
+            delay: 0.2,
+            keyframes: [0, 1],
+        })
+        expect(animationWithDelay.duration).toEqual(0)
+    })
 })

--- a/packages/framer-motion/src/animation/animators/instant.ts
+++ b/packages/framer-motion/src/animation/animators/instant.ts
@@ -4,7 +4,7 @@ import { noop } from "../../utils/noop"
 
 export function createInstantAnimation<V>({
     keyframes,
-    delay: delayBy,
+    delay,
     onUpdate,
     onComplete,
 }: ValueAnimationOptions<V>): AnimationPlaybackControls {
@@ -22,6 +22,7 @@ export function createInstantAnimation<V>({
         return {
             time: 0,
             speed: 1,
+            duration: 0,
             play: noop<void>,
             pause: noop<void>,
             stop: noop<void>,
@@ -34,10 +35,11 @@ export function createInstantAnimation<V>({
         }
     }
 
-    return delayBy
+    return delay
         ? animateValue({
               keyframes: [0, 1],
-              duration: delayBy,
+              duration: 0,
+              delay,
               onComplete: setValue,
           })
         : setValue()

--- a/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
+++ b/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
@@ -1242,4 +1242,56 @@ describe("animate", () => {
 
         await animation
     })
+
+    test("Correctly returns duration", async () => {
+        expect(
+            animateValue({
+                keyframes: [0, 100],
+                duration: 1000,
+            }).duration
+        ).toEqual(1)
+    })
+
+    test("Correctly returns duration when delay is defined", () => {
+        expect(
+            animateValue({
+                keyframes: [0, 100],
+                delay: 1000,
+                duration: 1000,
+            }).duration
+        ).toEqual(1)
+    })
+
+    test("Correctly returns duration when repeat is defined", () => {
+        expect(
+            animateValue({
+                keyframes: [0, 100],
+                delay: 1000,
+                duration: 1000,
+                repeat: Infinity,
+            }).duration
+        ).toEqual(1)
+    })
+
+    test("Correctly returns duration when animation is spring", () => {
+        expect(
+            animateValue({
+                keyframes: [0, 100],
+                delay: 1000,
+                duration: 1000,
+                type: "spring",
+            }).duration
+        ).toEqual(1)
+    })
+
+    test("Correctly returns duration when animation is dynamic spring", () => {
+        expect(
+            animateValue({
+                keyframes: [0, 100],
+                stiffness: 200,
+                damping: 10,
+                type: "spring",
+            }).duration
+        ).toEqual(1.2)
+    })
 })

--- a/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
@@ -169,6 +169,9 @@ export function createAcceleratedAnimation(
         set speed(newSpeed: number) {
             animation.playbackRate = newSpeed
         },
+        get duration() {
+            return millisecondsToSeconds(duration)
+        },
         play: () => {
             if (hasStopped) return
             animation.play()

--- a/packages/framer-motion/src/animation/interfaces/motion-value.ts
+++ b/packages/framer-motion/src/animation/interfaces/motion-value.ts
@@ -73,19 +73,6 @@ export const animateMotionValue = (
             },
         }
 
-        if (
-            !isOriginAnimatable ||
-            !isTargetAnimatable ||
-            instantAnimationState.current ||
-            valueTransition.type === false
-        ) {
-            /**
-             * If we can't animate this value, or the global instant animation flag is set,
-             * or this is simply defined as an instant transition, return an instant transition.
-             */
-            return createInstantAnimation(options)
-        }
-
         /**
          * If there's no transition defined for this value, we can generate
          * unqiue transition settings for this value.
@@ -108,6 +95,19 @@ export const animateMotionValue = (
 
         if (options.repeatDelay) {
             options.repeatDelay = secondsToMilliseconds(options.repeatDelay)
+        }
+
+        if (
+            !isOriginAnimatable ||
+            !isTargetAnimatable ||
+            instantAnimationState.current ||
+            valueTransition.type === false
+        ) {
+            /**
+             * If we can't animate this value, or the global instant animation flag is set,
+             * or this is simply defined as an instant transition, return an instant transition.
+             */
+            return createInstantAnimation(options)
         }
 
         /**

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -74,6 +74,7 @@ export type ElementOrSelector =
 export interface AnimationPlaybackControls {
     time: number
     speed: number
+    duration: number
     stop: () => void
     play: () => void
     pause: () => void

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -74,7 +74,14 @@ export type ElementOrSelector =
 export interface AnimationPlaybackControls {
     time: number
     speed: number
+
+    /*
+     * The duration is the duration of time calculated for the active part
+     * of the animation without delay or repeat,
+     * which may be added as an extra prop at a later date.
+     */
     duration: number
+
     stop: () => void
     play: () => void
     pause: () => void


### PR DESCRIPTION
This PR adds `.duration` as a read-only property for animations.

```javascript
const animation = animate(0, 100)

animation.duration // .3
```

The `duration` is the duration of time calculated for the active part of the animation without delay or repeat, which may be added as an extra prop at a later date.