### PR TITLE
fix: correctly type reorder group and item generics

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -45,6 +45,10 @@ function useDefaultMotionValue(value: any, defaultValue: number = 0) {
     return isMotionValue(value) ? value : useMotionValue(defaultValue)
 }
 
+type ReorderItemProps<V> = Props<V> &
+    HTMLMotionProps<any> &
+    React.PropsWithChildren<{}>
+
 export function ReorderItem<V>(
     {
         children,
@@ -54,8 +58,8 @@ export function ReorderItem<V>(
         onDrag,
         layout = true,
         ...props
-    }: Props<V> & HTMLMotionProps<any> & React.PropsWithChildren<{}>,
-    externalRef?: React.Ref<any>
+    }: ReorderItemProps<V>,
+    externalRef?: React.ForwardedRef<any>
 ) {
     const Component = useConstant(() => motion(as)) as FunctionComponent<
         React.PropsWithChildren<HTMLMotionProps<any> & { ref?: React.Ref<any> }>
@@ -106,4 +110,6 @@ export function ReorderItem<V>(
     )
 }
 
-export const Item = forwardRef(ReorderItem)
+export const Item = forwardRef(ReorderItem) as <V>(
+    props: ReorderItemProps<V> & { ref?: React.ForwardedRef<any> }
+) => ReturnType<typeof ReorderItem>

--- a/packages/framer-motion/src/components/Reorder/types.ts
+++ b/packages/framer-motion/src/components/Reorder/types.ts
@@ -2,8 +2,8 @@ import { Axis, Box } from "../../projection/geometry/types"
 
 export interface ReorderContextProps<T> {
     axis: "x" | "y"
-    registerItem: (id: T, layout: Box) => void
-    updateOrder: (id: T, offset: number, velocity: number) => void
+    registerItem: (item: T, layout: Box) => void
+    updateOrder: (item: T, offset: number, velocity: number) => void
 }
 
 export interface ItemData<T> {


### PR DESCRIPTION
The use of `forwardRef` caused the generic of the `Reorder.Group` and `Reorder.Item` components to always get inferred as unknown. Explicitly typing it like this solves that issue.