### PR TITLE
Fixing timing bug with `animate()` and `layout` prop

### DIFF
--- a/dev/tests/animate-layout-timing.tsx
+++ b/dev/tests/animate-layout-timing.tsx
@@ -1,0 +1,50 @@
+import { motion, animate } from "framer-motion"
+import * as React from "react"
+import { useEffect, useState } from "react"
+import styled from "styled-components"
+
+const Container = styled.section`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    padding: 100px;
+
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+    }
+`
+
+export const App = () => {
+    const [count, setCount] = useState(0)
+    const [result, setResult] = useState("")
+
+    useEffect(() => {
+        if (count % 2 === 0) return
+
+        const output: number[] = []
+        const controls = animate(0, 100, {
+            duration: 0.5,
+            ease: "linear",
+            onUpdate: (v: number) => output.push(v),
+            onComplete: () =>
+                setResult(
+                    output[1] !== 100 && output.length !== 2
+                        ? "Success"
+                        : "Fail"
+                ),
+        })
+        return controls.stop
+    }, [count])
+
+    return (
+        <Container>
+            <button id="action" onClick={() => setCount((c) => c + 1)}>
+                Animate
+            </button>
+            <input id="result" readOnly value={result} />
+            <motion.div className="box" layout />
+        </Container>
+    )
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
     "version": "10.12.14",
-    "packages": [
-        "packages/*"
-    ],
+    "packages": ["packages/*"],
     "npmClient": "yarn",
     "useWorkspaces": true
 }

--- a/packages/framer-motion/cypress/integration/animate-layout-timing.ts
+++ b/packages/framer-motion/cypress/integration/animate-layout-timing.ts
@@ -1,0 +1,13 @@
+describe("animate() x layout prop timing", () => {
+    it("animate() plays as expected when layout prop is present", () => {
+        cy.visit("?test=animate-layout-timing")
+            .wait(1000)
+            .get("#action")
+            .trigger("click", 1, 1, { force: true })
+            .wait(600)
+            .get("#result")
+            .should(([$element]: any) => {
+                expect($element.value).to.equal("Success")
+            })
+    })
+})

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -47,6 +47,7 @@ import { ValueAnimationOptions } from "../../animation/types"
 import { frameData } from "../../dom-entry"
 import { isSVGElement } from "../../render/dom/utils/is-svg-element"
 import { animateSingleValue } from "../../animation/interfaces/single-value"
+import { clamp } from "../../utils/clamp"
 
 const transformAxes = ["", "X", "Y", "Z"]
 
@@ -634,7 +635,9 @@ export function createProjectionNode<I>({
              * we could leave this to the following requestAnimationFrame but this seems
              * to leave a flash of incorrectly styled content.
              */
-            frameData.timestamp = performance.now()
+            const now = performance.now()
+            frameData.delta = clamp(0, 1000 / 60, now - frameData.timestamp)
+            frameData.timestamp = now
             frameData.isProcessing = true
             steps.update.process(frameData)
             steps.preRender.process(frameData)

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -629,10 +629,17 @@ export function createProjectionNode<I>({
             this.nodes!.forEach(notifyLayoutUpdate)
             this.clearAllSnapshots()
 
-            // Flush any scheduled updates
+            /**
+             * Manually flush any pending updates. Ideally
+             * we could leave this to the following requestAnimationFrame but this seems
+             * to leave a flash of incorrectly styled content.
+             */
+            frameData.timestamp = performance.now()
+            frameData.isProcessing = true
             steps.update.process(frameData)
             steps.preRender.process(frameData)
             steps.render.process(frameData)
+            frameData.isProcessing = false
         }
 
         didUpdate() {


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/2132

This PR fixes a bug with layout animations manually flushing a single animation frame whereby a stale timestamp might be used in some situations. This causes a conflict with `animate()` where if it schedules an animation before layout animations are flushed, the second animation frame will report a much larger time delta than could have occurred. 