### PR TITLE
Fix incorrect Reorder.Item order calculation (Part 2) 

### DIFF
--- a/packages/framer-motion/cypress/integration/drag-to-reorder.ts
+++ b/packages/framer-motion/cypress/integration/drag-to-reorder.ts
@@ -157,4 +157,44 @@ describe("Drag to reorder", () => {
                 })
             })
     })
+
+    it("Move around", () => {
+        const checkBox = (chain: Cypress.Chainable) => {
+            return chain.should(([$item]: any) => {
+                expectBbox($item, {
+                    height: 68,
+                    left: 350,
+                    top: 174,
+                    width: 340,
+                })
+            })
+        }
+
+        const moveAround = (chain: Cypress.Chainable, steps: number[]) => {
+            const baseY = 175
+            const delta = 20
+            chain = chain
+                .trigger("pointerdown", 360, baseY, { force: true })
+                .wait(50)
+            steps.forEach(step => {
+                Array.from({length: Math.abs(step)}).forEach(() => {
+                    const y = step > 0 ? delta : -delta
+                    chain = chain
+                        .trigger("pointermove", 360, baseY + y, { force: true })
+                        .wait(50)
+                })
+            })
+            return chain
+                .trigger("pointerup", 360, baseY, { force: true })
+                .wait(100)
+        }
+
+        const chain = checkBox(
+            cy.visit("?test=drag-to-reorder")
+                .wait(50)
+                .get("#Tomato")
+        )
+
+        checkBox(moveAround(chain, [-4, 14, -8, 4, -5, 2, -6]))
+    })
 })

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -85,7 +85,6 @@ export function ReorderGroup<V>(
     const context: ReorderContextProps<any> = {
         axis,
         registerItem: (value, layout) => {
-            if (!layout) return;
             // If the entry was already added, update it rather than adding it again
             const idx = order.findIndex((entry) => value === entry.value)
             if (idx !== -1) {

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -85,16 +85,15 @@ export function ReorderGroup<V>(
     const context: ReorderContextProps<any> = {
         axis,
         registerItem: (value, layout) => {
-            /**
-             * Ensure entries can't add themselves more than once
-             */
-            if (
-                layout &&
-                order.findIndex((entry) => value === entry.value) === -1
-            ) {
-                order.push({ value, layout: layout[axis] })
-                order.sort(compareMin)
+            if (!layout) return;
+            // If the entry was already added, update it rather than adding it again
+            const idx = order.findIndex((entry) => value === entry.value)
+            if (idx !== -1) {
+                order[idx].layout = layout[axis]
+            } else {
+                order.push({ value: value, layout: layout[axis] })
             }
+            order.sort(compareMin)
         },
         updateOrder: (id, offset, velocity) => {
             if (isReordering.current) return

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -4,12 +4,9 @@ import {
     ReactHTML,
     FunctionComponent,
     useContext,
-    useEffect,
-    useRef,
     forwardRef,
 } from "react"
 import { ReorderContext } from "../../context/ReorderContext"
-import { Box } from "../../projection/geometry/types"
 import { motion } from "../../render/dom/motion"
 import { HTMLMotionProps } from "../../render/html/types"
 import { useConstant } from "../../utils/use-constant"
@@ -71,15 +68,9 @@ export function ReorderItem<V>(
         latestX || latestY ? 1 : "unset"
     )
 
-    const measuredLayout = useRef<Box | null>(null)
-
     invariant(Boolean(context), "Reorder.Item must be a child of Reorder.Group")
 
     const { axis, registerItem, updateOrder } = context!
-
-    useEffect(() => {
-        registerItem(value, measuredLayout.current!)
-    }, [context])
 
     return (
         <Component
@@ -95,9 +86,7 @@ export function ReorderItem<V>(
 
                 onDrag && onDrag(event, gesturePoint)
             }}
-            onLayoutMeasure={(measured) => {
-                measuredLayout.current = measured
-            }}
+            onLayoutMeasure={(measured) => registerItem(value, measured)}
             ref={externalRef}
             ignoreStrict
         >


### PR DESCRIPTION
This PR aims to complete @obeattie's PR [here](https://github.com/framer/motion/pull/2231) by adding two more commits:

1. https://github.com/framer/motion/pull/2359/commits/cae864c621a6739f017c03ff42921e99cab7af27 Get rid of a null check that should be no longer necessary
2. https://github.com/framer/motion/pull/2359/commits/ce65afbe52a5d30f299853546b22d122c3a2571a Add a cypress test that is mostly reproducible.

#### Note:
Regarding the cypress test, unfortunately to reproduce this on ARM64 macOS (I am on M2), I needed to upgrade cypress to the latest to run the test on ARM64 native browsers - otherwise test passes on the main because of the poor browser performance on Rosetta 2, however I did not include that change here to keep this PR minimum.