### PR TITLE
Provide reason when resolving promise returned by animate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [10.16.0] 2023-08-09
+
+- Promise returned by `animate` now resolves with string `finished` or `canceled` indicating if animation was canceled or finished successfully.
+
 ## [10.15.1] 2023-08-07
 
 ### Fixed

--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -1,6 +1,6 @@
 import { observeTimeline } from "../render/dom/scroll/observe"
 import { supportsScrollTimeline } from "../render/dom/scroll/supports"
-import { AnimationPlaybackControls } from "./types"
+import { AnimationPlaybackControls, AnimationPlaybackControlsOnResolve } from "./types"
 
 type PropNames = "time" | "speed" | "duration" | "attachTimeline"
 
@@ -13,8 +13,11 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
         ) as AnimationPlaybackControls[]
     }
 
-    then(onResolve: VoidFunction, onReject?: VoidFunction) {
-        return Promise.all(this.animations).then(onResolve).catch(onReject)
+    then(onResolve: AnimationPlaybackControlsOnResolve, onReject?: VoidFunction) {
+        return Promise.all(this.animations).then((reasons) => {
+            const allCanceled = reasons.every(reason => reason === 'canceled')
+            return onResolve(allCanceled ? 'canceled' : 'finished')
+        }).catch(onReject)
     }
 
     /**

--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -14,9 +14,9 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
     }
 
     then(onResolve: AnimationPlaybackControlsOnResolve, onReject?: VoidFunction) {
-        return Promise.all(this.animations).then((reasons) => {
-            const allCanceled = reasons.every(reason => reason === 'canceled')
-            return onResolve(allCanceled ? 'canceled' : 'finished')
+        return Promise.all(this.animations).then((details) => {
+            const allCanceled = details.every(({ reason }) => reason === 'canceled')
+            return onResolve({ reason: allCanceled ? 'canceled' : 'finished' })
         }).catch(onReject)
     }
 

--- a/packages/framer-motion/src/animation/animators/instant.ts
+++ b/packages/framer-motion/src/animation/animators/instant.ts
@@ -27,7 +27,7 @@ export function createInstantAnimation<V>({
             pause: noop<void>,
             stop: noop<void>,
             then: (resolve: AnimationPlaybackControlsOnResolve) => {
-                resolve('finished')
+                resolve({ reason: 'finished' })
                 return Promise.resolve()
             },
             cancel: noop<void>,

--- a/packages/framer-motion/src/animation/animators/instant.ts
+++ b/packages/framer-motion/src/animation/animators/instant.ts
@@ -1,4 +1,4 @@
-import { AnimationPlaybackControls, ValueAnimationOptions } from "../types"
+import { AnimationPlaybackControls, AnimationPlaybackControlsOnResolve, ValueAnimationOptions } from "../types"
 import { animateValue } from "./js"
 import { noop } from "../../utils/noop"
 
@@ -26,8 +26,8 @@ export function createInstantAnimation<V>({
             play: noop<void>,
             pause: noop<void>,
             stop: noop<void>,
-            then: (resolve: VoidFunction) => {
-                resolve()
+            then: (resolve: AnimationPlaybackControlsOnResolve) => {
+                resolve('finished')
                 return Promise.resolve()
             },
             cancel: noop<void>,

--- a/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
+++ b/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
@@ -1110,7 +1110,7 @@ describe("animate", () => {
             ease: "linear",
         })
 
-        const reason = await animation
+        const { reason } = await animation
         expect(reason).toBe("finished")
     })
 
@@ -1130,7 +1130,7 @@ describe("animate", () => {
             },
         })
 
-        const reason = await animation
+        const { reason } = await animation
 
         expect(output).toEqual([0, 20, 40])
         expect(reason).toBe("canceled")

--- a/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
+++ b/packages/framer-motion/src/animation/animators/js/__tests__/animate.test.ts
@@ -1103,6 +1103,17 @@ describe("animate", () => {
         })
     })
 
+    test(".then() provides correct reason to callback when animation finished", async () => {
+        const animation = animateValue({
+            keyframes: [0, 100],
+            duration: 100,
+            ease: "linear",
+        })
+
+        const reason = await animation
+        expect(reason).toBe("finished")
+    })
+
     test("Correctly resolves when stopped", async () => {
         const output: number[] = []
 
@@ -1119,9 +1130,10 @@ describe("animate", () => {
             },
         })
 
-        await animation
+        const reason = await animation
 
         expect(output).toEqual([0, 20, 40])
+        expect(reason).toBe("canceled")
     })
 
     test("Correctly cancels an animation", async () => {

--- a/packages/framer-motion/src/animation/animators/js/index.ts
+++ b/packages/framer-motion/src/animation/animators/js/index.ts
@@ -1,4 +1,4 @@
-import { AnimationPlaybackControls, AnimationPlaybackControlsOnResolve, AnimationPlaybackControlsResolveReason } from "../../types"
+import { AnimationPlaybackControls, AnimationPlaybackControlsOnResolve, AnimationPlaybackControlsResolveDetails } from "../../types"
 import { keyframes as keyframesGeneratorFactory } from "../../generators/keyframes"
 import { spring } from "../../generators/spring/index"
 import { inertia } from "../../generators/inertia"
@@ -57,14 +57,14 @@ export function animateValue<V = number>({
 
     let hasStopped = false
     let resolveFinishedPromise: AnimationPlaybackControlsOnResolve
-    let currentFinishedPromise: Promise<AnimationPlaybackControlsResolveReason>
+    let currentFinishedPromise: Promise<AnimationPlaybackControlsResolveDetails>
 
     /**
      * Resolve the current Promise every time we enter the
      * finished state. This is WAAPI-compatible behaviour.
      */
     const updateFinishedPromise = () => {
-        currentFinishedPromise = new Promise<AnimationPlaybackControlsResolveReason>((resolve) => {
+        currentFinishedPromise = new Promise<AnimationPlaybackControlsResolveDetails>((resolve) => {
             resolveFinishedPromise = resolve
         })
     }
@@ -270,7 +270,7 @@ export function animateValue<V = number>({
     const cancel = () => {
         playState = "idle"
         stopAnimationDriver()
-        resolveFinishedPromise('canceled')
+        resolveFinishedPromise({ reason: 'canceled' })
         updateFinishedPromise()
         startTime = cancelTime = null
     }
@@ -279,7 +279,7 @@ export function animateValue<V = number>({
         playState = "finished"
         onComplete && onComplete()
         stopAnimationDriver()
-        resolveFinishedPromise('finished')
+        resolveFinishedPromise({ reason: 'finished' })
     }
 
     const play = () => {

--- a/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/create-accelerated-animation.ts
@@ -2,7 +2,7 @@ import { EasingDefinition } from "../../../easing/types"
 import { frame, cancelFrame } from "../../../frameloop"
 import type { VisualElement } from "../../../render/VisualElement"
 import type { MotionValue } from "../../../value"
-import { AnimationPlaybackControls, AnimationPlaybackControlsOnResolve, AnimationPlaybackControlsResolveReason, ValueAnimationOptions } from "../../types"
+import { AnimationPlaybackControls, AnimationPlaybackControlsOnResolve, AnimationPlaybackControlsResolveDetails, ValueAnimationOptions } from "../../types"
 import { animateStyle } from "."
 import { isWaapiSupportedEasing } from "./easing"
 import { getFinalKeyframe } from "./utils/get-final-keyframe"
@@ -70,14 +70,14 @@ export function createAcceleratedAnimation(
      */
     let hasStopped = false
     let resolveFinishedPromise: AnimationPlaybackControlsOnResolve
-    let currentFinishedPromise: Promise<AnimationPlaybackControlsResolveReason>
+    let currentFinishedPromise: Promise<AnimationPlaybackControlsResolveDetails>
 
     /**
      * Resolve the current Promise every time we enter the
      * finished state. This is WAAPI-compatible behaviour.
      */
     const updateFinishedPromise = () => {
-        currentFinishedPromise = new Promise<AnimationPlaybackControlsResolveReason>((resolve) => {
+        currentFinishedPromise = new Promise<AnimationPlaybackControlsResolveDetails>((resolve) => {
             resolveFinishedPromise = resolve
         })
     }
@@ -140,7 +140,7 @@ export function createAcceleratedAnimation(
 
     const safeCancel = () => {
         frame.update(cancelAnimation)
-        resolveFinishedPromise('canceled')
+        resolveFinishedPromise({ reason: 'canceled' })
         updateFinishedPromise()
     }
 

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -78,7 +78,11 @@ export type ElementOrSelector =
 
 export type AnimationPlaybackControlsResolveReason = "finished" | "canceled"
 
-export type AnimationPlaybackControlsOnResolve = (reason: AnimationPlaybackControlsResolveReason) => void
+export interface AnimationPlaybackControlsResolveDetails {
+    reason: AnimationPlaybackControlsResolveReason
+}
+
+export type AnimationPlaybackControlsOnResolve = (details: AnimationPlaybackControlsResolveDetails) => void
 
 /**
  * @public

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -74,6 +74,12 @@ export type ElementOrSelector =
     | NodeListOf<Element>
     | string
 
+
+
+export type AnimationPlaybackControlsResolveReason = "finished" | "canceled"
+
+export type AnimationPlaybackControlsOnResolve = (reason: AnimationPlaybackControlsResolveReason) => void
+
 /**
  * @public
  */
@@ -93,7 +99,7 @@ export interface AnimationPlaybackControls {
     pause: () => void
     complete: () => void
     cancel: () => void
-    then: (onResolve: VoidFunction, onReject?: VoidFunction) => Promise<void>
+    then: (onResolve: AnimationPlaybackControlsOnResolve, onReject?: VoidFunction) => Promise<void>
     attachTimeline?: (timeline: ProgressTimeline) => VoidFunction
 }
 


### PR DESCRIPTION
Promise returned by animate is resolved in both cases when animation finished and when it was cancelled. This makes it harder to build complex timelines (which include not only animations but also state updates for example). This PR modifies the code so details object with field `reason` will be returned to indicate if animation was cancelled or finished successfully. 

I added tests for this, but unfortunately couldn't check this change in wild, dev server from `dev` folder spits a bunch of TS errors and doesn't seem to be functional. 

I also wanted to update docs, but couldn't find them in this repo nor in framer org on GitHub. Please let me know if this PR requires any changes or if there is any way I can help this feature land in framer-motion :) 