### PR TITLE
Improve optimised appear scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [10.16.14] 2023-12-05
+
+### Fixed
+
+-   Ensure `animateChanges` only runs in layout effect in initial render.
+
 ## [10.16.13] 2023-12-05
 
 ### Fixed

--- a/packages/framer-motion/src/animation/optimized-appear/start.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/start.ts
@@ -29,7 +29,10 @@ export function startOptimizedAppearAnimation(
     onReady?: (animation: Animation) => void
 ): void {
     // Prevent optimised appear animations if Motion has already started animating.
-    if (window.HandoffComplete) return
+    if (window.HandoffComplete) {
+        window.HandoffAppearAnimations = undefined
+        return
+    }
 
     const id = element.dataset[optimizedAppearDataId]
 

--- a/packages/framer-motion/src/animation/optimized-appear/start.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/start.ts
@@ -29,7 +29,7 @@ export function startOptimizedAppearAnimation(
     onReady?: (animation: Animation) => void
 ): void {
     // Prevent optimised appear animations if Motion has already started animating.
-    if (window.HandoffAppearAnimations === false) return
+    if (window.HandoffComplete) return
 
     const id = element.dataset[optimizedAppearDataId]
 

--- a/packages/framer-motion/src/animation/optimized-appear/types.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/types.ts
@@ -14,6 +14,7 @@ type HandoffFunction = (
  */
 declare global {
     interface Window {
-        HandoffAppearAnimations?: false | HandoffFunction
+        HandoffAppearAnimations?: HandoffFunction
+        HandoffComplete?: boolean
     }
 }

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -52,7 +52,9 @@ export function useVisualElement<Instance, RenderState>(
      * Cache this value as we want to know whether HandoffAppearAnimations
      * was present on initial render - it will be deleted after this.
      */
-    const wantsHandoff = useRef(Boolean(props[optimizedAppearDataAttribute]))
+    const wantsHandoff = useRef(
+        Boolean(props[optimizedAppearDataAttribute] && !window.HandoffComplete)
+    )
 
     useIsomorphicLayoutEffect(() => {
         if (!visualElement) return
@@ -83,12 +85,9 @@ export function useVisualElement<Instance, RenderState>(
             visualElement.animationState.animateChanges()
         }
 
-        /**
-         * Once we've handed animations off, we can delete the global reference.
-         */
         if (wantsHandoff.current) {
-            window.HandoffAppearAnimations = false
             wantsHandoff.current = false
+            window.HandoffComplete = true
         }
     })
 


### PR DESCRIPTION
This PR ensures that only the first `animateChanges` runs in `useLayoutEffect` with a new variable, `HandoffComplete`, that avoids the race condition between not allowing `startOptimisedAppear` to run after hydration, and handoff working even if another React tree has been mounted first (like the Made in Framer button)