### PR TITLE
Passive velocity calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.0.0] 2024-02-19
+
+### Changed
+
+-   Replaced velocity-check jobs in favour of passive detection.
+
 ## [10.18.0] 2024-01-10
 
 ### Added

--- a/dev/examples/animate-stress-headless-color.tsx
+++ b/dev/examples/animate-stress-headless-color.tsx
@@ -4,7 +4,7 @@ import { animate } from "framer-motion"
 export const App = () => {
     React.useEffect(() => {
         let count = 0
-        for (let i = 0; i < 250; i++) {
+        for (let i = 0; i < 2000; i++) {
             count++
             animate("rgba(0,0,0,0)", "rgba(255,255,255,1)", { duration: 20 })
         }

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -27,7 +27,8 @@ function AnimationExample() {
                 animate={{
                     x: [-200, 200],
                     transition: {
-                        duration: 1,
+                        duration: 0.5,
+                        ease: "linear",
                         repeat: Infinity,
                         repeatType: "reverse",
                     },

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -1,102 +1,60 @@
 import * as React from "react"
-import { useState, useMemo, useEffect, useRef } from "react"
-import { render } from "react-dom"
-import { distance2D, motion, useMotionValue, useSpring } from "framer-motion"
+import { motion, useMotionValue, useSpring } from "framer-motion"
 
-//const grid = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
-const grid = [[0]]
-const size = 60
-const gap = 10
-const pushFactor = 0.4
-
-const Square = ({ active, setActive, colIndex, rowIndex, itemIndex, x, y }) => {
-    const isDragging = colIndex === active.col && rowIndex === active.row
-    const diagonalIndex = (360 / 6) * (colIndex + rowIndex)
-    const d = distance2D(
-        { x: active.col, y: active.row },
-        { x: colIndex, y: rowIndex }
-    )
-    const dx = useSpring(x, {
-        stiffness: Math.max(700 - d * 120, 0),
-        damping: 20 + d * 5,
-    })
-    const dy = useSpring(y, {
-        stiffness: Math.max(700 - d * 120, 0),
-        damping: 20 + d * 5,
-    })
-
+function DragExample() {
+    const dragX = useMotionValue(0)
+    const dragY = useMotionValue(0)
+    const x = useSpring(dragX)
+    const y = useSpring(dragY)
     return (
         <motion.div
             drag
-            dragConstraints={{ left: 0, right: 0, top: 0, bottom: 0 }}
-            dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
-            dragElastic={1}
-            onDragStart={() => setActive({ row: rowIndex, col: colIndex })}
-            transition={{
-                duration: 0.5,
-                ease: "easeInOut",
-                repeat: Infinity,
-                repeatType: "reverse",
-            }}
-            style={{
-                background: `hsla(calc(var(--base-hue) + ${diagonalIndex}), 80%, 60%, 1)`,
-                width: size,
-                height: size,
-                top: rowIndex * (size + gap),
-                left: colIndex * (size + gap),
-                position: "absolute",
-                borderRadius: "50%",
-                x: isDragging ? x : dx,
-                y: isDragging ? y : dy,
-                zIndex: isDragging ? 1 : 0,
-            }}
+            dragMomentum={false}
+            _dragX={dragX}
+            _dragY={dragY}
+            style={{ width: 100, height: 100, background: "red", x, y }}
         />
     )
 }
 
-export function App() {
-    const [active, setActive] = useState({ row: 0, col: 0 })
-    const x = useSpring(0)
-    const y = useSpring(0)
-    const z = useMotionValue(0)
+function AnimationExample() {
+    const x = useMotionValue(0)
+    const xSpring = useSpring(x)
 
     return (
-        <div className="app">
+        <div style={{ width: 100, height: 100, position: "relative" }}>
             <motion.div
-                animate={{ "--base-hue": 360 } as any}
-                initial={{ "--base-hue": 0 } as any}
-                transition={{ duration: 10, loop: Infinity, ease: "linear" }}
-                style={{ width: "100%", height: "100%" }}
-            >
-                <motion.div
-                    style={{
-                        display: "flex",
-                        width: (size + gap) * 4 - gap,
-                        height: (size + gap) * 4 - gap,
-                        top: "50%",
-                        left: "50%",
-                        transform: "translate(-50%, -50%)",
-                        position: "relative",
-                        perspective: 500,
-                    }}
-                >
-                    {grid.map((row, rowIndex) =>
-                        row.map((item, colIndex) => (
-                            <Square
-                                x={x}
-                                y={y}
-                                z={z}
-                                itemIndex={item}
-                                active={active}
-                                setActive={setActive}
-                                rowIndex={rowIndex}
-                                colIndex={colIndex}
-                                key={rowIndex + colIndex}
-                            />
-                        ))
-                    )}
-                </motion.div>
-            </motion.div>
+                animate={{
+                    x: [-200, 200],
+                    transition: {
+                        duration: 1,
+                        repeat: Infinity,
+                        repeatType: "reverse",
+                    },
+                }}
+                style={{ width: 100, height: 100, background: "lightblue", x }}
+            />
+            <motion.div
+                style={{
+                    width: 100,
+                    height: 100,
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    background: "lightblue",
+                    opacity: 0.5,
+                    x: xSpring,
+                }}
+            />
+        </div>
+    )
+}
+
+export function App() {
+    return (
+        <div style={{ display: "flex", gap: 100 }}>
+            <DragExample />
+            <AnimationExample />
         </div>
     )
 }

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -1,67 +1,102 @@
 import * as React from "react"
-import { useState } from "react"
-import { motion, useMotionValue, useSpring, frame } from "framer-motion"
-import { cancelFrame } from "framer-motion"
+import { useState, useMemo, useEffect, useRef } from "react"
+import { render } from "react-dom"
+import { distance2D, motion, useMotionValue, useSpring } from "framer-motion"
+
+//const grid = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
+const grid = [[0]]
+const size = 60
+const gap = 10
+const pushFactor = 0.4
+
+const Square = ({ active, setActive, colIndex, rowIndex, itemIndex, x, y }) => {
+    const isDragging = colIndex === active.col && rowIndex === active.row
+    const diagonalIndex = (360 / 6) * (colIndex + rowIndex)
+    const d = distance2D(
+        { x: active.col, y: active.row },
+        { x: colIndex, y: rowIndex }
+    )
+    const dx = useSpring(x, {
+        stiffness: Math.max(700 - d * 120, 0),
+        damping: 20 + d * 5,
+    })
+    const dy = useSpring(y, {
+        stiffness: Math.max(700 - d * 120, 0),
+        damping: 20 + d * 5,
+    })
+
+    return (
+        <motion.div
+            drag
+            dragConstraints={{ left: 0, right: 0, top: 0, bottom: 0 }}
+            dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
+            dragElastic={1}
+            onDragStart={() => setActive({ row: rowIndex, col: colIndex })}
+            transition={{
+                duration: 0.5,
+                ease: "easeInOut",
+                repeat: Infinity,
+                repeatType: "reverse",
+            }}
+            style={{
+                background: `hsla(calc(var(--base-hue) + ${diagonalIndex}), 80%, 60%, 1)`,
+                width: size,
+                height: size,
+                top: rowIndex * (size + gap),
+                left: colIndex * (size + gap),
+                position: "absolute",
+                borderRadius: "50%",
+                x: isDragging ? x : dx,
+                y: isDragging ? y : dy,
+                zIndex: isDragging ? 1 : 0,
+            }}
+        />
+    )
+}
 
 export function App() {
-    const value = useMotionValue(0)
+    const [active, setActive] = useState({ row: 0, col: 0 })
+    const x = useSpring(0)
+    const y = useSpring(0)
+    const z = useMotionValue(0)
 
-    React.useEffect(() => {
-        value.set(0)
-
-        const test = () => {
-            frame.update(() => {
-                value.set(1)
-                console.log(
-                    1,
-                    "velocity, should be non-zero",
-                    value.getVelocity()
-                )
-
-                frame.update(() => {
-                    value.set(2)
-                    console.log(
-                        2,
-                        "velocity, should be 60ish",
-                        value.getVelocity()
-                    )
-
-                    frame.update(() => {
-                        console.log(
-                            "velocity, should probably be same as previous frame",
-                            value.getVelocity()
-                        )
-                        value.set(3)
-                        console.log(
-                            "velocity, should be 60ish",
-                            value.getVelocity()
-                        )
-
-                        setTimeout(() => {
-                            frame.update(() => {
-                                console.log(
-                                    "before update, should be 0: ",
-                                    value.getVelocity()
-                                )
-                                value.set(4)
-                                console.log(
-                                    4,
-                                    "after update, should be non-zero: ",
-                                    value.getVelocity()
-                                )
-                            })
-                        }, 500)
-                    })
-                })
-            })
-        }
-
-        const timeout = setTimeout(test, 2000)
-
-        return () => {
-            clearTimeout(timeout)
-        }
-    }, [value])
-
-    return null
+    return (
+        <div className="app">
+            <motion.div
+                animate={{ "--base-hue": 360 } as any}
+                initial={{ "--base-hue": 0 } as any}
+                transition={{ duration: 10, loop: Infinity, ease: "linear" }}
+                style={{ width: "100%", height: "100%" }}
+            >
+                <motion.div
+                    style={{
+                        display: "flex",
+                        width: (size + gap) * 4 - gap,
+                        height: (size + gap) * 4 - gap,
+                        top: "50%",
+                        left: "50%",
+                        transform: "translate(-50%, -50%)",
+                        position: "relative",
+                        perspective: 500,
+                    }}
+                >
+                    {grid.map((row, rowIndex) =>
+                        row.map((item, colIndex) => (
+                            <Square
+                                x={x}
+                                y={y}
+                                z={z}
+                                itemIndex={item}
+                                active={active}
+                                setActive={setActive}
+                                rowIndex={rowIndex}
+                                colIndex={colIndex}
+                                key={rowIndex + colIndex}
+                            />
+                        ))
+                    )}
+                </motion.div>
+            </motion.div>
+        </div>
+    )
 }

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -1,102 +1,67 @@
 import * as React from "react"
-import { useState, useMemo, useEffect, useRef } from "react"
-import { render } from "react-dom"
-import { distance2D, motion, useMotionValue, useSpring } from "framer-motion"
-
-//const grid = [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]
-const grid = [[0]]
-const size = 60
-const gap = 10
-const pushFactor = 0.4
-
-const Square = ({ active, setActive, colIndex, rowIndex, itemIndex, x, y }) => {
-    const isDragging = colIndex === active.col && rowIndex === active.row
-    const diagonalIndex = (360 / 6) * (colIndex + rowIndex)
-    const d = distance2D(
-        { x: active.col, y: active.row },
-        { x: colIndex, y: rowIndex }
-    )
-    const dx = useSpring(x, {
-        stiffness: Math.max(700 - d * 120, 0),
-        damping: 20 + d * 5,
-    })
-    const dy = useSpring(y, {
-        stiffness: Math.max(700 - d * 120, 0),
-        damping: 20 + d * 5,
-    })
-
-    return (
-        <motion.div
-            drag
-            dragConstraints={{ left: 0, right: 0, top: 0, bottom: 0 }}
-            dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
-            dragElastic={1}
-            onDragStart={() => setActive({ row: rowIndex, col: colIndex })}
-            transition={{
-                duration: 0.5,
-                ease: "easeInOut",
-                repeat: Infinity,
-                repeatType: "reverse",
-            }}
-            style={{
-                background: `hsla(calc(var(--base-hue) + ${diagonalIndex}), 80%, 60%, 1)`,
-                width: size,
-                height: size,
-                top: rowIndex * (size + gap),
-                left: colIndex * (size + gap),
-                position: "absolute",
-                borderRadius: "50%",
-                x: isDragging ? x : dx,
-                y: isDragging ? y : dy,
-                zIndex: isDragging ? 1 : 0,
-            }}
-        />
-    )
-}
+import { useState } from "react"
+import { motion, useMotionValue, useSpring, frame } from "framer-motion"
+import { cancelFrame } from "framer-motion"
 
 export function App() {
-    const [active, setActive] = useState({ row: 0, col: 0 })
-    const x = useSpring(0)
-    const y = useSpring(0)
-    const z = useMotionValue(0)
+    const value = useMotionValue(0)
 
-    return (
-        <div className="app">
-            <motion.div
-                animate={{ "--base-hue": 360 } as any}
-                initial={{ "--base-hue": 0 } as any}
-                transition={{ duration: 10, loop: Infinity, ease: "linear" }}
-                style={{ width: "100%", height: "100%" }}
-            >
-                <motion.div
-                    style={{
-                        display: "flex",
-                        width: (size + gap) * 4 - gap,
-                        height: (size + gap) * 4 - gap,
-                        top: "50%",
-                        left: "50%",
-                        transform: "translate(-50%, -50%)",
-                        position: "relative",
-                        perspective: 500,
-                    }}
-                >
-                    {grid.map((row, rowIndex) =>
-                        row.map((item, colIndex) => (
-                            <Square
-                                x={x}
-                                y={y}
-                                z={z}
-                                itemIndex={item}
-                                active={active}
-                                setActive={setActive}
-                                rowIndex={rowIndex}
-                                colIndex={colIndex}
-                                key={rowIndex + colIndex}
-                            />
-                        ))
-                    )}
-                </motion.div>
-            </motion.div>
-        </div>
-    )
+    React.useEffect(() => {
+        value.set(0)
+
+        const test = () => {
+            frame.update(() => {
+                value.set(1)
+                console.log(
+                    1,
+                    "velocity, should be non-zero",
+                    value.getVelocity()
+                )
+
+                frame.update(() => {
+                    value.set(2)
+                    console.log(
+                        2,
+                        "velocity, should be 60ish",
+                        value.getVelocity()
+                    )
+
+                    frame.update(() => {
+                        console.log(
+                            "velocity, should probably be same as previous frame",
+                            value.getVelocity()
+                        )
+                        value.set(3)
+                        console.log(
+                            "velocity, should be 60ish",
+                            value.getVelocity()
+                        )
+
+                        setTimeout(() => {
+                            frame.update(() => {
+                                console.log(
+                                    "before update, should be 0: ",
+                                    value.getVelocity()
+                                )
+                                value.set(4)
+                                console.log(
+                                    4,
+                                    "after update, should be non-zero: ",
+                                    value.getVelocity()
+                                )
+                            })
+                        }, 500)
+                    })
+                })
+            })
+        }
+
+        const timeout = setTimeout(test, 2000)
+
+        return () => {
+            clearTimeout(timeout)
+        }
+    }, [value])
+
+    return null
 }

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -27,8 +27,7 @@ function AnimationExample() {
                 animate={{
                     x: [-200, 200],
                     transition: {
-                        duration: 0.5,
-                        ease: "linear",
+                        duration: 1,
                         repeat: Infinity,
                         repeatType: "reverse",
                     },

--- a/dev/examples/useVelocity.tsx
+++ b/dev/examples/useVelocity.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { useEffect, useState, useRef } from "react"
 import {
     motion,
     useMotionValue,
@@ -27,7 +26,12 @@ export const App = () => {
     )
 
     useMotionValueEvent(xAcceleration, "change", (v: number) =>
-        console.log("x acceleration", Math.round(v))
+        console.log(
+            "x acceleration",
+            Math.round(v),
+            "at",
+            Math.round(frameData.timestamp)
+        )
     )
 
     return (

--- a/dev/examples/useVelocity.tsx
+++ b/dev/examples/useVelocity.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useEffect, useState, useRef } from "react"
 import {
     motion,
     useMotionValue,
@@ -26,12 +27,7 @@ export const App = () => {
     )
 
     useMotionValueEvent(xAcceleration, "change", (v: number) =>
-        console.log(
-            "x acceleration",
-            Math.round(v),
-            "at",
-            Math.round(frameData.timestamp)
-        )
+        console.log("x acceleration", Math.round(v))
     )
 
     return (

--- a/dev/package.json
+++ b/dev/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion--dev",
-    "version": "10.18.0",
+    "version": "11.0.0-alpha.2",
     "private": true,
     "scripts": {
         "dev": "webpack serve --config ./webpack/config.js --hot"
@@ -8,8 +8,8 @@
     "dependencies": {
         "@react-three/drei": "^7.27.3",
         "@react-three/fiber": "^8.2.2",
-        "framer-motion": "^10.18.0",
-        "framer-motion-3d": "^10.18.0",
+        "framer-motion": "^11.0.0-alpha.2",
+        "framer-motion-3d": "^11.0.0-alpha.2",
         "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.18.0",
+    "version": "11.0.0-alpha.2",
     "packages": [
         "packages/*"
     ],

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -60,5 +60,5 @@
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1"
     },
-    "gitHead": "8ea9d6d92de25b624ce416e7785203cee679c88d"
+    "gitHead": "76928380fd5faf85fd0d9315b2a3c08498e8fd16"
 }

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -60,5 +60,5 @@
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1"
     },
-    "gitHead": "75992e6edcd37344df01c3cb772bc70580e68515"
+    "gitHead": "1daebee12047666ceeb1705853deae4e0b52f6e5"
 }

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -60,5 +60,5 @@
         "@react-three/test-renderer": "^9.0.0",
         "@rollup/plugin-commonjs": "^22.0.1"
     },
-    "gitHead": "1daebee12047666ceeb1705853deae4e0b52f6e5"
+    "gitHead": "8ea9d6d92de25b624ce416e7785203cee679c88d"
 }

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion-3d",
-    "version": "10.18.0",
+    "version": "11.0.0-alpha.2",
     "description": "A simple and powerful React animation library for @react-three/fiber",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",
@@ -46,7 +46,7 @@
         "postpublish": "git push --tags"
     },
     "dependencies": {
-        "framer-motion": "^10.18.0",
+        "framer-motion": "^11.0.0-alpha.2",
         "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 value/__tests__/index",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 use-velocity",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -116,5 +116,5 @@
             "maxSize": "32.1 kB"
         }
     ],
-    "gitHead": "1daebee12047666ceeb1705853deae4e0b52f6e5"
+    "gitHead": "8ea9d6d92de25b624ce416e7785203cee679c88d"
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 use-velocity",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -85,36 +85,36 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "31.15 kB"
+            "maxSize": "31.25 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "5.33 kB"
+            "maxSize": "5.35 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "15.2 kB"
+            "maxSize": "15.25 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "26.6 kB"
+            "maxSize": "26.7 kB"
         },
         {
             "path": "./dist/size-rollup-animate.js",
-            "maxSize": "16.52 kB"
+            "maxSize": "16.55 kB"
         },
         {
             "path": "./dist/size-webpack-m.js",
-            "maxSize": "5.45 kB"
+            "maxSize": "5.46 kB"
         },
         {
             "path": "./dist/size-webpack-dom-animation.js",
-            "maxSize": "19.75 kB"
+            "maxSize": "19.9 kB"
         },
         {
             "path": "./dist/size-webpack-dom-max.js",
-            "maxSize": "31.9 kB"
+            "maxSize": "32.1 kB"
         }
     ],
-    "gitHead": "75992e6edcd37344df01c3cb772bc70580e68515"
+    "gitHead": "1daebee12047666ceeb1705853deae4e0b52f6e5"
 }

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "10.18.0",
+    "version": "11.0.0-alpha.2",
     "description": "A simple and powerful JavaScript animation library",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -46,7 +46,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 value/__tests__/index",
         "test-server": "jest --config jest.config.ssr.json ",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-appear": "yarn run collect-appear-tests && start-server-and-test 'pushd ../../; python -m SimpleHTTPServer; popd' http://0.0.0.0:8000 'cypress run -s cypress/integration/appear.chrome.ts --config baseUrl=http://localhost:8000/'",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -116,5 +116,5 @@
             "maxSize": "32.1 kB"
         }
     ],
-    "gitHead": "8ea9d6d92de25b624ce416e7785203cee679c88d"
+    "gitHead": "76928380fd5faf85fd0d9315b2a3c08498e8fd16"
 }

--- a/packages/framer-motion/src/animation/animators/js/driver-frameloop.ts
+++ b/packages/framer-motion/src/animation/animators/js/driver-frameloop.ts
@@ -1,5 +1,6 @@
 import { frame, cancelFrame } from "../../../frameloop"
 import { frameData } from "../../../frameloop"
+import { time } from "../../../frameloop/sync-time"
 import { FrameData } from "../../../frameloop/types"
 import { Driver } from "./types"
 
@@ -13,7 +14,6 @@ export const frameloopDriver: Driver = (update) => {
          * If we're processing this frame we can use the
          * framelocked timestamp to keep things in sync.
          */
-        now: () =>
-            frameData.isProcessing ? frameData.timestamp : performance.now(),
+        now: () => (frameData.isProcessing ? frameData.timestamp : time.now()),
     }
 }

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -1,3 +1,4 @@
+import { MotionGlobalConfig } from "../utils/GlobalConfig"
 import { createRenderStep } from "./render-step"
 import { Batcher, Process, StepId, Steps, FrameData } from "./types"
 
@@ -33,7 +34,9 @@ export function createRenderBatcher(
     const processStep = (stepId: StepId) => steps[stepId].process(state)
 
     const processBatch = () => {
-        const timestamp = performance.now()
+        const timestamp = MotionGlobalConfig.useManualTiming
+            ? state.timestamp
+            : performance.now()
         runNextFrame = false
 
         state.delta = useDefaultElapsed

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -32,7 +32,8 @@ export function createRenderBatcher(
 
     const processStep = (stepId: StepId) => steps[stepId].process(state)
 
-    const processBatch = (timestamp = performance.now()) => {
+    const processBatch = () => {
+        const timestamp = performance.now()
         runNextFrame = false
 
         state.delta = useDefaultElapsed

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -33,7 +33,6 @@ export function createRenderBatcher(
     const processStep = (stepId: StepId) => steps[stepId].process(state)
 
     const processBatch = (timestamp = performance.now()) => {
-        console.log(timestamp, scheduleNextBatch === requestAnimationFrame)
         runNextFrame = false
 
         state.delta = useDefaultElapsed

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -32,9 +32,8 @@ export function createRenderBatcher(
 
     const processStep = (stepId: StepId) => steps[stepId].process(state)
 
-    const processBatch = () => {
-        const timestamp = performance.now()
-
+    const processBatch = (timestamp = performance.now()) => {
+        console.log(timestamp, scheduleNextBatch === requestAnimationFrame)
         runNextFrame = false
 
         state.delta = useDefaultElapsed

--- a/packages/framer-motion/src/frameloop/render-step.ts
+++ b/packages/framer-motion/src/frameloop/render-step.ts
@@ -1,6 +1,8 @@
 import { Step, Process } from "./types"
 
+let id = 0
 class Queue {
+    id = id++
     order: Process[] = []
     scheduled: Set<Process> = new Set()
 
@@ -104,12 +106,12 @@ export function createRenderStep(runNextFrame: () => void): Step {
                 for (let i = 0; i < numToRun; i++) {
                     const callback = thisFrame.order[i]
 
-                    callback(frameData)
-
                     if (toKeepAlive.has(callback)) {
                         step.schedule(callback)
                         runNextFrame()
                     }
+
+                    callback(frameData)
                 }
             }
 

--- a/packages/framer-motion/src/frameloop/render-step.ts
+++ b/packages/framer-motion/src/frameloop/render-step.ts
@@ -1,8 +1,6 @@
 import { Step, Process } from "./types"
 
-let id = 0
 class Queue {
-    id = id++
     order: Process[] = []
     scheduled: Set<Process> = new Set()
 

--- a/packages/framer-motion/src/frameloop/sync-time.ts
+++ b/packages/framer-motion/src/frameloop/sync-time.ts
@@ -1,3 +1,4 @@
+import { MotionGlobalConfig } from "../utils/GlobalConfig"
 import { frameData } from "./frame"
 import { microtask } from "./microtask"
 
@@ -19,7 +20,9 @@ export const time = {
     now: (): number => {
         if (now === undefined) {
             time.set(
-                frameData.isProcessing ? frameData.timestamp : performance.now()
+                frameData.isProcessing || MotionGlobalConfig.useManualTiming
+                    ? frameData.timestamp
+                    : performance.now()
             )
         }
 

--- a/packages/framer-motion/src/frameloop/sync-time.ts
+++ b/packages/framer-motion/src/frameloop/sync-time.ts
@@ -1,0 +1,32 @@
+import { frameData } from "./frame"
+import { microtask } from "./microtask"
+
+let now: number | undefined
+
+function clearTime() {
+    now = undefined
+}
+
+/**
+ * An eventloop-synchronous alternative to performance.now().
+ *
+ * Ensures that time measurements remain consistent within a synchronous context.
+ * Usually calling performance.now() twice within the same synchronous context
+ * will return different values which isn't useful for animations when we're usually
+ * trying to sync animations to the same frame.
+ */
+export const time = {
+    now: (): number => {
+        if (now === undefined) {
+            time.set(
+                frameData.isProcessing ? frameData.timestamp : performance.now()
+            )
+        }
+
+        return now!
+    },
+    set: (newTime: number) => {
+        now = newTime
+        microtask.postRender(clearTime)
+    },
+}

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -55,6 +55,7 @@ import { animateSingleValue } from "../../animation/interfaces/single-value"
 import { clamp } from "../../utils/clamp"
 import { steps } from "../../frameloop/frame"
 import { noop } from "../../utils/noop"
+import { time } from "../../frameloop/sync-time"
 
 const transformAxes = ["", "X", "Y", "Z"]
 
@@ -644,7 +645,7 @@ export function createProjectionNode<I>({
              * we could leave this to the following requestAnimationFrame but this seems
              * to leave a flash of incorrectly styled content.
              */
-            const now = performance.now()
+            const now = time.now()
             frameData.delta = clamp(0, 1000 / 60, now - frameData.timestamp)
             frameData.timestamp = now
             frameData.isProcessing = true

--- a/packages/framer-motion/src/projection/styles/types.ts
+++ b/packages/framer-motion/src/projection/styles/types.ts
@@ -13,18 +13,3 @@ export interface ScaleCorrectorDefinition {
 export interface ScaleCorrectorMap {
     [key: string]: ScaleCorrectorDefinition
 }
-
-// export type ScaleCorrection = (
-//     latest: string | number,
-//     layoutState: LayoutState,
-//     projection: TargetProjection
-// ) => string | number
-
-// export interface ScaleCorrectionDefinition {
-//     process: ScaleCorrection
-//     applyTo?: string[]
-// }
-
-// export type ScaleCorrectionDefinitionMap = {
-//     [key: string]: ScaleCorrectionDefinition
-// }

--- a/packages/framer-motion/src/utils/GlobalConfig.ts
+++ b/packages/framer-motion/src/utils/GlobalConfig.ts
@@ -1,3 +1,4 @@
 export const MotionGlobalConfig = {
     skipAnimations: false,
+    useManualTiming: false,
 }

--- a/packages/framer-motion/src/utils/delay.ts
+++ b/packages/framer-motion/src/utils/delay.ts
@@ -1,4 +1,5 @@
 import { frame, cancelFrame } from "../frameloop"
+import { time } from "../frameloop/sync-time"
 import { FrameData } from "../frameloop/types"
 
 export type DelayedFunction = (overshoot: number) => void
@@ -7,7 +8,7 @@ export type DelayedFunction = (overshoot: number) => void
  * Timeout defined in ms
  */
 export function delay(callback: DelayedFunction, timeout: number) {
-    const start = performance.now()
+    const start = time.now()
 
     const checkElapsed = ({ timestamp }: FrameData) => {
         const elapsed = timestamp - start

--- a/packages/framer-motion/src/value/__tests__/index.test.ts
+++ b/packages/framer-motion/src/value/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { motionValue } from "../"
 import { animate } from "../../animation/animate"
-import { frame } from "../../frameloop"
+import { frame, frameData } from "../../frameloop"
 
 describe("motionValue", () => {
     test("change event is type-inferred", () => {
@@ -98,5 +98,49 @@ describe("motionValue", () => {
                 resolve()
             })
         })
+    })
+
+    test("Velocity is reported correctly when value and timestamp has changed", () => {
+        const value = motionValue(0)
+
+        frameData.timestamp = 0
+        value.set(0)
+
+        frameData.timestamp = 10
+        value.set(1)
+
+        expect(value.getVelocity()).toEqual(100)
+    })
+
+    test("Velocity is reported correctly when value has changed twice in one frame", () => {
+        const value = motionValue(0)
+
+        frameData.timestamp = 0
+        value.set(0)
+
+        frameData.timestamp = 10
+        value.set(1)
+
+        expect(value.getVelocity()).toEqual(100)
+
+        value.set(2)
+
+        expect(value.getVelocity()).toEqual(200)
+    })
+
+    test("Velocity is reported as zero when time has been too long", () => {
+        const value = motionValue(0)
+
+        frameData.timestamp = 0
+        value.set(0)
+
+        frameData.timestamp = 100
+        value.set(1)
+
+        expect(value.getVelocity()).toEqual(100)
+
+        value.set(2)
+
+        expect(value.getVelocity()).toEqual(200)
     })
 })

--- a/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
@@ -85,7 +85,7 @@ describe("useSpring", () => {
         })
 
         const resolved = await promise
-
+        console.log({ resolved })
         const testNear = (value: number, expected: number, deviation = 2) => {
             expect(
                 value >= expected - deviation && value <= expected + deviation
@@ -93,8 +93,8 @@ describe("useSpring", () => {
         }
 
         testNear(resolved[0], 0)
-        testNear(resolved[4], 8)
-        testNear(resolved[8], 25)
+        testNear(resolved[4], 10)
+        testNear(resolved[8], 30)
     })
 
     test("will not animate if immediate=true", async () => {

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -3,11 +3,14 @@ import * as React from "react"
 import { useVelocity } from "../use-velocity"
 import { useMotionValue } from "../use-motion-value"
 import { animate } from "../../animation/animate"
-import { frame } from "../../frameloop"
+import { frame, steps } from "../../frameloop"
 import { frameData } from "../../frameloop"
 import { useMotionValueEvent } from "../../utils/use-motion-value-event"
 import { mirrorEasing } from "../../easing/modifiers/mirror"
 import { time } from "../../frameloop/sync-time"
+import { MotionGlobalConfig } from "../../utils/GlobalConfig"
+
+MotionGlobalConfig.useManualTiming = true
 
 const setFrameData = (interval: number, newTime: number) => {
     time.set(newTime)
@@ -29,6 +32,7 @@ const syncDriver =
                         elapsed += interval
                         setFrameData(interval, elapsed)
                         update(elapsed)
+                        steps.update.process(frameData)
                     }
                 }, 0)
             },
@@ -45,6 +49,8 @@ describe("useVelocity", () => {
 
         const promise = new Promise((resolve) => {
             const Component = () => {
+                time.set(0)
+
                 const x = useMotionValue(0)
                 const xVelocity = useVelocity(x)
                 const xAcceleration = useVelocity(xVelocity)
@@ -72,13 +78,16 @@ describe("useVelocity", () => {
                              * The more derivatives we have the more frames it'll take for
                              * all values to settle.
                              */
+                            frameData.timestamp = 110
                             frame.postRender(() => {
+                                frameData.timestamp = 120
                                 frame.postRender(() => {
+                                    frameData.timestamp = 130
                                     frame.postRender(() => {
+                                        frameData.timestamp = 140
                                         frame.postRender(() => {
-                                            frame.postRender(() => {
-                                                resolve(undefined)
-                                            })
+                                            frameData.timestamp = 150
+                                            resolve(undefined)
                                         })
                                     })
                                 })

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -7,9 +7,11 @@ import { frame } from "../../frameloop"
 import { frameData } from "../../frameloop"
 import { useMotionValueEvent } from "../../utils/use-motion-value-event"
 import { mirrorEasing } from "../../easing/modifiers/mirror"
+import { time } from "../../frameloop/sync-time"
 
-const setFrameData = (interval: number, time: number) => {
-    frameData.timestamp = time
+const setFrameData = (interval: number, newTime: number) => {
+    time.set(newTime)
+    frameData.timestamp = newTime
     frameData.delta = interval
 }
 

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -58,12 +58,12 @@ describe("useVelocity", () => {
                 useMotionValueEvent(x, "change", (v) =>
                     output.push(Math.round(v))
                 )
-                useMotionValueEvent(xVelocity, "change", (v) =>
+                useMotionValueEvent(xVelocity, "change", (v) => {
                     outputVelocity.push(Math.round(v))
-                )
-                useMotionValueEvent(xAcceleration, "change", (v) =>
+                })
+                useMotionValueEvent(xAcceleration, "change", (v) => {
                     outputAcceleration.push(Math.round(v))
-                )
+                })
 
                 React.useEffect(() => {
                     const animation = animate(x, 1000, {
@@ -79,14 +79,19 @@ describe("useVelocity", () => {
                              * all values to settle.
                              */
                             frameData.timestamp = 110
+                            steps.update.process(frameData)
                             frame.postRender(() => {
                                 frameData.timestamp = 120
+                                steps.update.process(frameData)
                                 frame.postRender(() => {
                                     frameData.timestamp = 130
+                                    steps.update.process(frameData)
                                     frame.postRender(() => {
                                         frameData.timestamp = 140
+                                        steps.update.process(frameData)
                                         frame.postRender(() => {
                                             frameData.timestamp = 150
+                                            steps.update.process(frameData)
                                             resolve(undefined)
                                         })
                                     })

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -71,13 +71,9 @@ describe("useVelocity", () => {
                              * all values to settle.
                              */
                             frame.postRender(() => {
-                                setFrameData(10, 110)
                                 frame.postRender(() => {
-                                    setFrameData(10, 120)
                                     frame.postRender(() => {
-                                        setFrameData(10, 130)
                                         frame.postRender(() => {
-                                            setFrameData(10, 140)
                                             resolve(undefined)
                                         })
                                     })

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -74,7 +74,9 @@ describe("useVelocity", () => {
                                 frame.postRender(() => {
                                     frame.postRender(() => {
                                         frame.postRender(() => {
-                                            resolve(undefined)
+                                            frame.postRender(() => {
+                                                resolve(undefined)
+                                            })
                                         })
                                     })
                                 })

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -30,7 +30,7 @@ export interface MotionValueEventCallbacks<V> {
 }
 
 /**
- * Maxoimum time between the value of two frames, beyond which we
+ * Maximum time between the value of two frames, beyond which we
  * assume the velocity has since been 0.
  */
 const MAX_VELOCITY_DELTA = 30

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -303,7 +303,7 @@ export class MotionValue<V = any> {
         this.current = v
 
         // Update update subscribers
-        if (this.events.change) {
+        if (this.current !== this.prev && this.events.change) {
             this.events.change.notify(this.current)
         }
 

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -303,7 +303,7 @@ export class MotionValue<V = any> {
         this.current = v
 
         // Update update subscribers
-        if (this.prev !== this.current && this.events.change) {
+        if (this.events.change) {
             this.events.change.notify(this.current)
         }
 

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -323,13 +323,10 @@ export class MotionValue<V = any> {
      * @public
      */
     getVelocity() {
-        console.log("can track velocity", this.canTrackVelocity)
         if (!this.canTrackVelocity) return 0
 
-        console.log("updated at", this.prevUpdatedAt, this.currentUpdatedAt)
         if (this.prevUpdatedAt === this.currentUpdatedAt) return 0
 
-        console.log("framestamp", frameData.timestamp)
         // TODO This will result in the wrong velocity if read before
         // the update part of the render loop.
         if (this.currentUpdatedAt !== frameData.timestamp) return 0

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -92,7 +92,7 @@ export class MotionValue<V = any> {
     /**
      * The last time the `MotionValue` was updated.
      */
-    private updatedAt: number
+    private updatedAt: number | undefined
 
     /**
      * The time `prevFrameValue` was updated.
@@ -269,7 +269,7 @@ export class MotionValue<V = any> {
     setWithVelocity(prev: V, current: V, delta: number) {
         this.set(current)
         this.prev = prev
-        this.prevUpdatedAt = this.updatedAt - delta
+        this.prevUpdatedAt = this.updatedAt! - delta
     }
 
     /**
@@ -348,6 +348,7 @@ export class MotionValue<V = any> {
         if (
             !this.canTrackVelocity ||
             this.prevFrameValue === undefined ||
+            this.updatedAt === undefined ||
             currentTime - this.updatedAt > MAX_VELOCITY_DELTA
         ) {
             return 0

--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -53,6 +53,8 @@ export function useSpring(
 
             stopAnimation()
 
+            console.log("reading value as ", value.getVelocity())
+
             activeSpringAnimation.current = animateValue({
                 keyframes: [value.get(), v],
                 velocity: value.getVelocity(),

--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -10,7 +10,6 @@ import {
     animateValue,
 } from "../animation/animators/js"
 import { frameData } from "../frameloop"
-import { millisecondsToSeconds } from "../utils/time-conversion"
 
 /**
  * Creates a `MotionValue` that, when `set`, will use a spring animation to animate to its new state.
@@ -58,14 +57,11 @@ export function useSpring(
              * If the previous animation hasn't had the chance to even render a frame, render it now.
              */
             const animation = activeSpringAnimation.current
-            // TODO Actually measure time from previous frame
             if (animation && animation.time === 0) {
                 animation.sample(frameData.delta)
             }
 
             stopAnimation()
-
-            console.log("reading value as ", value.get(), value.getVelocity())
 
             activeSpringAnimation.current = animateValue({
                 keyframes: [value.get(), v],

--- a/packages/framer-motion/src/value/use-velocity.ts
+++ b/packages/framer-motion/src/value/use-velocity.ts
@@ -1,4 +1,5 @@
 import { MotionValue } from "."
+import { frame } from "../frameloop"
 import { useMotionValueEvent } from "../utils/use-motion-value-event"
 import { useMotionValue } from "./use-motion-value"
 /**
@@ -15,8 +16,13 @@ import { useMotionValue } from "./use-motion-value"
 export function useVelocity(value: MotionValue<number>): MotionValue<number> {
     const velocity = useMotionValue(value.getVelocity())
 
-    useMotionValueEvent(value, "velocityChange", (newVelocity) => {
-        velocity.set(newVelocity)
+    const updateVelocity = () => {
+        velocity.set(value.getVelocity())
+    }
+
+    useMotionValueEvent(value, "change", () => {
+        updateVelocity()
+        frame.update(updateVelocity)
     })
 
     return velocity

--- a/packages/framer-motion/src/value/use-velocity.ts
+++ b/packages/framer-motion/src/value/use-velocity.ts
@@ -17,16 +17,15 @@ export function useVelocity(value: MotionValue<number>): MotionValue<number> {
     const velocity = useMotionValue(value.getVelocity())
 
     const updateVelocity = () => {
-        velocity.set(value.getVelocity())
+        const latest = value.getVelocity()
+        velocity.set(latest)
+
+        if (latest) frame.update(updateVelocity)
     }
 
     useMotionValueEvent(value, "change", () => {
         // Schedule an update to this value at the end of the current frame.
         frame.update(updateVelocity, false, true)
-
-        // Schedule an update for the following frame in case the tracked
-        // value doesn't update.
-        frame.update(updateVelocity)
     })
 
     return velocity

--- a/packages/framer-motion/src/value/use-velocity.ts
+++ b/packages/framer-motion/src/value/use-velocity.ts
@@ -21,7 +21,11 @@ export function useVelocity(value: MotionValue<number>): MotionValue<number> {
     }
 
     useMotionValueEvent(value, "change", () => {
-        updateVelocity()
+        // Schedule an update to this value at the end of the current frame.
+        frame.update(updateVelocity, false, true)
+
+        // Schedule an update for the following frame in case the tracked
+        // value doesn't update.
         frame.update(updateVelocity)
     })
 

--- a/packages/framer-motion/src/value/use-velocity.ts
+++ b/packages/framer-motion/src/value/use-velocity.ts
@@ -20,6 +20,10 @@ export function useVelocity(value: MotionValue<number>): MotionValue<number> {
         const latest = value.getVelocity()
         velocity.set(latest)
 
+        /**
+         * If we still have velocity, schedule an update for the next frame
+         * to keep checking until it is zero.
+         */
         if (latest) frame.update(updateVelocity)
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7993,8 +7993,8 @@ __metadata:
     cache-loader: ^1.2.5
     convert-tsconfig-paths-to-webpack-aliases: ^0.9.2
     fork-ts-checker-webpack-plugin: ^6.2.0
-    framer-motion: ^10.18.0
-    framer-motion-3d: ^10.18.0
+    framer-motion: ^11.0.0-alpha.2
+    framer-motion-3d: ^11.0.0-alpha.2
     path-browserify: ^1.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -8060,14 +8060,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion-3d@^10.18.0, framer-motion-3d@workspace:packages/framer-motion-3d":
+"framer-motion-3d@^11.0.0-alpha.2, framer-motion-3d@workspace:packages/framer-motion-3d":
   version: 0.0.0-use.local
   resolution: "framer-motion-3d@workspace:packages/framer-motion-3d"
   dependencies:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^10.18.0
+    framer-motion: ^11.0.0-alpha.2
     react-merge-refs: ^2.0.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
@@ -8077,7 +8077,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^10.18.0, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^11.0.0-alpha.2, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/2088

Replaces the current velocity calculation strategy with a passive approach.

Before, velocity was semi-naive and semi-actively calculated.

By semi-naive, I mean that values were pushed from `current` to `prev` with no concept of when they were produced. The most recent animation frame delta was used to calculate the velocity between the two values.

Take this:

```javascript
const x = motionValue(0)
x.set(1)
x.set(2)
```

The delta of this would likely be calculated as (2 - 1) with a time delta of 16ms.

But as this value was updated within synchronous code, conceptually there is no time delta. The velocity should be 0. (The alternative being using performance.now() for infinitesimally small time deltas - useless for any practical application)

By semi-active, I mean that although velocity itself was only calculated when `getVelocity` was called, consider this code:

```javascript
const x = motionValue(0)

requestAnimationFrame(() => x.set(1))
```

Querying velocity would return the correct velocity. But by calling `set`, we previously called a job (which scheduled another job) to run at the end of the following frame to replace `prev` with `current`, so that after a long enough time the delta would be (1 - 1) and the velocity would be correctly zero.

This active process actually adds a lot of overhead to animations, removing it increases "best-case" (linear easing, numerical interpolation) animation speed by 2x.

Instead we now maintain an `updatedAt` timestamp. `prevFrameValue` now stores the value of `current` at the end of the previous frame along with another timestamp. These timestamps are used to calculated velocity. A time delta larger than 30ms is considered too long and velocity is `0`.

Additionally we have replaced `performance.now()` in some instances with `time.now()`. `time` is a new eventloop-synchronous timer that ensures one time is used for a block of synchronous code. If a value is updated multiple times within the same block of synchronous code, only the latest value is used to calculate velocity.