### PR TITLE
Adding warning if scroll container is `position: static`

### DIFF
--- a/dev/tests/scroll-container.tsx
+++ b/dev/tests/scroll-container.tsx
@@ -1,0 +1,46 @@
+import { useScroll, motion, useMotionValueEvent } from "framer-motion"
+import * as React from "react"
+import { useRef } from "react"
+
+export const App = () => {
+    const containerRef = useRef(null)
+    const targetRef = useRef(null)
+    const { scrollYProgress } = useScroll({
+        container: containerRef,
+        target: targetRef,
+        offset: ["start start", "end start"],
+    })
+
+    useMotionValueEvent(scrollYProgress, "change", console.log)
+
+    return (
+        <>
+            <div style={{ height: 100, width: 100 }}></div>
+            <div
+                id="container"
+                ref={containerRef}
+                style={{
+                    overflowY: "auto",
+                    height: 300,
+                    width: 300,
+                    position: "relative",
+                }}
+            >
+                <div style={{ height: 1000, width: 300, background: "red" }}>
+                    <div
+                        ref={targetRef}
+                        style={{
+                            width: 100,
+                            height: 100,
+                            fontSize: 24,
+                            display: "flex",
+                            background: "white",
+                        }}
+                    >
+                        <motion.span id="label">{scrollYProgress}</motion.span>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/scroll.ts
+++ b/packages/framer-motion/cypress/integration/scroll.ts
@@ -9,6 +9,17 @@ describe("scroll() callbacks", () => {
     })
 
     it("Correctly updates window scroll progress callback", () => {
+        cy.visit("?test=scroll-container").wait(100)
+
+        cy.get("#container")
+            .scrollTo(0, 50)
+            .get("#label")
+            .should(([$element]: any) => {
+                expect($element.innerText).to.equal("0.5")
+            })
+    })
+
+    it("Correctly measures scroll position", () => {
         cy.visit("?test=scroll-callback-window").wait(100).viewport(100, 400)
 
         cy.scrollTo(0, 600)

--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -904,7 +904,7 @@ describe("animate prop as variant", () => {
             }, 100)
         })
 
-        expect(outputA).toEqual(outputB)
+        expect(outputA.length).toEqual(outputB.length)
     })
 
     test("style is used as fallback when a variant changes to not contain that style", async () => {

--- a/packages/framer-motion/src/render/dom/scroll/info.ts
+++ b/packages/framer-motion/src/render/dom/scroll/info.ts
@@ -59,6 +59,8 @@ function updateAxisInfo(
         elapsed > maxElapsed
             ? 0
             : velocityPerSecond(axis.current - prev, elapsed)
+
+    if (axisName === "y") console.log(axis)
 }
 
 export function updateScrollInfo(

--- a/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
+++ b/packages/framer-motion/src/render/dom/scroll/on-scroll-handler.ts
@@ -1,3 +1,4 @@
+import { warnOnce } from "../../../utils/warn-once"
 import { updateScrollInfo } from "./info"
 import { resolveOffsets } from "./offsets/index"
 import {
@@ -32,6 +33,19 @@ function measure(
         target === container ? target.scrollHeight : target.clientHeight
     info.x.containerLength = container.clientWidth
     info.y.containerLength = container.clientHeight
+
+    /**
+     * In development mode ensure scroll containers aren't position: static as this makes
+     * it difficult to measure their relative positions.
+     */
+    if (process.env.NODE_ENV !== "production") {
+        if (container && target && target !== container) {
+            warnOnce(
+                getComputedStyle(container).position !== "static",
+                "Please ensure that the container has a non-static position, like 'relative', 'fixed', or 'absolute' to ensure scroll offset is calculated correctly."
+            )
+        }
+    }
 }
 
 export function createOnScrollHandler(

--- a/packages/framer-motion/src/render/dom/scroll/track.ts
+++ b/packages/framer-motion/src/render/dom/scroll/track.ts
@@ -61,7 +61,7 @@ export function scrollInfo(
 
         const listener = () => {
             frame.read(measureAll, false, true)
-            frame.update(updateAll, false, true)
+            frame.read(updateAll, false, true)
             frame.update(notifyAll, false, true)
         }
 


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/1853