### PR TITLE
Fixed typo in LazyMotion component and its types

### DIFF
--- a/packages/framer-motion/src/components/LazyMotion/index.tsx
+++ b/packages/framer-motion/src/components/LazyMotion/index.tsx
@@ -17,11 +17,11 @@ import { LazyProps } from "./types"
  *
  * ```jsx
  * // Synchronous loading
- * import { LazyMotion, m, domAnimations } from "framer-motion"
+ * import { LazyMotion, m, domAnimation } from "framer-motion"
  *
  * function App() {
  *   return (
- *     <LazyMotion features={domAnimations}>
+ *     <LazyMotion features={domAnimation}>
  *       <m.div animate={{ scale: 2 }} />
  *     </LazyMotion>
  *   )
@@ -32,7 +32,7 @@ import { LazyProps } from "./types"
  *
  * function App() {
  *   return (
- *     <LazyMotion features={() => import('./path/to/domAnimations')}>
+ *     <LazyMotion features={() => import('./path/to/domAnimation')}>
  *       <m.div animate={{ scale: 2 }} />
  *     </LazyMotion>
  *   )

--- a/packages/framer-motion/src/components/LazyMotion/types.ts
+++ b/packages/framer-motion/src/components/LazyMotion/types.ts
@@ -13,8 +13,8 @@ export interface LazyProps {
      *
      * ```jsx
      * // features.js
-     * import { domAnimations } from "framer-motion"
-     * export default domAnimations
+     * import { domAnimation } from "framer-motion"
+     * export default domAnimation
      *
      * // index.js
      * import { LazyMotion, m } from "framer-motion"


### PR DESCRIPTION
While using the LazyMotion component from Framer Motion I encountered a small typo. It says that I should import domAnimations but I could not find such file exported from motion, and then I realized that It was domAnimation. So Im making this basic PR to address this typo fix.