### PR TITLE
Fix initial animation of background

### DIFF
--- a/dev/tests/layout-exit.tsx
+++ b/dev/tests/layout-exit.tsx
@@ -9,6 +9,8 @@ export const App = () => {
         opacity: 0.5,
     }
 
+    React.useEffect(() => setVisible(!visible), [])
+
     return (
         <>
             <AnimatePresence>
@@ -16,7 +18,6 @@ export const App = () => {
                     <motion.div
                         id="box"
                         layout
-                        onTap={() => setVisible(!visible)}
                         style={{ width: 100, height: 100, background: "blue" }}
                         exit={animation}
                     />

--- a/packages/framer-motion/cypress/integration/layout-exit.ts
+++ b/packages/framer-motion/cypress/integration/layout-exit.ts
@@ -2,7 +2,6 @@ describe("Layout exit animations", () => {
     it("Allows the animation to be marked complete", () => {
         cy.visit("?test=layout-exit")
             .get("#box")
-            .trigger("click")
             .wait(500)
             .should(($box: any) => {
                 const box = $box[0] as HTMLDivElement

--- a/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
@@ -744,4 +744,32 @@ describe("animate prop as object", () => {
         const { rerender } = render(<Component />)
         rerender(<Component />)
     })
+
+    test("Correctly animates complex value types on first rerender", async () => {
+        const result = await new Promise<string[]>((resolve) => {
+            const output: string[] = []
+            const Component = () => {
+                return (
+                    <motion.div
+                        animate={{
+                            background:
+                                "linear-gradient(0deg, hsl(216, 100%, 50%) 0%, hsl(301, 100%, 50%) 100%)",
+                        }}
+                        onUpdate={({ background }) =>
+                            output.push(background as string)
+                        }
+                        onAnimationComplete={() => resolve(output)}
+                        style={{
+                            background:
+                                "linear-gradient(180deg, hsl(216, 100%, 50%) 0%, hsl(301, 100%, 50%) 100%)",
+                        }}
+                    />
+                )
+            }
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        return expect(result.length).not.toBe(1)
+    })
 })

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -827,7 +827,7 @@ export abstract class VisualElement<
     readValue(key: string) {
         return this.latestValues[key] !== undefined || !this.current
             ? this.latestValues[key]
-            : this.getBaseTargetFromProps(this.props, key) ||
+            : this.getBaseTargetFromProps(this.props, key) ??
                   this.readValueFromInstance(this.current, key, this.options)
     }
 

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -827,7 +827,8 @@ export abstract class VisualElement<
     readValue(key: string) {
         return this.latestValues[key] !== undefined || !this.current
             ? this.latestValues[key]
-            : this.readValueFromInstance(this.current, key, this.options)
+            : this.getBaseTargetFromProps(this.props, key) ||
+                  this.readValueFromInstance(this.current, key, this.options)
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/framer/company/issues/27789

This makes sure we try to read an initial value from component props before reading from the DOM. These values are more likely to be animatable.