### PR TITLE
fix inertia: take care of the case when t is zero

### DIFF
--- a/packages/framer-motion/src/animation/generators/__tests__/inertia.test.ts
+++ b/packages/framer-motion/src/animation/generators/__tests__/inertia.test.ts
@@ -2,7 +2,7 @@ import { inertia } from "../inertia"
 import { pregenerateKeyframes } from "./utils"
 
 describe("inertia", () => {
-    test("Runs animations with default values ", () => {
+    test("Runs animations with default values", () => {
         const generator = inertia({
             keyframes: [0],
         })
@@ -21,6 +21,18 @@ describe("inertia", () => {
         const { keyframes, duration } = pregenerateKeyframes(generator)
         expect(duration).toEqual(3)
         expect(keyframes).toEqual(expectedAnimationKeyframes)
+    })
+
+    test("Continues animation when time is 0", () => {
+        const generator = inertia({
+            keyframes: [100],
+            min: 0,
+            max: 0,
+        })
+
+        const state = generator.next(0)
+        expect(state.done).toEqual(false)
+        expect(state.value).toEqual(100)
     })
 
     test("modifyTarget changes calculated target", () => {

--- a/packages/framer-motion/src/animation/generators/inertia.ts
+++ b/packages/framer-motion/src/animation/generators/inertia.ts
@@ -100,7 +100,7 @@ export function inertia({
              * If we have a spring and the provided t is beyond the moment the friction
              * animation crossed the min/max boundary, use the spring.
              */
-            if (timeReachedBoundary !== undefined && t > timeReachedBoundary) {
+            if (timeReachedBoundary !== undefined && (t > timeReachedBoundary || t === 0)) {
                 return spring!.next(t - timeReachedBoundary)
             } else {
                 !hasUpdatedFrame && applyFriction(t)


### PR DESCRIPTION
This PR aims to fix an issue where `Reorder.Item` randomly gets stuck as I posted [here](https://github.com/framer/motion/pull/2231#issuecomment-1655992476).

Related:
* https://github.com/framer/motion/issues/2101
* https://github.com/framer/motion/pull/2231

As noted [here](https://github.com/framer/motion/blob/main/packages/framer-motion/src/animation/animators/js/index.ts#L138-L141):

> requestAnimationFrame timestamps can come through as lower than the startTime

which means that `startTime` possibly can be equal to `currentTime` and `t` is 0 in that case. `inertia` returns the state with `done: true`  in that case, and stops the animation immediately.
