### PR TITLE
Improve performance of handoff animations

### DIFF
--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -9,7 +9,6 @@ import { VisualState } from "./use-visual-state"
 import { LazyContext } from "../../context/LazyContext"
 import { MotionConfigContext } from "../../context/MotionConfigContext"
 import type { VisualElement } from "../../render/VisualElement"
-import { useConstant } from "../../utils/use-constant"
 
 export function useVisualElement<Instance, RenderState>(
     Component: string | React.ComponentType<React.PropsWithChildren<unknown>>,

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -9,6 +9,7 @@ import { VisualState } from "./use-visual-state"
 import { LazyContext } from "../../context/LazyContext"
 import { MotionConfigContext } from "../../context/MotionConfigContext"
 import type { VisualElement } from "../../render/VisualElement"
+import { useConstant } from "../../utils/use-constant"
 
 export function useVisualElement<Instance, RenderState>(
     Component: string | React.ComponentType<React.PropsWithChildren<unknown>>,
@@ -47,31 +48,48 @@ export function useVisualElement<Instance, RenderState>(
         visualElement && visualElement.update(props, presenceContext)
     })
 
+    /**
+     * Cache this value as we want to know whether HandoffAppearAnimations
+     * was present on initial render - it will be deleted after this.
+     */
+    const canHandoff = useRef(Boolean(window.HandoffAppearAnimations))
+
     useIsomorphicLayoutEffect(() => {
-        visualElement && visualElement.render()
+        if (!visualElement) return
+
+        visualElement.render()
+
+        /**
+         * Ideally this function would always run in a useEffect.
+         *
+         * However, if we have optimised appear animations to handoff from,
+         * it needs to happen synchronously to ensure there's no flash of
+         * incorrect styles in the event of a hydration error.
+         *
+         * So if we detect a situtation where optimised appear animations
+         * are running, we use useLayoutEffect to trigger animations.
+         */
+        if (canHandoff.current && visualElement.animationState) {
+            visualElement.animationState.animateChanges()
+        }
     })
 
     useEffect(() => {
-        visualElement && visualElement.updateFeatures()
-    })
+        if (!visualElement) return
 
-    /**
-     * Ideally this function would always run in a useEffect.
-     *
-     * However, if we have optimised appear animations to handoff from,
-     * it needs to happen synchronously to ensure there's no flash of
-     * incorrect styles in the event of a hydration error.
-     *
-     * So if we detect a situtation where optimised appear animations
-     * are running, we use useLayoutEffect to trigger animations.
-     */
-    const useAnimateChangesEffect = window.HandoffAppearAnimations
-        ? useIsomorphicLayoutEffect
-        : useEffect
-    useAnimateChangesEffect(() => {
-        if (visualElement && visualElement.animationState) {
+        visualElement.updateFeatures()
+
+        if (!canHandoff.current && visualElement.animationState) {
             visualElement.animationState.animateChanges()
         }
+
+        /**
+         * Once we've handed off animations we can delete HandoffAppearAnimations
+         * so components added after the initial render can animate changes
+         * in useEffect vs useLayoutEffect.
+         */
+        window.HandoffAppearAnimations = undefined
+        canHandoff.current = false
     })
 
     return visualElement


### PR DESCRIPTION
This PR changes the behaviour of which effect triggers `animateChanges`.

Before, if `window.HandoffAnimations` was present, all animations would be triggered from `useLayoutEffect`.

Now, only components that are present for the page's initial render will trigger animations from `useLayoutEffect`, and only for their initial render. 