### PR TITLE
fix: add generic type to onReorder newOrder value

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -30,15 +30,13 @@ export interface Props<V> {
      */
     axis?: "x" | "y"
 
-    // TODO: This would be better typed as V, but that doesn't seem
-    // to correctly infer type from values
     /**
      * A callback to fire with the new value order. For instance, if the values
      * are provided as a state from `useState`, this could be the set state function.
      *
      * @public
      */
-    onReorder: (newOrder: any[]) => void
+    onReorder: (newOrder: V[]) => void
 
     /**
      * The latest values state.
@@ -82,7 +80,7 @@ export function ReorderGroup<V>(
 
     invariant(Boolean(values), "Reorder.Group must be provided a values prop")
 
-    const context: ReorderContextProps<any> = {
+    const context: ReorderContextProps<V> = {
         axis,
         registerItem: (value, layout) => {
             /**
@@ -96,10 +94,10 @@ export function ReorderGroup<V>(
                 order.sort(compareMin)
             }
         },
-        updateOrder: (id, offset, velocity) => {
+        updateOrder: (item, offset, velocity) => {
             if (isReordering.current) return
 
-            const newOrder = checkReorder(order, id, offset, velocity)
+            const newOrder = checkReorder(order, item, offset, velocity)
 
             if (order !== newOrder) {
                 isReordering.current = true

--- a/packages/framer-motion/src/components/Reorder/types.ts
+++ b/packages/framer-motion/src/components/Reorder/types.ts
@@ -2,8 +2,8 @@ import { Axis, Box } from "../../projection/geometry/types"
 
 export interface ReorderContextProps<T> {
     axis: "x" | "y"
-    registerItem: (id: T, layout: Box) => void
-    updateOrder: (id: T, offset: number, velocity: number) => void
+    registerItem: (item: T, layout: Box) => void
+    updateOrder: (item: T, offset: number, velocity: number) => void
 }
 
 export interface ItemData<T> {


### PR DESCRIPTION
Added a generic for the newOrder array to match the actual given values their types. This didn't work before (would be typed as unknown[]) since the context was not typed properly (poorly typed with any). Also renamed the id prop to item since it doesn't hold an id but the actual item data instead.