### PR TITLE
Replace `requestAnimationFrame` timestamp with `performance.now()`

### DIFF
--- a/dev/optimized-appear/resync-delay.html
+++ b/dev/optimized-appear/resync-delay.html
@@ -41,11 +41,11 @@
             const duration = 0.5
             const x = motionValue(0)
 
-            x.onChange((latest) => {
-                if (latest < 50) {
+            x.on("change", (latest) => {
+                if (latest < 100) {
                     showError(
                         document.getElementById("box"),
-                        `x transform should never be less than 50`
+                        `x transform should never be less than 100`
                     )
                 }
             })

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -32,7 +32,9 @@ export function createRenderBatcher(
 
     const processStep = (stepId: StepId) => steps[stepId].process(state)
 
-    const processBatch = (timestamp: number) => {
+    const processBatch = () => {
+        const timestamp = performance.now()
+
         runNextFrame = false
 
         state.delta = useDefaultElapsed
@@ -54,7 +56,9 @@ export function createRenderBatcher(
         runNextFrame = true
         useDefaultElapsed = true
 
-        if (!state.isProcessing) scheduleNextBatch(processBatch)
+        if (!state.isProcessing) {
+            scheduleNextBatch(processBatch)
+        }
     }
 
     const schedule = stepsOrder.reduce((acc, key) => {


### PR DESCRIPTION
In Chrome, the timestamp provided to `requestAnimationFrame` callbacks is erroneously the time of `rAF` invocation, not the time of the callback's invocation. Instead, we use `performance.now()` to get the actual time.

Avoids https://bugs.chromium.org/p/chromium/issues/detail?id=1470675#makechanges