### PR TITLE
Ensure AnimatePresence executes exiting animations in sequence

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -11,7 +11,6 @@ import {
 } from "../../.."
 import { motionValue } from "../../../value"
 import { ResolvedValues } from "../../../render/types"
-import { prettyDOM } from "@testing-library/dom"
 
 describe("AnimatePresence", () => {
     test("Allows initial animation if no `initial` prop defined", async () => {
@@ -472,7 +471,7 @@ describe("AnimatePresence", () => {
             )
         }
 
-        const { rerender, container, getAllByTestId } = render(
+        const { rerender, getAllByTestId } = render(
             <Component nums={[0, 1, 2, 3]} />
         )
 
@@ -488,27 +487,18 @@ describe("AnimatePresence", () => {
             setTimeout(() => {
                 act(() => rerender(<Component nums={[1, 2, 3]} />))
                 setTimeout(() => {
-                    const textContents = getTextContents()
-                    console.log(textContents)
-                    console.log(prettyDOM(container))
                     expect(getTextContents()).toEqual([1, 2, 3])
                 }, 100)
             }, 100)
             setTimeout(() => {
                 act(() => rerender(<Component nums={[2, 3]} />))
                 setTimeout(() => {
-                    const textContents = getTextContents()
-                    console.log(textContents)
-                    console.log(prettyDOM(container))
                     expect(getTextContents()).toEqual([2, 3])
                 }, 100)
             }, 250)
             setTimeout(() => {
                 act(() => rerender(<Component nums={[3]} />))
                 setTimeout(() => {
-                    const textContents = getTextContents()
-                    console.log(textContents)
-                    console.log(prettyDOM(container))
                     expect(getTextContents()).toEqual([3])
                     resolve()
                 }, 100)

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -96,8 +96,9 @@ export const AnimatePresence: React.FunctionComponent<
     const isMounted = useIsMounted()
 
     // Filter out any children that aren't ReactElements. We can only track ReactElements with a props.key
-    const filteredChildren = onlyElements(children)
-    let childrenToRender = filteredChildren
+    const filteredChildren = useRef(onlyElements(children))
+    filteredChildren.current = onlyElements(children)
+    let childrenToRender = filteredChildren.current
 
     const exitingChildren = useRef(
         new Map<ComponentKey, ReactElement<any> | undefined>()
@@ -105,7 +106,6 @@ export const AnimatePresence: React.FunctionComponent<
 
     // Keep a living record of the children we're actually rendering so we
     // can diff to figure out which are entering and exiting
-    const presentChildren = useRef(childrenToRender)
 
     // A lookup table to quickly reference components by key
     const allChildren = useRef(
@@ -118,9 +118,7 @@ export const AnimatePresence: React.FunctionComponent<
 
     useIsomorphicLayoutEffect(() => {
         isInitialRender.current = false
-
-        updateChildLookup(filteredChildren, allChildren)
-        presentChildren.current = childrenToRender
+        updateChildLookup(filteredChildren.current, allChildren)
     })
 
     useUnmountEffect(() => {
@@ -152,8 +150,8 @@ export const AnimatePresence: React.FunctionComponent<
 
     // Diff the keys of the currently-present and target children to update our
     // exiting list.
-    const presentKeys = presentChildren.current.map(getChildKey)
-    const targetKeys = filteredChildren.map(getChildKey)
+    const presentKeys = Array.from(allChildren.keys())
+    const targetKeys = filteredChildren.current.map(getChildKey)
 
     // Diff the present children with our target children and mark those that are exiting
     const numPresent = presentKeys.length
@@ -173,12 +171,12 @@ export const AnimatePresence: React.FunctionComponent<
 
     // Loop through all currently exiting components and clone them to overwrite `animate`
     // with any `exit` prop they might have defined.
-    exitingChildren.forEach((component, key) => {
+    for (const [key, component] of exitingChildren) {
         // If this component is actually entering again, early return
-        if (targetKeys.indexOf(key) !== -1) return
+        if (targetKeys.indexOf(key) !== -1) continue
 
         const child = allChildren.get(key)
-        if (!child) return
+        if (!child) continue
 
         const insertionIndex = presentKeys.indexOf(key)
 
@@ -187,6 +185,16 @@ export const AnimatePresence: React.FunctionComponent<
             const onExit = () => {
                 // clean up the exiting children map
                 exitingChildren.delete(key)
+
+                // Accounts for the edge case where there are still exiting children when the
+                // children list is already empty from React's POV, which results in React not
+                // auto re-rendering
+                if (
+                    filteredChildren.current.length === 0 &&
+                    exitingChildren.size > 0
+                ) {
+                    forceRender()
+                }
 
                 // compute the keys of children that were rendered once but are no longer present
                 // this could happen in case of too many fast consequent renderings
@@ -198,20 +206,6 @@ export const AnimatePresence: React.FunctionComponent<
                 // clean up the all children map
                 leftOverKeys.forEach((leftOverKey) =>
                     allChildren.delete(leftOverKey)
-                )
-
-                // make sure to render only the children that are actually visible
-                presentChildren.current = filteredChildren.filter(
-                    (presentChild) => {
-                        const presentChildKey = getChildKey(presentChild)
-
-                        return (
-                            // filter out the node exiting
-                            presentChildKey === key ||
-                            // filter out the leftover children
-                            leftOverKeys.includes(presentChildKey)
-                        )
-                    }
                 )
 
                 // Defer re-rendering until all exiting children have indeed left
@@ -239,7 +233,7 @@ export const AnimatePresence: React.FunctionComponent<
         }
 
         childrenToRender.splice(insertionIndex, 0, exitingComponent)
-    })
+    }
 
     // Add `MotionContext` even to children that don't need it to ensure we're rendering
     // the same tree between renders

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -104,9 +104,6 @@ export const AnimatePresence: React.FunctionComponent<
         new Map<ComponentKey, ReactElement<any> | undefined>()
     ).current
 
-    // Keep a living record of the children we're actually rendering so we
-    // can diff to figure out which are entering and exiting
-
     // A lookup table to quickly reference components by key
     const allChildren = useRef(
         new Map<ComponentKey, ReactElement<any>>()

--- a/packages/framer-motion/src/utils/use-force-update.ts
+++ b/packages/framer-motion/src/utils/use-force-update.ts
@@ -7,8 +7,8 @@ export function useForceUpdate(): [VoidFunction, number] {
     const [forcedRenderCount, setForcedRenderCount] = useState(0)
 
     const forceRender = useCallback(() => {
-        isMounted.current && setForcedRenderCount(forcedRenderCount + 1)
-    }, [forcedRenderCount])
+        isMounted.current && setForcedRenderCount((count) => count + 1)
+    }, [isMounted])
 
     /**
      * Defer this to the end of the next animation frame in case there are multiple


### PR DESCRIPTION
This PR fixes #2462. 

It also fixes 3 tests (i.e. "Only renders one child at a time if mode === 'wait'", "Fast animations with wait render the child content correctly", "Fast animations with wait render the child content correctly (strict mode disabled)") where not enough leeway is given for exiting elements to completely exit from the DOM.

# Before

https://github.com/framer/motion/assets/62209188/d73c8cdc-8cdd-4037-adda-d9cd901c613c

# Now

https://github.com/framer/motion/assets/62209188/da6e0868-f36e-4d95-a13f-4486389d8b7f

