### PR TITLE
Fixing layout projection with `motion(Fragment)` nodes

### DIFF
--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -46,6 +46,20 @@ import { visualElementStore } from "./store"
 const featureNames = Object.keys(featureDefinitions)
 const numFeatures = featureNames.length
 
+function getClosestProjectingNode(
+    visualElement?: VisualElement<
+        unknown,
+        unknown,
+        { allowProjection?: boolean }
+    >
+): IProjectionNode | undefined {
+    if (!visualElement) return undefined
+
+    return visualElement.options.allowProjection
+        ? visualElement.projection
+        : getClosestProjectingNode(visualElement.parent)
+}
+
 const propEventHandlers = [
     "AnimationStart",
     "AnimationComplete",
@@ -265,7 +279,7 @@ export abstract class VisualElement<
      * The options used to create this VisualElement. The Options type is defined
      * by the inheriting VisualElement and is passed straight through to the render functions.
      */
-    private readonly options: Options
+    readonly options: Options
 
     /**
      * A reference to the latest props provided to the VisualElement's host React component.
@@ -542,7 +556,7 @@ export abstract class VisualElement<
         ) {
             this.projection = new ProjectionNodeConstructor(
                 this.latestValues,
-                this.parent && this.parent.projection
+                getClosestProjectingNode(this.parent)
             ) as IProjectionNode
 
             const {

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -55,7 +55,7 @@ function getClosestProjectingNode(
 ): IProjectionNode | undefined {
     if (!visualElement) return undefined
 
-    return visualElement.options.allowProjection
+    return visualElement.options.allowProjection !== false
         ? visualElement.projection
         : getClosestProjectingNode(visualElement.parent)
 }

--- a/packages/framer-motion/src/render/dom/create-visual-element.ts
+++ b/packages/framer-motion/src/render/dom/create-visual-element.ts
@@ -3,6 +3,7 @@ import { HTMLVisualElement } from "../html/HTMLVisualElement"
 import { SVGVisualElement } from "../svg/SVGVisualElement"
 import { CreateVisualElement, VisualElementOptions } from "../types"
 import { isSVGComponent } from "./utils/is-svg-component"
+import React from "react"
 
 export const createDomVisualElement: CreateVisualElement<
     HTMLElement | SVGElement
@@ -12,5 +13,8 @@ export const createDomVisualElement: CreateVisualElement<
 ) => {
     return isSVGComponent(Component)
         ? new SVGVisualElement(options, { enableHardwareAcceleration: false })
-        : new HTMLVisualElement(options, { enableHardwareAcceleration: true })
+        : new HTMLVisualElement(options, {
+              enableHardwareAcceleration: true,
+              allowProjection: Component !== React.Fragment,
+          })
 }

--- a/packages/framer-motion/src/render/dom/types.ts
+++ b/packages/framer-motion/src/render/dom/types.ts
@@ -21,6 +21,13 @@ export interface DOMVisualElementOptions {
     allowTransformNone?: boolean
 
     /**
+     * If `true`, this element will be included in the projection tree.
+     *
+     * @public
+     */
+    allowProjection?: boolean
+
+    /**
      * Allow this element to be GPU-accelerated. We currently enable this by
      * adding a `translateZ(0)`.
      *

--- a/packages/framer-motion/src/render/dom/types.ts
+++ b/packages/framer-motion/src/render/dom/types.ts
@@ -23,6 +23,8 @@ export interface DOMVisualElementOptions {
     /**
      * If `true`, this element will be included in the projection tree.
      *
+     * Default: `true`
+     *
      * @public
      */
     allowProjection?: boolean


### PR DESCRIPTION
This PR skips adding `motion(Fragment)` nodes to the layout projection tree.

We added these nodes to allow animating variants via a renderless component rather than being bound to a `div` etc (@adamseckel has more context)

The problem with these nodes is layout animation scale correction is presumed to be performed by a child node, thus these nodes were swallowing the scale corrective calculations.