### PR TITLE
Resize MotionCanvas when container resizes (Fixes #1444)

### DIFF
--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -47,7 +47,8 @@
     },
     "dependencies": {
         "framer-motion": "^10.8.5",
-        "react-merge-refs": "^2.0.1"
+        "react-merge-refs": "^2.0.1",
+        "react-use-measure": "^2.1.1"
     },
     "peerDependencies": {
         "@react-three/fiber": "^8.2.2",

--- a/packages/framer-motion-3d/src/components/MotionCanvas.tsx
+++ b/packages/framer-motion-3d/src/components/MotionCanvas.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import {
     useContext,
-    useLayoutEffect,
+    useEffect,
     useRef,
     forwardRef,
     MutableRefObject,
@@ -23,6 +23,7 @@ import {
     Dpr,
     ReconcilerRoot,
 } from "@react-three/fiber"
+import useMeasure from "react-use-measure"
 import { DimensionsState, MotionCanvasContext } from "./MotionCanvasContext"
 
 export interface MotionCanvasProps extends Omit<Props, "resize"> {}
@@ -100,21 +101,21 @@ function CanvasComponent(
     })
     const { size, dpr } = dimensions.current
 
-    const containerRef = useRef<HTMLDivElement>(null)
+    const [containerRef, containerSize] = useMeasure();
 
     const handleResize = (): void => {
-        const container = containerRef.current!
+        const { width, height } = containerSize;
         dimensions.current = {
             size: {
-                width: container.offsetWidth,
-                height: container.offsetHeight,
+                width,
+                height,
             },
         }
         forceRender()
     }
 
     // Set canvas size on mount
-    useLayoutEffect(handleResize, [])
+    useEffect(handleResize, [containerSize, forceRender])
 
     const canvasRef = React.useRef<HTMLCanvasElement>(null!)
     const [block, setBlock] = React.useState<SetBlock>(false)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7920,6 +7920,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^22.0.1
     framer-motion: ^10.8.5
     react-merge-refs: ^2.0.1
+    react-use-measure: ^2.1.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
     react: ">=18.0"


### PR DESCRIPTION
I was facing the issue in #1444 and attempted to fix it locally via patch-package. It seems to correct the behaviour described in the issue with regards to updating the canvas size as the parent resizes, and utilizes react-use-measure as does the react-three implementation.

I did not find any relevant MotionCanvas tests I could use as a starting point, so I did not any tests for this case, but given it seems like a minor fix, that might be okay. Happy to add it if someone can point me in the right direction / contribute to this PR.