### PR TITLE
Transform newly-read values

### DIFF
--- a/packages/framer-motion/src/render/dom/DOMVisualElement.ts
+++ b/packages/framer-motion/src/render/dom/DOMVisualElement.ts
@@ -54,7 +54,17 @@ export abstract class DOMVisualElement<
         }
 
         if (isMounted) {
-            checkTargetForNewValues(this, target, origin as any)
+            const newValues = checkTargetForNewValues(
+                this,
+                target,
+                origin as any
+            )
+
+            // If new values have been added, for instance named color values, transform these
+            if (transformValues && newValues) {
+                origin = transformValues(origin as any)
+            }
+
             const parsed = parseDomVariant(this, target, origin, transitionEnd)
             transitionEnd = parsed.transitionEnd
             target = parsed.target

--- a/packages/framer-motion/src/render/utils/setters.ts
+++ b/packages/framer-motion/src/render/utils/setters.ts
@@ -91,7 +91,7 @@ export function checkTargetForNewValues(
 
     const numNewValues = newValueKeys.length
 
-    if (!numNewValues) return
+    if (!numNewValues) return false
 
     for (let i = 0; i < numNewValues; i++) {
         const key = newValueKeys[i]
@@ -140,6 +140,8 @@ export function checkTargetForNewValues(
         }
         if (value !== null) visualElement.setBaseTarget(key, value)
     }
+
+    return true
 }
 
 export function getOriginFromTransition(key: string, transition: Transition) {

--- a/packages/framer-motion/src/render/utils/setters.ts
+++ b/packages/framer-motion/src/render/utils/setters.ts
@@ -84,7 +84,7 @@ export function checkTargetForNewValues(
     visualElement: VisualElement,
     target: TargetWithKeyframes,
     origin: ResolvedValues
-) {
+): boolean {
     const newValueKeys = Object.keys(target).filter(
         (key) => !visualElement.hasValue(key)
     )


### PR DESCRIPTION
Values read from the DOM weren't being passed to `transformValues` if this was present.

Now initial values are being fished out of `style` before `getComputedStyle()` values like `"red"` may not correctly be animated in Framer.