### PR TITLE
Ensure new `layout` elements animate correctly

### DIFF
--- a/dev/tests/layout-repeat-new.tsx
+++ b/dev/tests/layout-repeat-new.tsx
@@ -1,0 +1,57 @@
+import { motion } from "framer-motion"
+import * as React from "react"
+import { useState } from "react"
+
+function range(num: number) {
+    return Array.from(Array(num).keys())
+}
+
+const sharedMotionProps = {
+    layout: true,
+    style: { background: "red", width: "100%", height: "100px" },
+    transition: {
+        duration: 0.25,
+        delay: 0.3,
+        ease: [0.2, 0.0, 0.83, 0.83],
+        layout: { duration: 0.3, ease: [0.2, 0.0, 0.83, 0.83] },
+    },
+}
+
+export function App() {
+    const [count, setCount] = useState(0)
+
+    return (
+        <>
+            <div style={{ height: 50 }}>
+                <button id="add" onClick={() => setCount((c) => c + 1)}>
+                    Add item
+                </button>
+                <button id="reset" onClick={() => setCount(0)}>
+                    Reset
+                </button>
+            </div>
+            <div
+                style={{
+                    display: "grid",
+                    gridTemplateColumns:
+                        "repeat(auto-fill, minmax(127px, 1fr))",
+                    gridGap: "10px",
+                    minHeight: "100px",
+                    width: "500px",
+                }}
+            >
+                {range(count)
+                    .reverse()
+                    .map((i) => (
+                        <motion.div
+                            id={`box-${i}`}
+                            key={i}
+                            {...sharedMotionProps}
+                        >
+                            {i}
+                        </motion.div>
+                    ))}
+            </div>
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/layout.ts
+++ b/packages/framer-motion/cypress/integration/layout.ts
@@ -198,4 +198,61 @@ describe("Layout animation", () => {
                 })
             })
     })
+
+    it("Newly-entering elements animate as expected", () => {
+        cy.visit("?test=layout-repeat-new")
+            .wait(50)
+            .get("#add")
+            .trigger("click")
+            .wait(50)
+            .get("#box-0")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 50,
+                    left: 0,
+                    width: 160,
+                    height: 100,
+                })
+            })
+            .get("#add")
+            .trigger("click")
+            .wait(50)
+            .get("#box-1")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 50,
+                    left: 0,
+                    width: 160,
+                    height: 100,
+                })
+            })
+            .get("#box-0")
+            .should(([$box]: any) => {
+                const bbox = $box.getBoundingClientRect()
+                expect(bbox.left).not.to.equal(170)
+            })
+            .get("#reset")
+            .trigger("click")
+            .wait(50)
+            .get("#add")
+            .trigger("click")
+            .wait(50)
+            .get("#box-0")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 50,
+                    left: 0,
+                    width: 160,
+                    height: 100,
+                })
+            })
+            .get("#add")
+            .trigger("click")
+            .wait(50)
+            .get("#box-0")
+            .should(([$box]: any) => {
+                const bbox = $box.getBoundingClientRect()
+                expect(bbox.left).not.to.equal(170)
+            })
+    })
 })


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/2129

This PR ensures `isLayoutDirty` is reset even when animations aren't run.