### PR TITLE
Batch SVG read/writes

### DIFF
--- a/dev/examples/SVG-transform.tsx
+++ b/dev/examples/SVG-transform.tsx
@@ -1,10 +1,6 @@
 import * as React from "react"
 import { motion } from "framer-motion"
 
-/**
- * An example of providing a MotionValue to an SVG component via its props
- */
-
 export const App = () => {
     return (
         <svg

--- a/dev/examples/SVG-transform.tsx
+++ b/dev/examples/SVG-transform.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { motion } from "framer-motion"
+
+/**
+ * An example of providing a MotionValue to an SVG component via its props
+ */
+
+export const App = () => {
+    return (
+        <svg
+            width="250"
+            height="250"
+            viewBox="0 0 250 250"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <motion.rect
+                x={50}
+                y={50}
+                width={100}
+                height={100}
+                transition={{ duration: 3 }}
+                style={{ rotate: 45 }}
+            />
+            <motion.rect
+                x={0}
+                y={0}
+                width={100}
+                height={100}
+                transition={{ duration: 3 }}
+                style={{ rotate: 45 }}
+            />
+            <motion.rect
+                x={100}
+                y={100}
+                width={100}
+                height={100}
+                transition={{ duration: 3 }}
+                style={{ rotate: 45 }}
+            />
+        </svg>
+    )
+}


### PR DESCRIPTION
SVG `transform-origin` is always relative to the parent `svg` element rather than the SVG element itself. To normalise this between HTML and SVG we measure the SVG on mount. This PR batches reads and writes of this process to reduce layout thrashing.