### PR TITLE
add: content-security-policy nonce support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.0.9] 2024-03-05
+
+### Added
+
+-   Added support for Content Security Policy (CSP) nonces.
+
 ## [11.0.8] 2024-02-29
 
 ### Fixed

--- a/dev/examples/MotionConfig-nonce.tsx
+++ b/dev/examples/MotionConfig-nonce.tsx
@@ -1,0 +1,71 @@
+import * as React from "react"
+import { motion, MotionConfig, AnimatePresence } from "framer-motion"
+
+/**
+ * An example of a nonce prop on MotionConfig
+ */
+
+const styleA = {
+    width: 100,
+    height: 100,
+    background: "white",
+    borderRadius: 20,
+}
+
+const styleB = {
+    width: 100,
+    height: 100,
+    background: "blue",
+    borderRadius: 20,
+}
+
+export const App = () => {
+    const [toggle, setToggle] = React.useState(false)
+
+    return (
+        <MotionConfig nonce="abc123">
+            <AnimatePresence mode="popLayout">
+                {toggle ? (
+                    <motion.div
+                        key="a"
+                        initial={{
+                            opacity: 0,
+                        }}
+                        animate={{
+                            opacity: 1,
+                        }}
+                        exit={{
+                            opacity: 0,
+                        }}
+                        transition={{
+                            duration: 1,
+                        }}
+                        style={styleA}
+                    >
+                        A
+                    </motion.div>
+                ) : (
+                    <motion.div
+                        key="b"
+                        initial={{
+                            opacity: 0,
+                        }}
+                        animate={{
+                            opacity: 1,
+                        }}
+                        exit={{
+                            opacity: 0,
+                        }}
+                        transition={{
+                            duration: 1,
+                        }}
+                        style={styleB}
+                    >
+                        B
+                    </motion.div>
+                )}
+            </AnimatePresence>
+            <button onClick={() => setToggle((prev) => !prev)}>Switch</button>
+        </MotionConfig>
+    )
+}

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
-import { useRef, useInsertionEffect, useId } from "react"
+import { useRef, useInsertionEffect, useId, useContext } from "react"
+
+import { MotionConfigContext } from "context/MotionConfigContext"
 
 interface Size {
     width: number
@@ -55,6 +57,7 @@ export function PopChild({ children, isPresent }: Props) {
         top: 0,
         left: 0,
     })
+    const { nonce } = useContext(MotionConfigContext)
 
     /**
      * We create and inject a style block so we can apply this explicit
@@ -72,6 +75,7 @@ export function PopChild({ children, isPresent }: Props) {
         ref.current.dataset.motionPopId = id
 
         const style = document.createElement("style")
+        if (nonce) style.nonce = nonce
         document.head.appendChild(style)
         if (style.sheet) {
             style.sheet.insertRule(`

--- a/packages/framer-motion/src/context/MotionConfigContext.tsx
+++ b/packages/framer-motion/src/context/MotionConfigContext.tsx
@@ -33,6 +33,15 @@ export interface MotionConfigContext {
      * @public
      */
     reducedMotion?: ReducedMotionConfig
+
+    /**
+     * A custom `nonce` attribute used when wanting to enforce a Content Security Policy (CSP).
+     * For more details see:
+     * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles
+     *
+     * @public
+     */
+    nonce?: string
 }
 
 /**


### PR DESCRIPTION
this PR adds support for [content-security-policy style nonces](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles)

fixes: https://github.com/framer/motion/issues/1727 https://github.com/framer/motion/discussions/2406

---

**use case:**

when a content security policy (CSP) is set up to require a nonce, all `style` tags within the document should also include the matching generated nonce.

this primarily has issues when using `<AnimatePresence>` as `PopChild` appends a `<style>` tag to the dom.

---
**example:**

if a CSP was set up with the following policy with a generated nonce:
```
Content-Security-Policy: style-src 'nonce-2726c7f26c'
```

all `style` tags within the document should also include the the matching generated nonce:
```html
<style nonce="2726c7f26c">
  .el {
    background: red;
  }
</style>
```

---

**proposed usage:**

given that the `MotionConfig` component is the only context provider in the library, it would be the only place where the nonce could currently be set.

the `nonce` prop can be added to the `MotionConfig` component to allow the `motion` components to use the nonce.

```jsx
import { MotionConfig } from "framer-motion";

<MotionConfig nonce="2726c7f26c">
  <motion.div animate={{ x: 100 }} />
</MotionConfig>
```

the [MotionConfig documentation](https://www.framer.com/motion/motion-config/) should also be updated to include this new option.