### PR TITLE
Fix relative animations with mixed instant/time: 0 transitions

### DIFF
--- a/dev/projection/animate-relative-mixed-transition.html
+++ b/dev/projection/animate-relative-mixed-transition.html
@@ -1,0 +1,101 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 0;
+                margin: 0;
+            }
+
+            #parent {
+                position: relative;
+                width: 200px;
+                height: 200px;
+                background-color: #00cc88;
+            }
+
+            #mid {
+                position: absolute;
+                width: auto;
+                height: auto;
+                left: 0;
+                top: 0;
+            }
+
+            .b #mid {
+                left: 100px;
+            }
+
+            #child {
+                width: 50px;
+                height: 50px;
+                background-color: #0077ff;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 0.5;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="parent">
+            <div id="mid"><div id="child" /></div>
+        </div>
+
+        <script src="../../packages/framer-motion/dist/projection.dev.js"></script>
+        <script src="./script-assert.js"></script>
+        <script src="./script-animate.js"></script>
+        <script>
+            const { createNode, relativeEase } = window.Animate
+            const { matchViewportBox } = window.Assert
+
+            const parent = document.getElementById("parent")
+            const mid = document.getElementById("mid")
+            const child = document.getElementById("child")
+
+            const parentProjection = createNode(
+                parent,
+                undefined,
+                {},
+                { duration: 0 }
+            )
+            const midProjection = createNode(
+                mid,
+                parentProjection,
+                {},
+                { duration: 0 }
+            )
+            const childProjection = createNode(
+                child,
+                midProjection,
+                {},
+                { type: false }
+            )
+
+            parentProjection.willUpdate()
+            midProjection.willUpdate()
+            childProjection.willUpdate()
+
+            parent.classList.add("b")
+
+            parentProjection.root.didUpdate()
+
+            frame.postRender(() => {
+                frame.postRender(() => {
+                    matchViewportBox(mid, {
+                        bottom: 50,
+                        left: 100,
+                        right: 150,
+                        top: 0,
+                    })
+                    matchViewportBox(child, {
+                        bottom: 50,
+                        left: 100,
+                        right: 150,
+                        top: 0,
+                    })
+                })
+            })
+        </script>
+    </body>
+</html>

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
     "version": "10.12.5",
-    "packages": [
-        "packages/*"
-    ],
+    "packages": ["packages/*"],
     "npmClient": "yarn",
     "useWorkspaces": true
 }

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1053,7 +1053,11 @@ export function createProjectionNode<I>({
             if (!this.targetDelta && !this.relativeTarget) {
                 // TODO: This is a semi-repetition of further down this function, make DRY
                 const relativeParent = this.getClosestProjectingParent()
-                if (relativeParent && relativeParent.layout && this.animationProgress !== 1) {
+                if (
+                    relativeParent &&
+                    relativeParent.layout &&
+                    this.animationProgress !== 1
+                ) {
                     this.relativeParent = relativeParent
                     this.forceRelativeParentToResolveTarget()
                     this.relativeTarget = createBox()
@@ -1132,7 +1136,8 @@ export function createProjectionNode<I>({
                     Boolean(relativeParent.resumingFrom) ===
                         Boolean(this.resumingFrom) &&
                     !relativeParent.options.layoutScroll &&
-                    relativeParent.target && this.animationProgress !== 1
+                    relativeParent.target &&
+                    this.animationProgress !== 1
                 ) {
                     this.relativeParent = relativeParent
                     this.forceRelativeParentToResolveTarget()
@@ -1431,7 +1436,6 @@ export function createProjectionNode<I>({
                 this.animationProgress = progress
             }
 
-            if ()
             this.mixTargetDelta(this.options.layoutRoot ? 1000 : 0)
         }
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -1053,7 +1053,7 @@ export function createProjectionNode<I>({
             if (!this.targetDelta && !this.relativeTarget) {
                 // TODO: This is a semi-repetition of further down this function, make DRY
                 const relativeParent = this.getClosestProjectingParent()
-                if (relativeParent && relativeParent.layout) {
+                if (relativeParent && relativeParent.layout && this.animationProgress !== 1) {
                     this.relativeParent = relativeParent
                     this.forceRelativeParentToResolveTarget()
                     this.relativeTarget = createBox()
@@ -1132,7 +1132,7 @@ export function createProjectionNode<I>({
                     Boolean(relativeParent.resumingFrom) ===
                         Boolean(this.resumingFrom) &&
                     !relativeParent.options.layoutScroll &&
-                    relativeParent.target
+                    relativeParent.target && this.animationProgress !== 1
                 ) {
                     this.relativeParent = relativeParent
                     this.forceRelativeParentToResolveTarget()
@@ -1431,6 +1431,7 @@ export function createProjectionNode<I>({
                 this.animationProgress = progress
             }
 
+            if ()
             this.mixTargetDelta(this.options.layoutRoot ? 1000 : 0)
         }
 


### PR DESCRIPTION
This PR disables relative animations for animations that have already completed.

This is essentially a quick fix that checks whether an animation has already completed before resolving a relative box. Reason being, the box can be resolved against a parent box which, if animating using a `duration: 0` animation, will itself complete a frame later leaving the relative box incorrect for subsequent frames.