### PR TITLE
Update DOMMotionComponents type

### DIFF
--- a/packages/framer-motion/src/render/dom/types.ts
+++ b/packages/framer-motion/src/render/dom/types.ts
@@ -29,4 +29,4 @@ export interface DOMVisualElementOptions {
     enableHardwareAcceleration?: boolean
 }
 
-export type DOMMotionComponents = HTMLMotionComponents & SVGMotionComponents
+export type DOMMotionComponents = HTMLMotionComponents | SVGMotionComponents


### PR DESCRIPTION
I’m assuming this type is meant to express “the union of all types in HTMLMotionComponents and SVGMotionComponents”, but currently it means that all DOMMotionComponents are/need to be compatible with both HTML and SVG components.

Depending on your TypeScript configuration, this will lead to errors such as:
<img width="864" alt="image" src="https://github.com/framer/motion/assets/12829/103cfdf7-ef88-4216-9983-b1506caaeeaf">
<details>
<summary>(as text)</summary>
<pre>
Type 'RefObject<HTMLDivElement>' is not assignable to type '((((instance: SVGElement | null) => void) | RefObject<SVGElement>) & (((instance: HTMLElement | null) => void) | RefObject<HTMLElement>)) | null | undefined'.
  Type 'RefObject<HTMLDivElement>' is not assignable to type 'RefObject<SVGElement> & RefObject<HTMLElement>'.
    Type 'RefObject<HTMLDivElement>' is not assignable to type 'RefObject<SVGElement>'.
      Type 'HTMLDivElement' is missing the following properties from type 'SVGElement': ownerSVGElement, viewportElementts(2322)
index.d.ts(135, 9): The expected type comes from property 'ref' which is declared here on type 'IntrinsicAttributes & SVGMotionProps<SVGElement> & RefAttributes<SVGElement> & HTMLAttributesWithoutMotionProps<HTMLAttributes<HTMLElement>, HTMLElement> & MotionProps & RefAttributes<...>'
(property) React.RefAttributes<T>.ref?: ((((instance: SVGElement | null) => void) | React.RefObject<SVGElement>) & (((instance: HTMLElement | null) => void) | React.RefObject<HTMLElement>)) | null | undefined
</pre>
</details>