### PR TITLE
Export types

### DIFF
--- a/packages/framer-motion/src/animation/animate.ts
+++ b/packages/framer-motion/src/animation/animate.ts
@@ -4,11 +4,10 @@ import { invariant } from "../utils/errors"
 import { MotionValue } from "../value"
 import { GroupPlaybackControls } from "./GroupPlaybackControls"
 import {
-    AnimationOptionsWithValueOverrides,
     AnimationPlaybackControls,
     AnimationScope,
     DOMKeyframesDefinition,
-    DynamicOption,
+    DynamicAnimationOptions,
     ElementOrSelector,
     ValueAnimationTransition,
 } from "./types"
@@ -20,11 +19,6 @@ import { animateSingleValue } from "./interfaces/single-value"
 import { AnimationSequence, SequenceOptions } from "./sequence/types"
 import { createAnimationsFromSequence } from "./sequence/create"
 import { isMotionValue } from "../value/utils/is-motion-value"
-
-export interface DynamicAnimationOptions
-    extends Omit<AnimationOptionsWithValueOverrides, "delay"> {
-    delay?: number | DynamicOption<number>
-}
 
 function animateElements(
     elementOrSelector: ElementOrSelector,

--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -7,7 +7,7 @@ import { progress } from "../../utils/progress"
 import { secondsToMilliseconds } from "../../utils/time-conversion"
 import type { MotionValue } from "../../value"
 import { isMotionValue } from "../../value/utils/is-motion-value"
-import { DynamicAnimationOptions } from "../animate"
+import { DynamicAnimationOptions } from "../types"
 import {
     AnimationScope,
     DOMKeyframesDefinition,

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -1,6 +1,6 @@
 import { Easing } from "../../easing/types"
 import type { MotionValue } from "../../value"
-import { DynamicAnimationOptions } from "../animate"
+import { DynamicAnimationOptions } from "../types"
 import {
     DOMKeyframesDefinition,
     ElementOrSelector,

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -62,6 +62,11 @@ export type AnimationOptionsWithValueOverrides<V = any> = StyleTransitions &
     VariableTransitions &
     ValueAnimationTransition<V>
 
+export interface DynamicAnimationOptions
+    extends Omit<AnimationOptionsWithValueOverrides, "delay"> {
+    delay?: number | DynamicOption<number>
+}
+
 export type ElementOrSelector =
     | Element
     | Element[]

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -111,7 +111,6 @@ export { SwitchLayoutGroupContext } from "./context/SwitchLayoutGroupContext"
 export { HTMLMotionProps, ForwardRefComponent } from "./render/html/types"
 export { SVGMotionProps, SVGAttributesAsMotionValues } from "./render/svg/types"
 export { AnimationLifecycles } from "./render/types"
-export { AnimationPlaybackControls } from "./animation/types"
 export { CustomDomComponent } from "./render/dom/motion-proxy"
 export { ScrollMotionValues } from "./value/scroll/utils"
 export {

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -161,6 +161,7 @@ export { CreateVisualElement } from "./render/types"
 export * from "./projection/geometry/types"
 export { IProjectionNode } from "./projection/node/types"
 export * from "./animation/types"
+export * from "./animation/sequence/types"
 
 /**
  * Deprecated


### PR DESCRIPTION
Fix #2180 

Also, [the Contributing](https://github.com/framer/motion/blob/main/CONTRIBUTING.md) page has

> If a PR introduces or changes API, it should link to a sister PR on the [API docs repo](https://github.com/framer/api-docs/blob/master/CONTRIBUTING.md).

There is no such repo. 