### PR TITLE
fix: CI - Update yarn.lock to match lerna.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7844,8 +7844,8 @@ __metadata:
     cache-loader: ^1.2.5
     convert-tsconfig-paths-to-webpack-aliases: ^0.9.2
     fork-ts-checker-webpack-plugin: ^6.2.0
-    framer-motion: ^10.16.3
-    framer-motion-3d: ^10.16.3
+    framer-motion: ^10.16.4
+    framer-motion-3d: ^10.16.4
     path-browserify: ^1.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -7911,14 +7911,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion-3d@^10.16.3, framer-motion-3d@workspace:packages/framer-motion-3d":
+"framer-motion-3d@^10.16.4, framer-motion-3d@workspace:packages/framer-motion-3d":
   version: 0.0.0-use.local
   resolution: "framer-motion-3d@workspace:packages/framer-motion-3d"
   dependencies:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^10.16.3
+    framer-motion: ^10.16.4
     react-merge-refs: ^2.0.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
@@ -7928,7 +7928,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^10.16.3, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^10.16.4, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:


### PR DESCRIPTION
This PR should fix the following CI pipeline error:
```
 -"framer-motion@^10.16.3, framer-motion@workspace:packages/framer-motion":
➤ YN0028: │ +"framer-motion@^10.16.4, framer-motion@workspace:packages/framer-motion":
➤ YN0000: │    version: 0.0.0-use.local
➤ YN0000: │    resolution: "framer-motion@workspace:packages/framer-motion"
➤ YN0000: │    dependencies:
➤ YN0000: │      "@emotion/is-prop-valid": ^0.8.2
➤ YN0000: │ 
➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```