### PR TITLE
Remove CSS variables before interpolating

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -85,7 +85,11 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
+<<<<<<< HEAD
             "maxSize": "30.33 kB"
+=======
+            "maxSize": "30.31 kB"
+>>>>>>> 22c49d6a (Adding CSS var detection to mixComplex)
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -101,7 +105,11 @@
         },
         {
             "path": "./dist/size-rollup-animate.js",
+<<<<<<< HEAD
             "maxSize": "15.83 kB"
+=======
+            "maxSize": "15.81 kB"
+>>>>>>> 22c49d6a (Adding CSS var detection to mixComplex)
         },
         {
             "path": "./dist/size-webpack-m.js",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -85,11 +85,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-<<<<<<< HEAD
-            "maxSize": "30.33 kB"
-=======
             "maxSize": "30.31 kB"
->>>>>>> 22c49d6a (Adding CSS var detection to mixComplex)
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -105,11 +101,7 @@
         },
         {
             "path": "./dist/size-rollup-animate.js",
-<<<<<<< HEAD
-            "maxSize": "15.83 kB"
-=======
             "maxSize": "15.81 kB"
->>>>>>> 22c49d6a (Adding CSS var detection to mixComplex)
         },
         {
             "path": "./dist/size-webpack-m.js",

--- a/packages/framer-motion/src/projection/styles/scale-box-shadow.ts
+++ b/packages/framer-motion/src/projection/styles/scale-box-shadow.ts
@@ -1,26 +1,10 @@
-import { cssVariableRegex } from "../../render/dom/utils/is-css-variable"
 import { mix } from "../../utils/mix"
 import { complex } from "../../value/types/complex"
 import { ScaleCorrectorDefinition } from "./types"
 
-const varToken = "_$css"
-
 export const correctBoxShadow: ScaleCorrectorDefinition = {
     correct: (latest: string, { treeScale, projectionDelta }) => {
         const original = latest
-
-        /**
-         * We need to first strip and store CSS variables from the string.
-         */
-        const containsCSSVariables = latest.includes("var(")
-        const cssVariables: string[] = []
-        if (containsCSSVariables) {
-            latest = latest.replace(cssVariableRegex, (match) => {
-                cssVariables.push(match)
-                return varToken
-            })
-        }
-
         const shadow = complex.parse(latest)
 
         // TODO: Doesn't support multiple shadows
@@ -53,17 +37,6 @@ export const correctBoxShadow: ScaleCorrectorDefinition = {
         if (typeof shadow[3 + offset] === "number")
             (shadow[3 + offset] as number) /= averageScale
 
-        let output = template(shadow)
-
-        if (containsCSSVariables) {
-            let i = 0
-            output = output.replace(varToken, () => {
-                const cssVariable = cssVariables[i]
-                i++
-                return cssVariable
-            })
-        }
-
-        return output
+        return template(shadow)
     },
 }

--- a/packages/framer-motion/src/projection/styles/scale-box-shadow.ts
+++ b/packages/framer-motion/src/projection/styles/scale-box-shadow.ts
@@ -1,4 +1,4 @@
-import { cssVariableRegex } from "../../render/dom/utils/css-variables-conversion"
+import { cssVariableRegex } from "../../render/dom/utils/is-css-variable"
 import { mix } from "../../utils/mix"
 import { complex } from "../../value/types/complex"
 import { ScaleCorrectorDefinition } from "./types"

--- a/packages/framer-motion/src/render/dom/utils/css-variables-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/css-variables-conversion.ts
@@ -12,10 +12,10 @@ import { isCSSVariableToken, CSSVariableToken } from "./is-css-variable"
  *
  * @param current
  */
-const splitCssVariableRegex =
+const splitCSSVariableRegex =
     /var\((--[a-zA-Z0-9-_]+),? ?([a-zA-Z0-9 ()%#.,-]+)?\)/
 export function parseCSSVariable(current: string) {
-    const match = splitCssVariableRegex.exec(current)
+    const match = splitCSSVariableRegex.exec(current)
     if (!match) return [,]
 
     const [, token, fallback] = match

--- a/packages/framer-motion/src/render/dom/utils/css-variables-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/css-variables-conversion.ts
@@ -1,11 +1,7 @@
 import { Target, TargetWithKeyframes } from "../../../types"
 import { invariant } from "../../../utils/errors"
 import type { VisualElement } from "../../VisualElement"
-import {
-    isCSSVariableToken,
-    CSSVariableToken,
-    cssVariableRegex,
-} from "./is-css-variable"
+import { isCSSVariableToken, CSSVariableToken } from "./is-css-variable"
 
 /**
  * Parse Framer's special CSS variable format into a CSS token and a fallback.
@@ -16,8 +12,10 @@ import {
  *
  * @param current
  */
+const splitCssVariableRegex =
+    /var\((--[a-zA-Z0-9-_]+),? ?([a-zA-Z0-9 ()%#.,-]+)?\)/
 export function parseCSSVariable(current: string) {
-    const match = cssVariableRegex.exec(current)
+    const match = splitCssVariableRegex.exec(current)
     if (!match) return [,]
 
     const [, token, fallback] = match

--- a/packages/framer-motion/src/render/dom/utils/css-variables-conversion.ts
+++ b/packages/framer-motion/src/render/dom/utils/css-variables-conversion.ts
@@ -1,7 +1,11 @@
 import { Target, TargetWithKeyframes } from "../../../types"
 import { invariant } from "../../../utils/errors"
 import type { VisualElement } from "../../VisualElement"
-import { isCSSVariableToken, CSSVariableToken } from "./is-css-variable"
+import {
+    isCSSVariableToken,
+    CSSVariableToken,
+    cssVariableRegex,
+} from "./is-css-variable"
 
 /**
  * Parse Framer's special CSS variable format into a CSS token and a fallback.
@@ -12,8 +16,6 @@ import { isCSSVariableToken, CSSVariableToken } from "./is-css-variable"
  *
  * @param current
  */
-export const cssVariableRegex =
-    /var\((--[a-zA-Z0-9-_]+),? ?([a-zA-Z0-9 ()%#.,-]+)?\)/
 export function parseCSSVariable(current: string) {
     const match = cssVariableRegex.exec(current)
     if (!match) return [,]

--- a/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
+++ b/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
@@ -10,3 +10,6 @@ const checkStringStartsWith =
 export const isCSSVariableName = checkStringStartsWith<CSSVariableName>("--")
 export const isCSSVariableToken =
     checkStringStartsWith<CSSVariableToken>("var(--")
+
+export const cssVariableRegex =
+    /var\((--[a-zA-Z0-9-_]+),? ?([a-zA-Z0-9 ()%#.,-]+)?\)/

--- a/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
+++ b/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
@@ -12,4 +12,4 @@ export const isCSSVariableToken =
     checkStringStartsWith<CSSVariableToken>("var(--")
 
 export const cssVariableRegex =
-    /var\((--[a-zA-Z0-9-_]+),? ?([a-zA-Z0-9 ()%#.,-]+)?\)/
+    /var\s*\(\s*--[\w-]+(\s*,\s*(?:(?:[^)(]|\((?:[^)(]+|\([^)(]*\))*\))*)+)?\s*\)/g

--- a/packages/framer-motion/src/utils/__tests__/interpolate.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/interpolate.test.ts
@@ -114,10 +114,34 @@ test("custom mixer", () => {
 test("interpolate - CSS variables", () => {
     const f = interpolate(
         [0, 1],
-        ["linear-gradient(#fff, grey)", "linear-gradient(var(--10), grey)"]
+        [
+            "linear-gradient(var(--10), var(--20, rgba(0,0,0,0)), #fff)",
+            "linear-gradient(var(--20), var(--20, rgba(0,0,0,0)), #000)",
+        ]
     )
-    expect(f(0)).toEqual("linear-gradient(#fff, grey)")
-    expect(f(0.5)).toEqual("linear-gradient(#fff, grey)")
-    expect(f(1)).toEqual("linear-gradient(var(--10), grey)")
-    expect(f(1.4)).toEqual("linear-gradient(var(--10), grey)")
+    expect(f(0.5)).toEqual(
+        "linear-gradient(var(--20), var(--20, rgba(0,0,0,0)), rgba(180, 180, 180, 1))"
+    )
+})
+
+test("interpolate - color to CSS variables", () => {
+    const f = interpolate(
+        [0, 1],
+        [
+            "linear-gradient(#fff, var(--20, rgba(0,0,0,0)), grey)",
+            "linear-gradient(var(--10), var(--20, rgba(0,0,0,0)), grey)",
+        ]
+    )
+    expect(f(0)).toEqual(
+        "linear-gradient(#fff, var(--20, rgba(0,0,0,0)), grey)"
+    )
+    expect(f(0.5)).toEqual(
+        "linear-gradient(var(--10), var(--20, rgba(0,0,0,0)), grey)"
+    )
+    expect(f(1)).toEqual(
+        "linear-gradient(var(--10), var(--20, rgba(0,0,0,0)), grey)"
+    )
+    expect(f(1.4)).toEqual(
+        "linear-gradient(var(--10), var(--20, rgba(0,0,0,0)), grey)"
+    )
 })

--- a/packages/framer-motion/src/utils/__tests__/interpolate.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/interpolate.test.ts
@@ -110,3 +110,14 @@ test("custom mixer", () => {
     })
     expect(a(0.5)).toBe(42)
 })
+
+test("interpolate - CSS variables", () => {
+    const f = interpolate(
+        [0, 1],
+        ["linear-gradient(#fff, grey)", "linear-gradient(var(--10), grey)"]
+    )
+    expect(f(0)).toEqual("linear-gradient(#fff, grey)")
+    expect(f(0.5)).toEqual("linear-gradient(#fff, grey)")
+    expect(f(1)).toEqual("linear-gradient(var(--10), grey)")
+    expect(f(1.4)).toEqual("linear-gradient(var(--10), grey)")
+})

--- a/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
@@ -43,3 +43,15 @@ test("mixComplex can animate from a value with extra zeros", () => {
         "10px 0px rgba(180, 180, 180, 1)"
     )
 })
+
+test("mixComplex won't interpolate strings containing CSS variables", () => {
+    expect(
+        mixComplex("#fff 0 var(--grey) 10px", "#000 0 var(--grey) 0px")(0)
+    ).toBe("#fff 0 var(--grey) 10px")
+    expect(
+        mixComplex("#fff 0 var(--grey) 10px", "#000 0 var(--grey) 0px")(0.5)
+    ).toBe("#000 0 var(--grey) 0px")
+    expect(
+        mixComplex("#fff 0 var(--grey) 10px", "#000 0 var(--grey) 0px")(1)
+    ).toBe("#000 0 var(--grey) 0px")
+})

--- a/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
+++ b/packages/framer-motion/src/utils/__tests__/mix-complex.test.ts
@@ -44,14 +44,12 @@ test("mixComplex can animate from a value with extra zeros", () => {
     )
 })
 
-test("mixComplex won't interpolate strings containing CSS variables", () => {
-    expect(
-        mixComplex("#fff 0 var(--grey) 10px", "#000 0 var(--grey) 0px")(0)
-    ).toBe("#fff 0 var(--grey) 10px")
-    expect(
-        mixComplex("#fff 0 var(--grey) 10px", "#000 0 var(--grey) 0px")(0.5)
-    ).toBe("#000 0 var(--grey) 0px")
-    expect(
-        mixComplex("#fff 0 var(--grey) 10px", "#000 0 var(--grey) 0px")(1)
-    ).toBe("#000 0 var(--grey) 0px")
+test("mixComplex will only interpolate values outside of CSS variables", () => {
+    const mixer = mixComplex(
+        "#fff 0 var(--grey, 0px) 10px",
+        "#000 0 var(--grey, 10px) 0px"
+    )
+    expect(mixer(0)).toBe("rgba(255, 255, 255, 1) 0 var(--grey, 0px) 10px")
+    expect(mixer(0.5)).toBe("rgba(180, 180, 180, 1) 0 var(--grey, 10px) 5px")
+    expect(mixer(1)).toBe("rgba(0, 0, 0, 1) 0 var(--grey, 10px) 0px")
 })

--- a/packages/framer-motion/src/utils/interpolate.ts
+++ b/packages/framer-motion/src/utils/interpolate.ts
@@ -24,11 +24,7 @@ function detectMixerFactory<T>(v: T): MixerFactory<any> {
     if (typeof v === "number") {
         return mixNumber
     } else if (typeof v === "string") {
-        if (color.test(v)) {
-            return mixColor
-        } else {
-            return mixComplex
-        }
+        return color.test(v) ? mixColor : mixComplex
     } else if (Array.isArray(v)) {
         return mixArray
     } else if (typeof v === "object") {

--- a/packages/framer-motion/src/utils/mix-complex.ts
+++ b/packages/framer-motion/src/utils/mix-complex.ts
@@ -65,7 +65,9 @@ export const mixComplex = (
 
     const canInterpolate =
         originStats.numColors === targetStats.numColors &&
-        originStats.numNumbers >= targetStats.numNumbers
+        originStats.numNumbers >= targetStats.numNumbers &&
+        !originStats.containsCSSVars &&
+        !targetStats.containsCSSVars
 
     if (canInterpolate) {
         return pipe(

--- a/packages/framer-motion/src/utils/mix-complex.ts
+++ b/packages/framer-motion/src/utils/mix-complex.ts
@@ -14,7 +14,7 @@ type BlendableObject = {
 }
 
 const mixImmediate =
-    (from: number | string, to: number | string) => (p: number) =>
+    (origin: number | string, target: number | string) => (p: number) =>
         `${p > 0 ? target : origin}`
 
 function getMixer(origin: any, target: any) {

--- a/packages/framer-motion/src/utils/mix-complex.ts
+++ b/packages/framer-motion/src/utils/mix-complex.ts
@@ -13,13 +13,19 @@ type BlendableObject = {
     [key: string]: string | number | RGBA | HSLA
 }
 
+const mixImmediate =
+    (from: number | string, to: number | string) => (p: number) =>
+        `${p > 0 ? target : origin}`
+
 function getMixer(origin: any, target: any) {
     if (typeof origin === "number") {
         return (v: number) => mix(origin, target as number, v)
     } else if (color.test(origin)) {
         return mixColor(origin, target as HSLA | RGBA | string)
     } else {
-        return mixComplex(origin as string, target as string)
+        return origin.startsWith("var(")
+            ? mixImmediate(origin, target)
+            : mixComplex(origin as string, target as string)
     }
 }
 
@@ -64,10 +70,9 @@ export const mixComplex = (
     const targetStats = analyseComplexValue(target)
 
     const canInterpolate =
+        originStats.numVars === targetStats.numVars &&
         originStats.numColors === targetStats.numColors &&
-        originStats.numNumbers >= targetStats.numNumbers &&
-        !originStats.containsCSSVars &&
-        !targetStats.containsCSSVars
+        originStats.numNumbers >= targetStats.numNumbers
 
     if (canInterpolate) {
         return pipe(
@@ -80,6 +85,6 @@ export const mixComplex = (
             `Complex values '${origin}' and '${target}' too different to mix. Ensure all colors are of the same type, and that each contains the same quantity of number and color values. Falling back to instant transition.`
         )
 
-        return (p: number) => `${p > 0 ? target : origin}`
+        return mixImmediate(origin, target)
     }
 }

--- a/packages/framer-motion/src/value/types/__tests__/index.test.ts
+++ b/packages/framer-motion/src/value/types/__tests__/index.test.ts
@@ -141,7 +141,7 @@ describe("complex value type", () => {
         expect(transformSingleNumber([100])).toBe("100")
     })
 
-    it.only('can create an animatable "none"', () => {
+    it('can create an animatable "none"', () => {
         expect(
             complex.getAnimatableNone("100% 0px var(--grey, 100) #fff")
         ).toBe("0% 0px var(--grey, 100) rgba(255, 255, 255, 1)")

--- a/packages/framer-motion/src/value/types/__tests__/index.test.ts
+++ b/packages/framer-motion/src/value/types/__tests__/index.test.ts
@@ -141,10 +141,10 @@ describe("complex value type", () => {
         expect(transformSingleNumber([100])).toBe("100")
     })
 
-    it('can create an animatable "none"', () => {
-        expect(complex.getAnimatableNone("100% 0px #fff")).toBe(
-            "0% 0px rgba(255, 255, 255, 1)"
-        )
+    it.only('can create an animatable "none"', () => {
+        expect(
+            complex.getAnimatableNone("100% 0px var(--grey, 100) #fff")
+        ).toBe("0% 0px var(--grey, 100) rgba(255, 255, 255, 1)")
     })
 })
 

--- a/packages/framer-motion/src/value/types/complex/index.ts
+++ b/packages/framer-motion/src/value/types/complex/index.ts
@@ -39,7 +39,13 @@ export function analyseComplexValue(v: string | number) {
         values.push(...numbers.map(number.parse))
     }
 
-    return { values, numColors, numNumbers, tokenised: v }
+    return {
+        values,
+        numColors,
+        numNumbers,
+        tokenised: v,
+        containsCSSVars: v.includes("var(--"),
+    }
 }
 
 function parse(v: string | number) {

--- a/packages/framer-motion/src/value/types/complex/index.ts
+++ b/packages/framer-motion/src/value/types/complex/index.ts
@@ -59,23 +59,24 @@ function tokenise(
     info: ComplexValueInfo,
     { regex, countKey, token, parse }: Tokeniser
 ) {
-    const matches = info.value.match(regex)
+    const matches = info.tokenised.match(regex)
 
     if (!matches) return
 
     info["num" + countKey] = matches.length
-    info.value = info.value.replace(regex, token)
+    info.tokenised = info.tokenised.replace(regex, token)
     info.values.push(...(matches.map(parse) as any))
 }
 
 export function analyseComplexValue(value: string | number): ComplexValueInfo {
+    const originalValue = value.toString()
     const info = {
-        value: typeof value === "number" ? "" + value : value,
+        value: originalValue,
+        tokenised: originalValue,
         values: [],
         numVars: 0,
         numColors: 0,
         numNumbers: 0,
-        tokenised: "",
     }
 
     if (info.value.includes("var(--")) tokenise(info, cssVarTokeniser)


### PR DESCRIPTION
This PR ensures CSS variable tokens are removed from complex values before interpolation, so we don't end up animating numbers in tokens.

This PR doesn't allow us to animate strings containing multiple tokens, but these styles will still be set as expected if left unresolved.