### PR TITLE
Fix CSS variable regex performance

### DIFF
--- a/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
+++ b/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
@@ -10,8 +10,16 @@ const checkStringStartsWith =
 export const isCSSVariableName = checkStringStartsWith<CSSVariableName>("--")
 
 const startsAsVariableToken = checkStringStartsWith<CSSVariableToken>("var(--")
-export const isCSSVariableToken = (key?: string): key is CSSVariableToken =>
-    startsAsVariableToken(key) && singleCssVariableRegex.test(key)
+export const isCSSVariableToken = (
+    value?: string
+): value is CSSVariableToken => {
+    const startsWithToken = startsAsVariableToken(value)
+
+    if (!startsWithToken) return false
+
+    // Ensure any comments are stripped from the value as this can harm performance of the regex.
+    return singleCssVariableRegex.test(value.split("/*")[0])
+}
 
 export const cssVariableRegex =
     /var\s*\(\s*--[\w-]+(\s*,\s*(?:(?:[^)(]|\((?:[^)(]+|\([^)(]*\))*\))*)+)?\s*\)/g

--- a/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
+++ b/packages/framer-motion/src/render/dom/utils/is-css-variable.ts
@@ -21,7 +21,5 @@ export const isCSSVariableToken = (
     return singleCssVariableRegex.test(value.split("/*")[0])
 }
 
-export const cssVariableRegex =
-    /var\s*\(\s*--[\w-]+(\s*,\s*(?:(?:[^)(]|\((?:[^)(]+|\([^)(]*\))*\))*)+)?\s*\)/g
 const singleCssVariableRegex =
     /var\s*\(\s*--[\w-]+(\s*,\s*(?:(?:[^)(]|\((?:[^)(]+|\([^)(]*\))*\))*)+)?\s*\)$/i


### PR DESCRIPTION
Surprising values can cause a catastrophic degredation in performance of this regex

```
var(--token-31a8b72b-4f05-4fb3-b778-63a7fb0d9454, hsl(224, 78%, 54%)) /* {"name":"Midnight Blue"} */
// ~5ms

var(--token-c534b380-e14e-4ddc-9802-ad88d1f94f8e, rgba(255, 255, 255, 0.12)) /* {"name":"Border Night"} */
// ~500ms
```

This PR trims strings of comments and brings execution time reliably down to ~0ms.