### PR TITLE
Fix incorrect Reorder.Item order calculation

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -85,16 +85,15 @@ export function ReorderGroup<V>(
     const context: ReorderContextProps<any> = {
         axis,
         registerItem: (value, layout) => {
-            /**
-             * Ensure entries can't add themselves more than once
-             */
-            if (
-                layout &&
-                order.findIndex((entry) => value === entry.value) === -1
-            ) {
-                order.push({ value, layout: layout[axis] })
-                order.sort(compareMin)
+            if (!layout) return;
+            // If the entry was already added, update it rather than adding it again
+            const idx = order.findIndex((entry) => value === entry.value)
+            if (idx !== -1) {
+                order[idx].layout = layout[axis]
+            } else {
+                order.push({ value: value, layout: layout[axis] })
             }
+            order.sort(compareMin)
         },
         updateOrder: (id, offset, velocity) => {
             if (isReordering.current) return

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -4,12 +4,9 @@ import {
     ReactHTML,
     FunctionComponent,
     useContext,
-    useEffect,
-    useRef,
     forwardRef,
 } from "react"
 import { ReorderContext } from "../../context/ReorderContext"
-import { Box } from "../../projection/geometry/types"
 import { motion } from "../../render/dom/motion"
 import { HTMLMotionProps } from "../../render/html/types"
 import { useConstant } from "../../utils/use-constant"
@@ -71,15 +68,9 @@ export function ReorderItem<V>(
         latestX || latestY ? 1 : "unset"
     )
 
-    const measuredLayout = useRef<Box | null>(null)
-
     invariant(Boolean(context), "Reorder.Item must be a child of Reorder.Group")
 
     const { axis, registerItem, updateOrder } = context!
-
-    useEffect(() => {
-        registerItem(value, measuredLayout.current!)
-    }, [context])
 
     return (
         <Component
@@ -95,9 +86,7 @@ export function ReorderItem<V>(
 
                 onDrag && onDrag(event, gesturePoint)
             }}
-            onLayoutMeasure={(measured) => {
-                measuredLayout.current = measured
-            }}
+            onLayoutMeasure={(measured) => registerItem(value, measured)}
             ref={externalRef}
             ignoreStrict
         >


### PR DESCRIPTION
## Problem

I've been experiencing an issue with `Reorder` lately, where items can become "stuck" while being dragged. It's a little hard to describe in words, but here's a recording of an example from an app I am building:

![Before](https://github.com/framer/motion/assets/5988/b01cb0b8-4206-4c92-a2b5-ca215aa85f2a)

As you can see here, the "Sydney" item is first dragged over "Vancouver", and then "London" without a problem. But when "Vancouver" is then dragged backwards over "London", "Vancouver" also moves, even though the user hasn't moved the cursor that far to the left yet. As the dragging continues, it becomes totally impossible to reorder the items. This is reliably reproducible in my example, but not in more trivial examples, leading to much frustration.

## Cause

The underlying issue is that `Reorder.Group` has an incorrect view of the current order of its items on the page. To determine that order, [relies on the layout measurements it is passed by its child `Reorder.Item`s](https://github.com/framer/motion/blob/10bfeace9183f344b2098ee659dc0c6848f0d705/packages/framer-motion/src/components/Reorder/Group.tsx#L87-L98) via a `registerItem` callback. But [the code in `Reorder.Item` to pass the layout measurements](https://github.com/framer/motion/blob/10bfeace9183f344b2098ee659dc0c6848f0d705/packages/framer-motion/src/components/Reorder/Item.tsx#L74-L100) has a race condition. The intended flow seems to be:

1. Layout measurements are taken and passed to the items' `onLayoutMeasure` handler
2. The handler stores the measurements in a ref
3. An effect reads the measurements from the ref on each render and invokes the `registerItem` callback

But there is a race condition between 1 and 3, and sometimes 3 can execute before 1. I'm not familiar enough with React's internals to understand why the two hooks execute in a non-deterministic order, but they do. And when that happens, stale layout values from the last render are passed to `registerItem` and the `Reorder.Group` gets an incorrect order.

## Solution

Instead of using a ref to temporarily hold the layout information, I'm just invoking `registerItem` directly in the `onLayoutMeasure` callback.

With this patch, the issue disappears and the reordering works as you would expect:

![After](https://github.com/framer/motion/assets/5988/1964ecf3-4fb9-442c-8d9a-9140bdb247c2)


I've also tried this fix with the example in #2101. I can reproduce that issue pretty easily with framer-motion 10.12.21, and it seems fixed with this patch. Perhaps some of the other open Reorder bugs can be attributed to this, too. (Fixes #2101).

## Notes

There aren't any comments in the code to explain why the extra indirection with the ref is necessary, and [the commit that introduced the code](https://github.com/framer/motion/commit/be5c949daf652167ff3f4365135ac6fc42369c02) doesn't contain any helpful description either. Being unsure why that choice was made, I'm left wondering if it was meant to solve a problem I am now overlooking. But, things seem to work just as well as before with my change, and the bug is fixed too.