### PR TITLE
Skip animations globally

### DIFF
--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "../../../jest.setup"
 import * as React from "react"
 import { useEffect } from "react"
-import { motion } from "../.."
+import { motion, MotionGlobalConfig } from "../.."
 import { animate } from "../animate"
 import { useMotionValue } from "../../value/use-motion-value"
 import { motionValue, MotionValue } from "../../value"
@@ -225,6 +225,19 @@ describe("animate", () => {
         )
         await animation.then(() => {
             expect(div).toHaveStyle("opacity: 0.2")
+        })
+    })
+
+    test("Skips animations", async () => {
+        const div = document.createElement("div")
+        MotionGlobalConfig.skipAnimations = true
+        animate(div, { opacity: [0.2, 0.5] }, { duration: 1 })
+        await new Promise<void>((resolve) => {
+            setTimeout(() => {
+                MotionGlobalConfig.skipAnimations = false
+                expect(div).toHaveStyle("opacity: 0.5")
+                resolve()
+            }, 100)
         })
     })
 

--- a/packages/framer-motion/src/animation/interfaces/motion-value.ts
+++ b/packages/framer-motion/src/animation/interfaces/motion-value.ts
@@ -11,6 +11,7 @@ import { getKeyframes } from "../utils/keyframes"
 import { getValueTransition, isTransitionDefined } from "../utils/transitions"
 import { animateValue } from "../animators/js"
 import { AnimationPlaybackControls, ValueAnimationOptions } from "../types"
+import { MotionGlobalConfig } from "../../utils/GlobalConfig"
 
 export const animateMotionValue = (
     valueName: string,
@@ -101,7 +102,8 @@ export const animateMotionValue = (
             !isOriginAnimatable ||
             !isTargetAnimatable ||
             instantAnimationState.current ||
-            valueTransition.type === false
+            valueTransition.type === false ||
+            MotionGlobalConfig.skipAnimations
         ) {
             /**
              * If we can't animate this value, or the global instant animation flag is set,

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -78,7 +78,10 @@ export { isMotionComponent } from "./motion/utils/is-motion-component"
 export { unwrapMotionComponent } from "./motion/utils/unwrap-motion-component"
 export { VisualElement } from "./render/VisualElement"
 export { addScaleCorrector } from "./projection/styles/scale-correction"
-export { useInstantTransition, disableInstantTransitions } from "./utils/use-instant-transition"
+export {
+    useInstantTransition,
+    disableInstantTransitions,
+} from "./utils/use-instant-transition"
 export { useInstantLayoutTransition } from "./projection/use-instant-layout-transition"
 export { useResetProjection } from "./projection/use-reset-projection"
 export { buildTransform } from "./render/html/utils/build-transform"
@@ -88,6 +91,7 @@ export { color } from "./value/types/color"
 export { complex } from "./value/types/complex"
 export { px } from "./value/types/numbers/units"
 export { ValueType } from "./value/types/types"
+export { MotionGlobalConfig } from "./utils/GlobalConfig"
 
 /**
  * Appear animations

--- a/packages/framer-motion/src/utils/GlobalConfig.ts
+++ b/packages/framer-motion/src/utils/GlobalConfig.ts
@@ -1,0 +1,3 @@
+export const MotionGlobalConfig = {
+    skipAnimations: false,
+}


### PR DESCRIPTION
This allows setting a config option that disables animations globally.

```javascript
import { MotionGlobalConfig } from "framer-motion"

MotionGlobalConfig.skipAnimations = true
```

Fixes https://github.com/framer/motion/issues/1160