### PR TITLE
[BUG] Nextjs Build runtime error due to undefined navigator

### DIFF
--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -2108,7 +2108,7 @@ const defaultLayoutTransition = {
 }
 
 const userAgentContains = (string: string) =>
-    typeof navigator !== "undefined" &&
+    typeof window !== "undefined" &&
     navigator.userAgent.toLowerCase().includes(string)
 
 /**


### PR DESCRIPTION
#### 1. reference issue: https://github.com/vercel/next.js/issues/57183
####  2. Describe the bug
While building a Next.js project, I encountered the issue linked above, which prevented a successful build. This commit addresses a bug where the ‘navigator’ object was being accessed in a non-browser environment, leading to an error. The solution implemented is to replace ‘navigator’ with ‘window’, which is more universally supported across different JavaScript environments. I believe this change will help prevent similar errors in the future and enhance the robustness of the code.
#### 3. Steps to reproduce
Just build a nextjs project with framer-motion as its dependency. the bug prevents building nextjs project.
#### 4. Expected behavior
when running 'npm run build' the nextjs project have to build successfully
#### 5. screenshot
![framer-motion-bug](https://github.com/framer/motion/assets/42533280/dfa1880a-2e30-46af-bbf8-31f639810598)
#### 6. Environment details
windows 10, node v21.0.0, nextjs14