### PR TITLE
Remove unknown eslint extension setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "typescript.tsdk": "node_modules/typescript/lib",
-    "eslint.alwaysShowStatus": true,
     "eslint.validate": [
         "javascript",
         "javascriptreact",


### PR DESCRIPTION
This setting has been removed from the eslint vscode extension now as it happens [automatically](https://github.com/microsoft/vscode-eslint/issues/848#issuecomment-567544759)