### PR TITLE
Fix for motion value animations not sequencing correctly

### DIFF
--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -230,10 +230,10 @@ export function createAnimationsFromSequence(
                     )
                 }
             }
-
-            prevTime = currentTime
-            currentTime += maxDuration
         }
+
+        prevTime = currentTime
+        currentTime += maxDuration
     }
 
     /**


### PR DESCRIPTION
Hello, I thought instead of just reporting an issue I might help a bit by trying to find the location where the problem originiates. What I noticed is that when using an animation sequence the motion value animation segments don't push the next animation to start after they are finished. I think it's just these two assignments that accidentaly got in one curly brace to early.