### PR TITLE
Change scheduling of `useTransform`

### DIFF
--- a/packages/framer-motion/src/value/use-combine-values.ts
+++ b/packages/framer-motion/src/value/use-combine-values.ts
@@ -31,7 +31,7 @@ export function useCombineMotionValues<R>(
      * schedule an update.
      */
     useIsomorphicLayoutEffect(() => {
-        const scheduleUpdate = () => frame.update(updateValue, false, true)
+        const scheduleUpdate = () => frame.preRender(updateValue, false, true)
         const subscriptions = values.map((v) => v.on("change", scheduleUpdate))
 
         return () => {


### PR DESCRIPTION
This PR ensures `useTransform` computations happen after the "update" stage of the render loop.