### PR TITLE
fix: correctly type reorder components

### DIFF
--- a/dev/tests/drag-tabs.tsx
+++ b/dev/tests/drag-tabs.tsx
@@ -1,6 +1,7 @@
 import {
     motion,
-    Reorder,
+    ReorderGroup,
+    ReorderItem,
     AnimatePresence,
     MotionConfig,
     LayoutGroup,
@@ -45,7 +46,7 @@ export function App() {
             <div className="window">
                 <nav>
                     <LayoutGroup>
-                        <Reorder.Group
+                        <ReorderGroup
                             as="ul"
                             axis="x"
                             onReorder={setTabs}
@@ -63,7 +64,7 @@ export function App() {
                                     />
                                 ))}
                             </AnimatePresence>
-                        </Reorder.Group>
+                        </ReorderGroup>
                         <motion.button
                             className="add-item"
                             onClick={add}
@@ -105,7 +106,7 @@ interface Props {
 
 export const Item = ({ item, onClick, onRemove, isSelected }: Props) => {
     return (
-        <Reorder.Item
+        <ReorderItem
             value={item}
             id={item.label + "-tab"}
             initial={{ opacity: 0, y: 30, transition: { duration: 0.15 } }}
@@ -140,7 +141,7 @@ export const Item = ({ item, onClick, onRemove, isSelected }: Props) => {
                     <CloseIcon />
                 </motion.button>
             </motion.div>
-        </Reorder.Item>
+        </ReorderItem>
     )
 }
 

--- a/dev/tests/drag-to-reorder.tsx
+++ b/dev/tests/drag-to-reorder.tsx
@@ -1,6 +1,11 @@
 import * as React from "react"
 import { useEffect, useState } from "react"
-import { Reorder, useMotionValue, animate } from "framer-motion"
+import {
+    ReorderGroup,
+    ReorderItem,
+    useMotionValue,
+    animate,
+} from "framer-motion"
 
 const inactiveShadow = "0px 0px 0px rgba(0,0,0,0.8)"
 
@@ -30,7 +35,7 @@ const Item = ({ item, axis }) => {
     }, [y, boxShadow])
 
     return (
-        <Reorder.Item
+        <ReorderItem
             value={item}
             id={item}
             drag
@@ -44,7 +49,7 @@ const Item = ({ item, axis }) => {
             <ReorderIcon
             // dragControls={dragControls}
             />
-        </Reorder.Item>
+        </ReorderItem>
     )
 }
 
@@ -54,7 +59,7 @@ export const App = () => {
     const axis = params.get("axis") || "y"
 
     return (
-        <Reorder.Group
+        <ReorderGroup
             axis={axis}
             onReorder={setItems}
             style={axis === "y" ? verticalList : horizontalList}
@@ -64,7 +69,7 @@ export const App = () => {
                 <Item axis={axis} key={item} item={item} />
             ))}
             <style>{styles}</style>
-        </Reorder.Group>
+        </ReorderGroup>
     )
 }
 

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -23,6 +23,13 @@ export interface Props<V> {
     as?: keyof ReactHTML
 
     /**
+     * A ref that gets passed to the group component.
+     *
+     * @public
+     */
+    ref?: React.RefObject<HTMLElement>
+
+    /**
      * The axis to reorder along. By default, items will be draggable on this axis.
      * To make draggable on both axes, set `<Reorder.Item drag />`
      *

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -31,7 +31,7 @@ export interface Props<V> {
 
     /**
      * The axis to reorder along. By default, items will be draggable on this axis.
-     * To make draggable on both axes, set `<Reorder.Item drag />`
+     * To make draggable on both axes, set `<ReorderItem drag />`
      *
      * @public
      */
@@ -53,9 +53,9 @@ export interface Props<V> {
      *   const [items, setItems] = useState([0, 1, 2])
      *
      *   return (
-     *     <Reorder.Group values={items} onReorder={setItems}>
-     *         {items.map((item) => <Reorder.Item key={item} value={item} />)}
-     *     </Reorder.Group>
+     *     <ReorderGroup values={items} onReorder={setItems}>
+     *         {items.map((item) => <ReorderItem key={item} value={item} />)}
+     *     </ReorderGroup>
      *   )
      * }
      * ```
@@ -85,7 +85,7 @@ export function ReorderGroup<V>(
     const order: ItemData<V>[] = []
     const isReordering = useRef(false)
 
-    invariant(Boolean(values), "Reorder.Group must be provided a values prop")
+    invariant(Boolean(values), "ReorderGroup must be provided a values prop")
 
     const context: ReorderContextProps<V> = {
         axis,

--- a/packages/framer-motion/src/components/Reorder/Group.tsx
+++ b/packages/framer-motion/src/components/Reorder/Group.tsx
@@ -30,15 +30,13 @@ export interface Props<V> {
      */
     axis?: "x" | "y"
 
-    // TODO: This would be better typed as V, but that doesn't seem
-    // to correctly infer type from values
     /**
      * A callback to fire with the new value order. For instance, if the values
      * are provided as a state from `useState`, this could be the set state function.
      *
      * @public
      */
-    onReorder: (newOrder: any[]) => void
+    onReorder: (newOrder: V[]) => void
 
     /**
      * The latest values state.
@@ -82,7 +80,7 @@ export function ReorderGroup<V>(
 
     invariant(Boolean(values), "Reorder.Group must be provided a values prop")
 
-    const context: ReorderContextProps<any> = {
+    const context: ReorderContextProps<V> = {
         axis,
         registerItem: (value, layout) => {
             /**
@@ -96,10 +94,10 @@ export function ReorderGroup<V>(
                 order.sort(compareMin)
             }
         },
-        updateOrder: (id, offset, velocity) => {
+        updateOrder: (item, offset, velocity) => {
             if (isReordering.current) return
 
-            const newOrder = checkReorder(order, id, offset, velocity)
+            const newOrder = checkReorder(order, item, offset, velocity)
 
             if (order !== newOrder) {
                 isReordering.current = true

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -80,7 +80,7 @@ export function ReorderItem<V>(
 
     const measuredLayout = useRef<Box | null>(null)
 
-    invariant(Boolean(context), "Reorder.Item must be a child of Reorder.Group")
+    invariant(Boolean(context), "ReorderItem must be a child of ReorderGroup")
 
     const { axis, registerItem, updateOrder } = context!
 

--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -26,6 +26,13 @@ export interface Props<V> {
     as?: keyof ReactHTML
 
     /**
+     * A ref that gets passed to the item component.
+     *
+     * @public
+     */
+    ref?: React.RefObject<HTMLElement>
+
+    /**
      * The value in the list that this component represents.
      *
      * @public

--- a/packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "../../../../jest.setup"
 import * as React from "react"
 import { useRef, useLayoutEffect } from "react"
-import { Reorder } from ".."
+import { ReorderGroup, ReorderItem } from ".."
 
 describe("Reorder", () => {
     it("Correctly hydrates ref", () => {
@@ -23,14 +23,14 @@ describe("Reorder", () => {
             })
 
             return (
-                <Reorder.Group
+                <ReorderGroup
                     as="article"
                     ref={groupRef}
                     onReorder={() => {}}
                     values={[]}
                 >
-                    <Reorder.Item as="main" ref={itemRef} value={0} />
-                </Reorder.Group>
+                    <ReorderItem as="main" ref={itemRef} value={0} />
+                </ReorderGroup>
             )
         }
 

--- a/packages/framer-motion/src/components/Reorder/__tests__/server.ssr.test.tsx
+++ b/packages/framer-motion/src/components/Reorder/__tests__/server.ssr.test.tsx
@@ -1,14 +1,14 @@
 import * as React from "react"
 import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { useState } from "react"
-import { Reorder } from ".."
+import { ReorderGroup, ReorderItem } from ".."
 
 describe("Reorder", () => {
     it("Correctly renders HTML", () => {
         const Component = () => (
-            <Reorder.Group as="article" onReorder={() => {}} values={[]}>
-                <Reorder.Item as="main" value={0} />
-            </Reorder.Group>
+            <ReorderGroup as="article" onReorder={() => {}} values={[]}>
+                <ReorderItem as="main" value={0} />
+            </ReorderGroup>
         )
 
         const staticMarkup = renderToStaticMarkup(<Component />)
@@ -24,9 +24,9 @@ describe("Reorder", () => {
         const Component = () => {
             const [_items, setItems] = useState(["a"])
             return (
-                <Reorder.Group as="article" onReorder={setItems} values={[]}>
-                    <Reorder.Item as="main" value={0} />
-                </Reorder.Group>
+                <ReorderGroup as="article" onReorder={setItems} values={[]}>
+                    <ReorderItem as="main" value={0} />
+                </ReorderGroup>
             )
         }
 

--- a/packages/framer-motion/src/components/Reorder/index.tsx
+++ b/packages/framer-motion/src/components/Reorder/index.tsx
@@ -1,7 +1,2 @@
-import { Group } from "./Group"
-import { Item } from "./Item"
-
-export const Reorder = {
-    Group,
-    Item,
-}
+export { ReorderGroup } from "./Group"
+export { ReorderItem } from "./Item"

--- a/packages/framer-motion/src/components/Reorder/index.tsx
+++ b/packages/framer-motion/src/components/Reorder/index.tsx
@@ -1,2 +1,12 @@
-export { ReorderGroup } from "./Group"
-export { ReorderItem } from "./Item"
+import { ReorderGroup } from "./Group"
+import { ReorderItem } from "./Item"
+
+/**
+ * @deprecated use `ReorderGroup` and `ReorderItem` components instead.
+ */
+const Reorder = {
+    Group: ReorderGroup,
+    Item: ReorderItem,
+}
+
+export { Reorder, ReorderGroup, ReorderItem }

--- a/packages/framer-motion/src/components/Reorder/types.ts
+++ b/packages/framer-motion/src/components/Reorder/types.ts
@@ -2,8 +2,8 @@ import { Axis, Box } from "../../projection/geometry/types"
 
 export interface ReorderContextProps<T> {
     axis: "x" | "y"
-    registerItem: (id: T, layout: Box) => void
-    updateOrder: (id: T, offset: number, velocity: number) => void
+    registerItem: (item: T, layout: Box) => void
+    updateOrder: (item: T, offset: number, velocity: number) => void
 }
 
 export interface ItemData<T> {

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -9,7 +9,7 @@ export { AnimatePresence } from "./components/AnimatePresence"
 export { MotionConfig } from "./components/MotionConfig"
 export { LazyMotion } from "./components/LazyMotion"
 export { LayoutGroup } from "./components/LayoutGroup"
-export { Reorder } from "./components/Reorder"
+export { ReorderGroup, ReorderItem } from "./components/Reorder"
 
 export * from "./dom-entry"
 export * from "./three-entry"

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -9,7 +9,7 @@ export { AnimatePresence } from "./components/AnimatePresence"
 export { MotionConfig } from "./components/MotionConfig"
 export { LazyMotion } from "./components/LazyMotion"
 export { LayoutGroup } from "./components/LayoutGroup"
-export { ReorderGroup, ReorderItem } from "./components/Reorder"
+export { Reorder, ReorderGroup, ReorderItem } from "./components/Reorder"
 
 export * from "./dom-entry"
 export * from "./three-entry"

--- a/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
@@ -3,7 +3,7 @@ import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { motion, useMotionValue } from "../../"
 import { motionValue } from "../../value"
 import { AnimatePresence } from "../../components/AnimatePresence"
-import { Reorder } from "../../components/Reorder"
+import { ReorderGroup, ReorderItem } from "../../components/Reorder"
 
 function runTests(render: (components: any) => string) {
     test("doesn't throw", () => {
@@ -150,9 +150,9 @@ function runTests(render: (components: any) => string) {
         function Component() {
             const [state, setState] = React.useState([0])
             return (
-                <Reorder.Group onReorder={setState} values={state}>
-                    <Reorder.Item value="a" />
-                </Reorder.Group>
+                <ReorderGroup onReorder={setState} values={state}>
+                    <ReorderItem value="a" />
+                </ReorderGroup>
             )
         }
         const div = render(<Component />)
@@ -166,9 +166,9 @@ function runTests(render: (components: any) => string) {
         function Component() {
             const [state, setState] = React.useState([0])
             return (
-                <Reorder.Group onReorder={setState} values={state}>
-                    <Reorder.Item value="a" dragListener={false} />
-                </Reorder.Group>
+                <ReorderGroup onReorder={setState} values={state}>
+                    <ReorderItem value="a" dragListener={false} />
+                </ReorderGroup>
             )
         }
         const div = render(<Component />)
@@ -182,9 +182,9 @@ function runTests(render: (components: any) => string) {
         function Component() {
             const [state, setState] = React.useState([0])
             return (
-                <Reorder.Group as="div" onReorder={setState} values={state}>
-                    <Reorder.Item as="div" value="a" />
-                </Reorder.Group>
+                <ReorderGroup as="div" onReorder={setState} values={state}>
+                    <ReorderItem as="div" value="a" />
+                </ReorderGroup>
             )
         }
         const div = render(<Component />)


### PR DESCRIPTION
The typing of both reorder components was incorrect. Both were using generics, however they would always get inferred as unknown. This was happening because both components were getting exported in the following way (causing the generics to 'get lost'):
```javascript
export const Reorder = {
  Group,
  Item,
}
```
I've also used the generic to type the `onReorder` callback correctly (this was the main reason for me to pick up this issue).

Please note that this does require users that update their version to rename their Reorder imports etc. The docs should also get updated when this gets merged.