### PR TITLE
`transitionEnd` should not be applied when new animations caused the animation to stop

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
@@ -136,6 +136,33 @@ describe("animate prop as object", () => {
         })
         return expect(promise).resolves.toBe(300)
     })
+    test("uses the latest styles on subsequent renders", async () => {
+        const promise = new Promise((resolve) => {
+            const x = motionValue(0)
+            const Component = ({ animate }: any) => (
+                <motion.div animate={animate} style={{ x }} />
+            )
+            const { rerender } = render(
+                <Component
+                    animate={{
+                        x: 10,
+                        transition: { type: false },
+                        transitionEnd: { x: 100 },
+                    }}
+                />
+            )
+            rerender(
+                <Component
+                    animate={{
+                        x: 20,
+                        transition: { type: false },
+                    }}
+                />
+            )
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+        return expect(promise).resolves.toBe(20)
+    })
     test("animates to set prop and preserves existing initial transform props", async () => {
         const promise = new Promise((resolve) => {
             const onComplete = () => {


### PR DESCRIPTION
This PR aims to fix an issue where `transitionEnd` styles are applied after new animation starts and accidentally overrides the latest motion values.

When new animation starts while animating, `MotionValue` stops the ongoing animation and immediately starts the new one. However as `transitionEnd` waits for all animations to be resolved, some `transitionEnd` styles overrides new values.

It seems to be introduced in https://github.com/framer/motion/pull/2025. Before it lands, calling `stop()` never resolves animation Promises, which are used to apply the `transitionEnd` styles at the end, so there was no race condition..

Closes: https://github.com/chakra-ui/chakra-ui/issues/7775
