### PR TITLE
Ensure optimised animations don't run after hydration

### DIFF
--- a/dev/optimized-appear/start-after-hydration.html
+++ b/dev/optimized-appear/start-after-hydration.html
@@ -1,0 +1,95 @@
+<html>
+    <head>
+        <style>
+            body {
+                padding: 100px;
+                margin: 0;
+            }
+
+            #box {
+                width: 100px;
+                height: 100px;
+                background-color: #0077ff;
+            }
+
+            [data-layout-correct="false"] {
+                background: #dd1144 !important;
+                opacity: 1 !important;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script src="../../node_modules/react/umd/react.development.js"></script>
+        <script src="../../node_modules/react-dom/umd/react-dom.development.js"></script>
+        <script src="../../node_modules/react-dom/umd/react-dom-server-legacy.browser.development.js"></script>
+        <script src="../../packages/framer-motion/dist/framer-motion.dev.js"></script>
+        <script src="../projection/script-assert.js"></script>
+
+        <script>
+            const {
+                motion,
+                animateStyle,
+                startOptimizedAppearAnimation,
+                optimizedAppearDataAttribute,
+                motionValue,
+            } = window.Motion
+            const { matchViewportBox } = window.Assert
+            const root = document.getElementById("root")
+
+            const duration = 1
+
+            // This is the tree to be rendered "server" and client-side.
+            const Component = React.createElement(motion.div, {
+                id: "box",
+                initial: { x: 0, opacity: 0.5 },
+                animate: { x: 100, opacity: 1 },
+                transition: { duration, ease: "linear" },
+                /**
+                 * On animation start, check the values we expect to see here
+                 */
+                onAnimationStart: () => {
+                    setTimeout(() => {
+                        // Start WAAPI animation
+                        startOptimizedAppearAnimation(
+                            document.getElementById("box"),
+                            "transform",
+                            ["translateX(0px)", "translateX(100px)"],
+                            {
+                                duration: duration * 1000,
+                                ease: "linear",
+                            }
+                        )
+
+                        // Start WAAPI animation
+                        startOptimizedAppearAnimation(
+                            document.getElementById("box"),
+                            "opacity",
+                            [0.5, 1],
+                            {
+                                duration: duration * 1000,
+                                ease: "linear",
+                            }
+                        )
+                        requestAnimationFrame(() => {
+                            const { top, left } = document
+                                .getElementById("box")
+                                .getBoundingClientRect()
+
+                            // Fuzzy to be permissive towards Cypress runner
+                            if (left < 130) {
+                                showError(box, `unexpected viewport box`)
+                            }
+                        })
+                    }, 500)
+                },
+                [optimizedAppearDataAttribute]: "a",
+                children: "Content",
+            })
+            // Emulate server rendering of element
+            root.innerHTML = ReactDOMServer.renderToString(Component)
+
+            ReactDOM.hydrateRoot(root, Component)
+        </script>
+    </body>
+</html>

--- a/packages/framer-motion/src/animation/optimized-appear/start.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/start.ts
@@ -13,6 +13,9 @@ export function startOptimizedAppearAnimation(
     options: NativeAnimationOptions,
     onReady?: (animation: Animation) => void
 ): void {
+    // Prevent optimised appear animations if Motion has already started animating.
+    if (window.HandoffAppearAnimations === false) return
+
     const id = element.dataset[optimizedAppearDataId]
 
     if (!id) return

--- a/packages/framer-motion/src/animation/optimized-appear/types.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/types.ts
@@ -1,17 +1,19 @@
 import { Batcher } from "../../frameloop/types"
 import { MotionValue } from "../../value"
 
+type HandoffFunction = (
+    storeId: string,
+    valueName: string,
+    value: MotionValue,
+    sync: Batcher
+) => number
+
 /**
  * The window global object acts as a bridge between our inline script
  * triggering the optimized appear animations, and Framer Motion.
  */
 declare global {
     interface Window {
-        HandoffAppearAnimations?: (
-            storeId: string,
-            valueName: string,
-            value: MotionValue,
-            sync: Batcher
-        ) => number
+        HandoffAppearAnimations: undefined | false | HandoffFunction
     }
 }

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -87,7 +87,7 @@ export function useVisualElement<Instance, RenderState>(
          * so components added after the initial render can animate changes
          * in useEffect vs useLayoutEffect.
          */
-        window.HandoffAppearAnimations = undefined
+        window.HandoffAppearAnimations = false
         canHandoff.current = false
     })
 


### PR DESCRIPTION
In Safari it can be that the optimised appear animation script runs after hydration. This PR ensures optimised animations won't trigger in this situation.