### PR TITLE
Fix instant layout animation with React double renders

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -53,7 +53,7 @@
         "test-projection": "yarn run collect-projection-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/projection.chrome.ts --config baseUrl=http://localhost:8000/'",
         "test-e2e-chrome": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --headless --browser chrome  --spec \"cypress/integration/layout-relative.chrome.ts\"'",
         "test-e2e-electron": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --headless --config ignoreTestFiles=*.chrome.ts'",
-        "test-e2e": "",
+        "test-e2e": "yarn test-appear && yarn test-projection && yarn test-e2e-electron",
         "test-e2e-file": "start-server-and-test start-dev-server http://localhost:9990 'cypress run --headless --spec \"cypress/integration/while-in-view.ts\"'",
         "collect-appear-tests": "node ../../dev/optimized-appear/collect-appear-tests.js",
         "collect-projection-tests": "node ../../dev/projection/collect-projection-tests.js",


### PR DESCRIPTION
This PR fixes `useInstantLayoutAnimation` after a double render by only unlocking layout animations in a microtask, which fires after all synchronous double renders have flushed.