### PR TITLE
Update changelog for 10.12.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [10.12.18] 2023-06-30
+
+### Fixed
+
+-   When layout animation is forced to be instant via `useInstantTransition`, ignore the delay option.
+
 ## [10.12.17] 2023-06-23
 
 ### Fixed

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion--dev",
-    "version": "10.12.16",
+    "version": "10.12.18-alpha.0",
     "private": true,
     "scripts": {
         "dev": "webpack serve --config ./webpack/config.js --hot"
@@ -8,8 +8,8 @@
     "dependencies": {
         "@react-three/drei": "^7.27.3",
         "@react-three/fiber": "^8.2.2",
-        "framer-motion": "^10.12.16",
-        "framer-motion-3d": "^10.12.16",
+        "framer-motion": "^10.12.18-alpha.0",
+        "framer-motion-3d": "^10.12.18-alpha.0",
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.12.16",
+    "version": "10.12.18-alpha.0",
     "packages": [
         "packages/*"
     ],

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion-3d",
-    "version": "10.12.16",
+    "version": "10.12.18-alpha.0",
     "description": "A simple and powerful React animation library for @react-three/fiber",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",
@@ -46,7 +46,7 @@
         "postpublish": "git push --tags"
     },
     "dependencies": {
-        "framer-motion": "^10.12.16",
+        "framer-motion": "^10.12.18-alpha.0",
         "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "10.12.16",
+    "version": "10.12.18-alpha.0",
     "description": "A simple and powerful React and JavaScript animation library",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7844,8 +7844,8 @@ __metadata:
     cache-loader: ^1.2.5
     convert-tsconfig-paths-to-webpack-aliases: ^0.9.2
     fork-ts-checker-webpack-plugin: ^6.2.0
-    framer-motion: ^10.12.16
-    framer-motion-3d: ^10.12.16
+    framer-motion: ^10.12.18-alpha.0
+    framer-motion-3d: ^10.12.18-alpha.0
     path-browserify: ^1.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -7911,14 +7911,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion-3d@^10.12.16, framer-motion-3d@workspace:packages/framer-motion-3d":
+"framer-motion-3d@^10.12.18-alpha.0, framer-motion-3d@workspace:packages/framer-motion-3d":
   version: 0.0.0-use.local
   resolution: "framer-motion-3d@workspace:packages/framer-motion-3d"
   dependencies:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^10.12.16
+    framer-motion: ^10.12.18-alpha.0
     react-merge-refs: ^2.0.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
@@ -7928,7 +7928,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^10.12.16, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^10.12.18-alpha.0, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:


### PR DESCRIPTION
This PR bumps version to 10.12.18-alpha.0, and updates the changelog in preparation of 10.12.18.