### PR TITLE
feat: use modern jsx transform

### DIFF
--- a/dev/examples/AnimatePresence-image-gallery.tsx
+++ b/dev/examples/AnimatePresence-image-gallery.tsx
@@ -1,5 +1,4 @@
 import { motion, AnimatePresence, wrap } from "framer-motion"
-import * as React from "react"
 import { useState } from "react"
 
 /**

--- a/dev/examples/AnimatePresence-layout-animations-siblings.tsx
+++ b/dev/examples/AnimatePresence-layout-animations-siblings.tsx
@@ -1,6 +1,5 @@
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion"
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 
 /**
  * An example of an AnimatePresence child animating in and out with shared layout
@@ -33,7 +32,7 @@ function ExitComponent() {
 export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         setTimeout(() => {
             setVisible(!isVisible)
         }, 3000)

--- a/dev/examples/AnimatePresence-notifications-list-pop.tsx
+++ b/dev/examples/AnimatePresence-notifications-list-pop.tsx
@@ -1,8 +1,7 @@
-import * as React from "react"
-import { useState } from "react"
+import { forwardRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion"
 
-const Notification = React.forwardRef(function (
+const Notification = forwardRef(function (
     { id, notifications, setNotifications, style },
     ref
 ) {

--- a/dev/examples/AnimatePresence-notifications-list.tsx
+++ b/dev/examples/AnimatePresence-notifications-list.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 

--- a/dev/examples/AnimatePresence-parallel-children.tsx
+++ b/dev/examples/AnimatePresence-parallel-children.tsx
@@ -1,6 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 
 /**
  * An example of three top-level AnimatePresence children controlling the exit of a single
@@ -17,7 +16,7 @@ const style = {
 export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         setTimeout(() => {
             setVisible(!isVisible)
         }, 3000)

--- a/dev/examples/AnimatePresence-siblings.tsx
+++ b/dev/examples/AnimatePresence-siblings.tsx
@@ -1,5 +1,4 @@
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion"
-import * as React from "react"
 import { useState } from "react"
 
 /**

--- a/dev/examples/AnimatePresence-variants.tsx
+++ b/dev/examples/AnimatePresence-variants.tsx
@@ -1,6 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 
 /**
  * An example of AnimatePresence with exit defined as a variant through a tree.
@@ -42,7 +41,7 @@ const listVariants = {
 export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         setTimeout(() => {
             setVisible(!isVisible)
         }, 3000)

--- a/dev/examples/AnimatePresence.tsx
+++ b/dev/examples/AnimatePresence.tsx
@@ -1,6 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 
 /**
  * An example of a single-child AnimatePresence animation
@@ -16,7 +15,7 @@ const style = {
 export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         setTimeout(() => {
             setVisible(!isVisible)
         }, 1500)

--- a/dev/examples/Animation-CSS-variables.tsx
+++ b/dev/examples/Animation-CSS-variables.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { useEffect } from "react"
+import { useRef, useEffect } from "react";
 import { motion } from "framer-motion"
 
 /**
@@ -20,7 +19,7 @@ export const App = () => {
         duration: 1,
     }
 
-    const ref = React.useRef<HTMLDivElement>(null)
+    const ref = useRef<HTMLDivElement>(null)
     useEffect(() => {
         function changeToVar() {
             ref.current.style.setProperty("--to", "cyan")

--- a/dev/examples/Animation-animate.tsx
+++ b/dev/examples/Animation-animate.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useState } from "react"
 import { motion, motionValue, useAnimate } from "framer-motion"
 import { frame } from "framer-motion"

--- a/dev/examples/Animation-batch-read-writes.tsx
+++ b/dev/examples/Animation-batch-read-writes.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { MotionConfig, motion } from "framer-motion"
 
 const style = {

--- a/dev/examples/Animation-between-value-types-x.tsx
+++ b/dev/examples/Animation-between-value-types-x.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-boxShadow.tsx
+++ b/dev/examples/Animation-boxShadow.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-cleanup.tsx
+++ b/dev/examples/Animation-cleanup.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion } from "framer-motion"
 
 export const App = () => {
-    const [open, setOpen] = React.useState(true)
+    const [open, setOpen] = useState(true)
     return (
         <div>
             {open && (

--- a/dev/examples/Animation-filter.tsx
+++ b/dev/examples/Animation-filter.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-height-auto-display-none.tsx
+++ b/dev/examples/Animation-height-auto-display-none.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { mix, motion } from "framer-motion"
 

--- a/dev/examples/Animation-height-auto-padding.tsx
+++ b/dev/examples/Animation-height-auto-padding.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 

--- a/dev/examples/Animation-height-auto-rotate-scale.tsx
+++ b/dev/examples/Animation-height-auto-rotate-scale.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, mix } from "framer-motion"
 

--- a/dev/examples/Animation-keyframes.tsx
+++ b/dev/examples/Animation-keyframes.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-layout-delay-children.tsx
+++ b/dev/examples/Animation-layout-delay-children.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 export const App = () => {

--- a/dev/examples/Animation-layout-nested-position.tsx
+++ b/dev/examples/Animation-layout-nested-position.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-layout-scale-correction.tsx
+++ b/dev/examples/Animation-layout-scale-correction.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion"
 import styled from "styled-components"
 
@@ -12,7 +11,7 @@ export const App = () => {
     const [isOn, setIsOn] = useState(false)
 
     // Double render to ensure it doesn't matter if we trigger a animate transition mid-animation
-    React.useEffect(() => {
+    useEffect(() => {
         isOn && setTimeout(() => setIsOn(isOn), 500)
     }, [isOn])
 

--- a/dev/examples/Animation-layout-seperate-children.tsx
+++ b/dev/examples/Animation-layout-seperate-children.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Animation-layout-size.tsx
+++ b/dev/examples/Animation-layout-size.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-layout-text-size.tsx
+++ b/dev/examples/Animation-layout-text-size.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/Animation-layout-transform-template.tsx
+++ b/dev/examples/Animation-layout-transform-template.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 import styled from "styled-components"

--- a/dev/examples/Animation-layout-update-stress.tsx
+++ b/dev/examples/Animation-layout-update-stress.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/Animation-repeat-spring.tsx
+++ b/dev/examples/Animation-repeat-spring.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-reverse.tsx
+++ b/dev/examples/Animation-reverse.tsx
@@ -1,5 +1,4 @@
 import { useAnimate } from "framer-motion"
-import * as React from "react"
 
 export const App = () => {
     const [scope, animate] = useAnimate()

--- a/dev/examples/Animation-stagger-custom.tsx
+++ b/dev/examples/Animation-stagger-custom.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState, useEffect } from "react";
 import { useAnimation, distance2D, wrap } from "framer-motion"
 import { motion } from "framer-motion"
 
@@ -12,7 +12,7 @@ const stagger = 0.1
 let interval
 
 export const App = () => {
-    const [center, setCenter] = React.useState({ x: len / 2, y: len / 2 })
+    const [center, setCenter] = useState({ x: len / 2, y: len / 2 })
 
     const cells = Array.from(Array(count).keys()).map((i) => {
         return (
@@ -74,7 +74,7 @@ const Cell = ({ center, i, onClick }) => {
         })
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         animate()
     })
 

--- a/dev/examples/Animation-stress-mount.tsx
+++ b/dev/examples/Animation-stress-mount.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Animation-transition-tween.tsx
+++ b/dev/examples/Animation-transition-tween.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Animation-variants.tsx
+++ b/dev/examples/Animation-variants.tsx
@@ -1,11 +1,11 @@
-import React from "react"
+import { Fragment, useState } from "react";
 import { motion, useMotionValue } from "framer-motion"
 
-const MotionFragment = motion(React.Fragment)
+const MotionFragment = motion(Fragment)
 
 export function App() {
     const backgroundColor = useMotionValue("#f00")
-    const [isActive, setIsActive] = React.useState(true)
+    const [isActive, setIsActive] = useState(true)
     return (
         <MotionFragment initial="initial" animate={isActive ? "to" : "initial"}>
             <motion.div>

--- a/dev/examples/Benchmark-cold-start-gsap.tsx
+++ b/dev/examples/Benchmark-cold-start-gsap.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useRef } from "react";
 import gsap from "gsap"
 import { useGSAP } from "@gsap/react"
 
@@ -26,7 +26,7 @@ const boxContainer = {
 const num = 100
 
 function Box() {
-    const ref = React.useRef(null)
+    const ref = useRef(null)
 
     useGSAP(
         () => {

--- a/dev/examples/Benchmark-cold-start-motion.tsx
+++ b/dev/examples/Benchmark-cold-start-motion.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Drag-SharedLayout.tsx
+++ b/dev/examples/Drag-SharedLayout.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { useState, useRef } from "react"
+import { useEffect, useState, useRef } from "react";
 import { motion } from "framer-motion"
 import styled from "styled-components"
 
@@ -68,7 +67,7 @@ function DragDrop() {
     const viewportWidth = useRef(0)
     const [is, setIs] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         viewportWidth.current = window.innerWidth
     }, [])
 

--- a/dev/examples/Drag-block-viewport-conditionally.tsx
+++ b/dev/examples/Drag-block-viewport-conditionally.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/Drag-constraints-ref-small-container-layout.tsx
+++ b/dev/examples/Drag-constraints-ref-small-container-layout.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Drag-constraints-ref-small-container.tsx
+++ b/dev/examples/Drag-constraints-ref-small-container.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Drag-constraints-ref.tsx
+++ b/dev/examples/Drag-constraints-ref.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef, useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Drag-constraints-relative.tsx
+++ b/dev/examples/Drag-constraints-relative.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/Drag-constraints-resize.tsx
+++ b/dev/examples/Drag-constraints-resize.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState, useEffect } from "react";
 import { motion } from "framer-motion"
 
 const styleA = {
@@ -8,8 +8,8 @@ const styleA = {
 }
 
 export function App() {
-    const [backgroundColor, setBackgroundColor] = React.useState("darkgray")
-    React.useEffect(() => {
+    const [backgroundColor, setBackgroundColor] = useState("darkgray")
+    useEffect(() => {
         const listener = () => {
             // The re-render will have updateBlockedByResize as true and cause clearMeasurements() to be called.
             setBackgroundColor("pink")

--- a/dev/examples/Drag-draggable.tsx
+++ b/dev/examples/Drag-draggable.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState, useRef, useEffect } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Drag-nested.tsx
+++ b/dev/examples/Drag-nested.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const scroll = {

--- a/dev/examples/Drag-svg.tsx
+++ b/dev/examples/Drag-svg.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 export const App = () => {

--- a/dev/examples/Drag-to-reorder.tsx
+++ b/dev/examples/Drag-to-reorder.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useState } from "react"
 import { Reorder, useMotionValue, animate } from "framer-motion"
 

--- a/dev/examples/Drag-useDragControls-snapToCursor.tsx
+++ b/dev/examples/Drag-useDragControls-snapToCursor.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useDragControls } from "framer-motion"
 
 /**

--- a/dev/examples/Drag-useDragControls.tsx
+++ b/dev/examples/Drag-useDragControls.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useDragControls } from "framer-motion"
 
 /**

--- a/dev/examples/Events-onTap.tsx
+++ b/dev/examples/Events-onTap.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Events-pan.tsx
+++ b/dev/examples/Events-pan.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/Events-whileFocus-variants.tsx
+++ b/dev/examples/Events-whileFocus-variants.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Events-whileFocus.tsx
+++ b/dev/examples/Events-whileFocus.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Events-whileHover-unit-conversion.tsx
+++ b/dev/examples/Events-whileHover-unit-conversion.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/Events-whileHover.tsx
+++ b/dev/examples/Events-whileHover.tsx
@@ -1,8 +1,8 @@
-import React from "react"
+import { useState } from "react";
 import { motion } from "framer-motion"
 
 export function App() {
-    const [scale, setScale] = React.useState(2)
+    const [scale, setScale] = useState(2)
     return (
         <motion.div
             whileHover={{

--- a/dev/examples/Events-whileTap-cancel-on-scroll.tsx
+++ b/dev/examples/Events-whileTap-cancel-on-scroll.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/Events-whileTap-global.tsx
+++ b/dev/examples/Events-whileTap-global.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const style = {

--- a/dev/examples/Events-whileTap-variants.tsx
+++ b/dev/examples/Events-whileTap-variants.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef, useState } from "react"
 import { motion, useAnimation } from "framer-motion"
 import { useMotionValue } from "framer-motion"

--- a/dev/examples/Events-whileTap.tsx
+++ b/dev/examples/Events-whileTap.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const style = {

--- a/dev/examples/Layout-Projection-correct-style-border-radius.tsx
+++ b/dev/examples/Layout-Projection-correct-style-border-radius.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-Projection-custom-values.tsx
+++ b/dev/examples/Layout-Projection-custom-values.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 import { mix, motion, addScaleCorrector } from "framer-motion"
 import styled from "styled-components"
 
@@ -45,7 +44,7 @@ const border = {
 export const App = () => {
     const [isOn, setOn] = useState(false)
 
-    React.useEffect(() => {
+    useEffect(() => {
         addScaleCorrector(border)
     }, [])
 

--- a/dev/examples/Layout-Projection-scale-correction-border-radius.tsx
+++ b/dev/examples/Layout-Projection-scale-correction-border-radius.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-Projection-scale-correction-shadow.tsx
+++ b/dev/examples/Layout-Projection-scale-correction-shadow.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-Projection-scale-position.tsx
+++ b/dev/examples/Layout-Projection-scale-position.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-Projection-scale-size.tsx
+++ b/dev/examples/Layout-Projection-scale-size.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-SVG.tsx
+++ b/dev/examples/Layout-SVG.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-rotate.tsx
+++ b/dev/examples/Layout-rotate.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/Layout-skew.tsx
+++ b/dev/examples/Layout-skew.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/LazyMotion-async.tsx
+++ b/dev/examples/LazyMotion-async.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
+import { memo, useEffect, useState } from "react";
 import { m, LazyMotion, domAnimation } from "framer-motion"
-import { useEffect, useState } from "react"
 
 /**
  * An example of dynamically loading features from a different entry point.
@@ -14,7 +13,7 @@ const style = {
     borderRadius: 20,
 }
 
-const Component = React.memo(() => {
+const Component = memo(() => {
     return (
         <m.div
             animate={{

--- a/dev/examples/LazyMotion-sync.tsx
+++ b/dev/examples/LazyMotion-sync.tsx
@@ -1,6 +1,5 @@
-import * as React from "react"
+import { memo, useEffect, useState } from "react";
 import { m, LazyMotion, domAnimation } from "framer-motion"
-import { useEffect, useState } from "react"
 
 /**
  * An example of dynamically loading features from a different entry point.
@@ -14,7 +13,7 @@ const style = {
     borderRadius: 20,
 }
 
-const Component = React.memo(() => {
+const Component = memo(() => {
     return (
         <m.div
             animate={{

--- a/dev/examples/MotionConfig-isStatic.tsx
+++ b/dev/examples/MotionConfig-isStatic.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, MotionConfig } from "framer-motion"
 
 /**

--- a/dev/examples/MotionConfig-nonce.tsx
+++ b/dev/examples/MotionConfig-nonce.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion, MotionConfig, AnimatePresence } from "framer-motion"
 
 /**
@@ -20,7 +20,7 @@ const styleB = {
 }
 
 export const App = () => {
-    const [toggle, setToggle] = React.useState(false)
+    const [toggle, setToggle] = useState(false)
 
     return (
         <MotionConfig nonce="abc123">

--- a/dev/examples/Prop-ref.tsx
+++ b/dev/examples/Prop-ref.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion"
-import * as React from "react"
 import { useRef, useLayoutEffect, useEffect } from "react"
 
 /**

--- a/dev/examples/Prop-style.tsx
+++ b/dev/examples/Prop-style.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/examples/SVG-MotionValue.tsx
+++ b/dev/examples/SVG-MotionValue.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useMotionValue, useTransform } from "framer-motion"
 
 /**

--- a/dev/examples/SVG-path.tsx
+++ b/dev/examples/SVG-path.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, useMotionValue, useTransform } from "framer-motion"
 

--- a/dev/examples/SVG-transform.tsx
+++ b/dev/examples/SVG-transform.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 export const App = () => {

--- a/dev/examples/SVG-without-initial-values.tsx
+++ b/dev/examples/SVG-without-initial-values.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useCallback } from "react"
 import { motion, useAnimation } from "framer-motion"
 

--- a/dev/examples/Shared-layout-continuity-crossfade.tsx
+++ b/dev/examples/Shared-layout-continuity-crossfade.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle, AnimatePresence } from "framer-motion"
 
 /**

--- a/dev/examples/Shared-layout-continuity.tsx
+++ b/dev/examples/Shared-layout-continuity.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/examples/Shared-layout-lightbox-crossfade.tsx
+++ b/dev/examples/Shared-layout-lightbox-crossfade.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { CSSProperties, useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 

--- a/dev/examples/Shared-layout-lightbox.tsx
+++ b/dev/examples/Shared-layout-lightbox.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { CSSProperties, useState } from "react"
 import {
     motion,

--- a/dev/examples/Shared-layout-lists.tsx
+++ b/dev/examples/Shared-layout-lists.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion"
 

--- a/dev/examples/Shared-layout-nested-inset-elements-no-layout.tsx
+++ b/dev/examples/Shared-layout-nested-inset-elements-no-layout.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle, AnimatePresence } from "framer-motion"
 
 export const App = () => {

--- a/dev/examples/Shared-layout-nested-inset-elements.tsx
+++ b/dev/examples/Shared-layout-nested-inset-elements.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle, AnimatePresence } from "framer-motion"
 
 export const App = () => {

--- a/dev/examples/Shared-layout-reparenting-transform-template.tsx
+++ b/dev/examples/Shared-layout-reparenting-transform-template.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/Shared-layout-reparenting.tsx
+++ b/dev/examples/Shared-layout-reparenting.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/Shared-layout-rotate.tsx
+++ b/dev/examples/Shared-layout-rotate.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 

--- a/dev/examples/Shared-layout-sibling-to-child.tsx
+++ b/dev/examples/Shared-layout-sibling-to-child.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/Shared-layout-skew.tsx
+++ b/dev/examples/Shared-layout-skew.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 

--- a/dev/examples/Shared-layout-toggle-details.tsx
+++ b/dev/examples/Shared-layout-toggle-details.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence, LayoutGroup } from "framer-motion"
 import styled from "styled-components"

--- a/dev/examples/ThreeBox.tsx
+++ b/dev/examples/ThreeBox.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { MotionConfig, motion as motionDom, useTransform } from "framer-motion"
 import { motion, MotionCanvas, useTime } from "framer-motion-3d"

--- a/dev/examples/ThreeButton.tsx
+++ b/dev/examples/ThreeButton.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { useRef, useState } from "react"
+import { Suspense, useRef, useState } from "react";
 import { motion as motionThree, MotionCanvas } from "framer-motion-3d"
 import { motion, Variants } from "framer-motion"
 import styled from "styled-components"
@@ -87,9 +86,9 @@ export const App = () => {
                 id="button"
             >
                 <motion.div className="icon" variants={iconVariants}>
-                    <React.Suspense fallback={null}>
+                    <Suspense fallback={null}>
                         <StarIcon />
-                    </React.Suspense>
+                    </Suspense>
                     <motion.section
                         style={{
                             width: 100,
@@ -125,7 +124,7 @@ export const App = () => {
                 </div>
             </motion.button>
         </Container>
-    )
+    );
 }
 
 const Container = styled.div`

--- a/dev/examples/ThreeLayout.tsx
+++ b/dev/examples/ThreeLayout.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState, Suspense } from "react"
 import "@react-three/fiber"
 import styled from "styled-components"

--- a/dev/examples/ThreeLayoutOrthogonal.tsx
+++ b/dev/examples/ThreeLayoutOrthogonal.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef, useState } from "react"
 import "@react-three/fiber"
 import styled from "styled-components"

--- a/dev/examples/ThreeSwitch.tsx
+++ b/dev/examples/ThreeSwitch.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState, Suspense, useCallback, useRef, useEffect } from "react"
 import "@react-three/fiber"
 import styled from "styled-components"

--- a/dev/examples/ThreeVariant.tsx
+++ b/dev/examples/ThreeVariant.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { MotionConfig, motion as motionDom } from "framer-motion"
 import { motion, MotionCanvas } from "framer-motion-3d"
 import { Canvas, extend } from "@react-three/fiber"

--- a/dev/examples/WAAPI-background-color.tsx
+++ b/dev/examples/WAAPI-background-color.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/WAAPI-interrupt.tsx
+++ b/dev/examples/WAAPI-interrupt.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/WAAPI-opacity-orchestration.tsx
+++ b/dev/examples/WAAPI-opacity-orchestration.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/WAAPI-opacity.tsx
+++ b/dev/examples/WAAPI-opacity.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/_SVG-layout-animation-correction.tsx
+++ b/dev/examples/_SVG-layout-animation-correction.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 const transition = {

--- a/dev/examples/_conditionalDraggable.tsx
+++ b/dev/examples/_conditionalDraggable.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, usePanGesture } from "framer-motion"
 import { useState } from "react"
 

--- a/dev/examples/_dragClickable.tsx
+++ b/dev/examples/_dragClickable.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const style = {

--- a/dev/examples/_dragConstraintChanges.tsx
+++ b/dev/examples/_dragConstraintChanges.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion } from "framer-motion"
 
 const styleA = {
@@ -9,7 +9,7 @@ const styleA = {
     position: "absolute",
 }
 export const App = () => {
-    const [constraint, setContraint] = React.useState(0)
+    const [constraint, setContraint] = useState(0)
     function onDrag(event, { point }) {
         setContraint(point.x)
     }

--- a/dev/examples/_dragConstraints.tsx
+++ b/dev/examples/_dragConstraints.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/_dragConstraintsRef.tsx
+++ b/dev/examples/_dragConstraintsRef.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/_dragConstraintsRefScale.tsx
+++ b/dev/examples/_dragConstraintsRefScale.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef } from "react"
 import { motion, MotionConfig } from "framer-motion"
 

--- a/dev/examples/_dragConstraintsRefSmallerThanChild.tsx
+++ b/dev/examples/_dragConstraintsRefSmallerThanChild.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/examples/_dragContainingInput.tsx
+++ b/dev/examples/_dragContainingInput.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/_dragDevice.tsx
+++ b/dev/examples/_dragDevice.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, MotionConfig } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/_dragExternalControl.tsx
+++ b/dev/examples/_dragExternalControl.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion, useMotionValue } from "framer-motion"
 

--- a/dev/examples/_dragOverdrag.tsx
+++ b/dev/examples/_dragOverdrag.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/_dragPropagation.tsx
+++ b/dev/examples/_dragPropagation.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 const styleA = {

--- a/dev/examples/_dragSetState.tsx
+++ b/dev/examples/_dragSetState.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion } from "framer-motion"
 
 const styleA = {
@@ -10,7 +10,7 @@ const styleA = {
 
 console.clear()
 export const App = () => {
-    const [state, setState] = React.useState(0)
+    const [state, setState] = useState(0)
 
     const onDrag = () => {
         setState(state + 10)

--- a/dev/examples/_layoutDragTransform.tsx
+++ b/dev/examples/_layoutDragTransform.tsx
@@ -1,5 +1,4 @@
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 import { motion } from "framer-motion"
 import styled from "styled-components"
 
@@ -13,7 +12,7 @@ export const App = () => {
     const [dragEnabled, setIsDragEnabled] = useState(false)
     const [layoutEnabled, setIsLayoutEnabled] = useState(false)
 
-    React.useEffect(() => {
+    useEffect(() => {
         const timer = setTimeout(() => setIsOpen(!isOpen), 2000)
         return () => clearTimeout(timer)
     }, [isOpen])

--- a/dev/examples/_layoutTransform.tsx
+++ b/dev/examples/_layoutTransform.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 import styled from "styled-components"

--- a/dev/examples/animate-stress-headless-color.tsx
+++ b/dev/examples/animate-stress-headless-color.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import { useEffect } from "react";
 import { animate } from "framer-motion"
 
 export const App = () => {
-    React.useEffect(() => {
+    useEffect(() => {
         let count = 0
         for (let i = 0; i < 2000; i++) {
             count++

--- a/dev/examples/animate-stress-headless-x.tsx
+++ b/dev/examples/animate-stress-headless-x.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import { useEffect } from "react";
 import { animate } from "framer-motion"
 
 export const App = () => {
-    React.useEffect(() => {
+    useEffect(() => {
         let count = 0
         for (let i = 0; i < 2000; i++) {
             count++

--- a/dev/examples/motion-custom-tag.tsx
+++ b/dev/examples/motion-custom-tag.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion"
-import * as React from "react"
 
 /**
  * An example of creating a `motion` version of a custom element. This will render <global> into the HTML

--- a/dev/examples/useAnimatedState.tsx
+++ b/dev/examples/useAnimatedState.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useEffect } from "react";
 import { useDeprecatedAnimatedState } from "framer-motion"
 
 /**
@@ -10,7 +10,7 @@ export const App = () => {
         foo: 0,
     })
     console.log(state.foo)
-    React.useEffect(() => {
+    useEffect(() => {
         animate({ foo: 100 }, { duration: 3 })
     }, [])
 

--- a/dev/examples/useAnimation.tsx
+++ b/dev/examples/useAnimation.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useEffect } from "react";
 import { motion, useAnimation, useMotionValue } from "framer-motion"
 
 /**
@@ -20,7 +20,7 @@ export const App = () => {
         hidden: { opacity: 0 },
     }
     const x = useMotionValue(0)
-    React.useEffect(() => {
+    useEffect(() => {
         controls.start("visible")
 
         setTimeout(() => x.set(100), 2000)

--- a/dev/examples/usePresence.tsx
+++ b/dev/examples/usePresence.tsx
@@ -1,6 +1,5 @@
 import { usePresence, AnimatePresence } from "framer-motion"
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 
 const style = {
     width: 100,
@@ -12,7 +11,7 @@ const style = {
 const Component = () => {
     const [isPresent, safeToRemove] = usePresence()
 
-    React.useEffect(() => {
+    useEffect(() => {
         !isPresent && setTimeout(safeToRemove, 1000)
     }, [isPresent])
 
@@ -22,7 +21,7 @@ const Component = () => {
 export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         setTimeout(() => {
             setVisible(!isVisible)
         }, 2000)

--- a/dev/examples/useReducedMotion.tsx
+++ b/dev/examples/useReducedMotion.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState, useEffect } from "react";
 import { motion, useReducedMotion } from "framer-motion"
 
 const style = {
@@ -9,7 +9,7 @@ const style = {
 }
 
 export const App = () => {
-    const [isVisible, setIsVisible] = React.useState(false)
+    const [isVisible, setIsVisible] = useState(false)
     const shouldReduceMotion = useReducedMotion()
     const transition = shouldReduceMotion ? { type: false } : { duration: 1 }
     const variants = {
@@ -17,7 +17,7 @@ export const App = () => {
         hidden: { opacity: 0, transition },
     }
 
-    React.useEffect(() => {
+    useEffect(() => {
         setTimeout(() => setIsVisible(!isVisible), 1500)
     }, [isVisible])
 

--- a/dev/examples/useScroll.tsx
+++ b/dev/examples/useScroll.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useState, useRef } from "react"
 import {
     mix,

--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useMotionValue, useSpring } from "framer-motion"
 
 function DragExample() {

--- a/dev/examples/useTransform-with-useLayoutEffect.tsx
+++ b/dev/examples/useTransform-with-useLayoutEffect.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useLayoutEffect, useEffect } from "react"
+import { useRef, useState, useLayoutEffect, useEffect } from "react";
 import { motion, useTransform, useViewportScroll } from "framer-motion"
 import styled from "styled-components"
 

--- a/dev/examples/useVelocity.tsx
+++ b/dev/examples/useVelocity.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import {
     motion,
     useMotionValue,

--- a/dev/examples/useViewportScroll.tsx
+++ b/dev/examples/useViewportScroll.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useState } from "react"
 import {
     mix,

--- a/dev/examples/variants-race.tsx
+++ b/dev/examples/variants-race.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/tests/animate-height.tsx
+++ b/dev/tests/animate-height.tsx
@@ -1,10 +1,10 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
+import { useRef, useState } from "react";
 
 export const App = () => {
-    const output = React.useRef<Array<string | number>>([])
-    const ref = React.useRef<HTMLDivElement>(null)
-    const [state, setState] = React.useState(true)
+    const output = useRef<Array<string | number>>([])
+    const ref = useRef<HTMLDivElement>(null)
+    const [state, setState] = useState(true)
 
     return (
         <div style={{ height: 100, width: 100, display: "flex" }}>

--- a/dev/tests/animate-layout-timing.tsx
+++ b/dev/tests/animate-layout-timing.tsx
@@ -1,5 +1,4 @@
 import { motion, animate } from "framer-motion"
-import * as React from "react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/animate-presence-pop.tsx
+++ b/dev/tests/animate-presence-pop.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence, motion, animate } from "framer-motion"
-import * as React from "react"
 import { useState, useRef, useEffect } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/animate-presence-remove.tsx
+++ b/dev/tests/animate-presence-remove.tsx
@@ -1,5 +1,4 @@
 import { AnimatePresence, motion } from "framer-motion"
-import * as React from "react"
 import { useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/animate-reverse.tsx
+++ b/dev/tests/animate-reverse.tsx
@@ -1,5 +1,4 @@
 import { motion, animate } from "framer-motion"
-import * as React from "react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/animate-x-percent.tsx
+++ b/dev/tests/animate-x-percent.tsx
@@ -1,10 +1,10 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
+import { useRef, useState } from "react";
 
 export const App = () => {
-    const output = React.useRef<Array<string | number>>([])
-    const ref = React.useRef<HTMLDivElement>(null)
-    const [state, setState] = React.useState(true)
+    const output = useRef<Array<string | number>>([])
+    const ref = useRef<HTMLDivElement>(null)
+    const [state, setState] = useState(true)
 
     return (
         <div style={{ height: 100, width: 200, display: "flex" }}>

--- a/dev/tests/css-vars.tsx
+++ b/dev/tests/css-vars.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useMotionValue } from "framer-motion"
 
 /**

--- a/dev/tests/drag-layout-nested.tsx
+++ b/dev/tests/drag-layout-nested.tsx
@@ -1,8 +1,8 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState, useEffect } from "react";
 
 export const App = () => {
-    const [count, setCount] = React.useState(0)
+    const [count, setCount] = useState(0)
     const params = new URLSearchParams(window.location.search)
     let parentDrag: boolean | string = params.get("parentDrag") || true
     let childDrag: boolean | string = params.get("childDrag") || true
@@ -18,7 +18,7 @@ export const App = () => {
     }
 
     // Trigger layout projection in the child
-    React.useEffect(() => {
+    useEffect(() => {
         setCount(count + 1)
     }, [])
 

--- a/dev/tests/drag-ref-constraints-resize.tsx
+++ b/dev/tests/drag-ref-constraints-resize.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useRef, useState } from "react"
 import { motion } from "framer-motion"
 

--- a/dev/tests/drag-ref-constraints.tsx
+++ b/dev/tests/drag-ref-constraints.tsx
@@ -1,16 +1,16 @@
 import { motion, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useRef, useState, useLayoutEffect } from "react";
 
 // It's important for this test to only trigger a single rerender while dragging (in response to onDragStart) of draggable component.
 
 export const App = () => {
-    const containerRef = React.useRef(null)
-    const [dragging, setDragging] = React.useState(false)
+    const containerRef = useRef(null)
+    const [dragging, setDragging] = useState(false)
     const params = new URLSearchParams(window.location.search)
     const layout = params.get("layout") || undefined
 
     // We do this to test when scroll position isn't 0/0
-    React.useLayoutEffect(() => {
+    useLayoutEffect(() => {
         window.scrollTo(0, 100)
     }, [])
     const x = useMotionValue("100%")

--- a/dev/tests/drag-snap-to-cursor.tsx
+++ b/dev/tests/drag-snap-to-cursor.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useDragControls } from "framer-motion"
 
 /**

--- a/dev/tests/drag-svg.tsx
+++ b/dev/tests/drag-svg.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion"
-import * as React from "react"
 
 // It's important for this test to only trigger a single rerender while dragging (in response to onDragStart) of draggable component.
 

--- a/dev/tests/drag-tabs.tsx
+++ b/dev/tests/drag-tabs.tsx
@@ -5,8 +5,7 @@ import {
     MotionConfig,
     LayoutGroup,
 } from "framer-motion"
-import * as React from "react"
-import { useState } from "react"
+import { useEffect, useState } from "react";
 
 export function App() {
     const [tabs, setTabs] = useState(initialTabs)
@@ -29,7 +28,7 @@ export function App() {
     }
 
     // Automatically repopulate tabs when they all close
-    React.useEffect(() => {
+    useEffect(() => {
         if (!tabs.length) {
             const timer = setTimeout(() => {
                 setTabs(initialTabs)

--- a/dev/tests/drag-to-reorder.tsx
+++ b/dev/tests/drag-to-reorder.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useState } from "react"
 import { Reorder, useMotionValue, animate } from "framer-motion"
 

--- a/dev/tests/drag.tsx
+++ b/dev/tests/drag.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useLayoutEffect } from "react";
 
 function getValueParam(params: any, name: string) {
     const param = params.get(name) as string | undefined
@@ -26,7 +26,7 @@ export const App = () => {
     const layout = params.get("layout") || undefined
 
     // We do this to test when scroll position isn't 0/0
-    React.useLayoutEffect(() => {
+    useLayoutEffect(() => {
         window.scrollTo(0, 100)
     }, [])
 

--- a/dev/tests/layout-cancelled-finishes.tsx
+++ b/dev/tests/layout-cancelled-finishes.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import {
     motion,
     AnimatePresence,
@@ -6,7 +6,7 @@ import {
 } from "framer-motion"
 
 export const App = () => {
-    const [isVisible, setIsVisible] = React.useState(true)
+    const [isVisible, setIsVisible] = useState(true)
     const startTransition = useInstantLayoutTransition()
 
     return (

--- a/dev/tests/layout-dependency.tsx
+++ b/dev/tests/layout-dependency.tsx
@@ -1,10 +1,10 @@
 import { motion, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     const backgroundColor = useMotionValue("red")
 
     return (

--- a/dev/tests/layout-exit.tsx
+++ b/dev/tests/layout-exit.tsx
@@ -1,15 +1,15 @@
-import * as React from "react"
+import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion"
 
 export const App = () => {
-    const [visible, setVisible] = React.useState(true)
+    const [visible, setVisible] = useState(true)
 
     const animation = {
         x: 0,
         opacity: 0.5,
     }
 
-    React.useEffect(() => setVisible(!visible), [])
+    useEffect(() => setVisible(!visible), [])
 
     return (
         <>

--- a/dev/tests/layout-follow-pointer-events.tsx
+++ b/dev/tests/layout-follow-pointer-events.tsx
@@ -1,8 +1,8 @@
 import { motion, MotionConfig } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
-    const [isOpen, setIsOpen] = React.useState(false)
+    const [isOpen, setIsOpen] = useState(false)
 
     return (
         <MotionConfig transition={{ duration: 0.1 }}>

--- a/dev/tests/layout-group-unmount.tsx
+++ b/dev/tests/layout-group-unmount.tsx
@@ -1,5 +1,4 @@
 import { motion, LayoutGroup } from "framer-motion"
-import * as React from "react"
 import { useState } from "react"
 
 const style = {

--- a/dev/tests/layout-instant-undo.tsx
+++ b/dev/tests/layout-instant-undo.tsx
@@ -1,9 +1,8 @@
 import { motion } from "framer-motion"
-import * as React from "react"
-import { useLayoutEffect } from "react"
+import { useState, useLayoutEffect } from "react";
 
 export const App = () => {
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     useLayoutEffect(() => {
         if (state === false) setState(true)

--- a/dev/tests/layout-interrupt.tsx
+++ b/dev/tests/layout-interrupt.tsx
@@ -1,8 +1,8 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
-    const [count, setCount] = React.useState(0)
+    const [count, setCount] = useState(0)
 
     return (
         <motion.div

--- a/dev/tests/layout-preserve-ratio.tsx
+++ b/dev/tests/layout-preserve-ratio.tsx
@@ -1,12 +1,12 @@
 import { mix, motion, useAnimationFrame, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 5 },
 }
 
 export const App = () => {
-    const [state, setState] = React.useState(false)
+    const [state, setState] = useState(false)
     // Force animation frames to pull transform
     const opacity = useMotionValue(0)
     useAnimationFrame(() => opacity.set(mix(0.99, 1, Math.random())))

--- a/dev/tests/layout-queuemicrotask.tsx
+++ b/dev/tests/layout-queuemicrotask.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, AnimatePresence } from "framer-motion"
 import { useState } from "react"
 

--- a/dev/tests/layout-relative-delay.tsx
+++ b/dev/tests/layout-relative-delay.tsx
@@ -1,8 +1,8 @@
 import { m, LazyMotion, domMax } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     let frameCount = 0
     return (
         <LazyMotion features={domMax}>

--- a/dev/tests/layout-relative-drag.tsx
+++ b/dev/tests/layout-relative-drag.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState, useEffect } from "react";
 
 export const App = () => {
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
-    React.useEffect(() => {
+    useEffect(() => {
         setState(!state)
     }, [])
 

--- a/dev/tests/layout-relative-target-change.tsx
+++ b/dev/tests/layout-relative-target-change.tsx
@@ -1,8 +1,8 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const Box = () => {
-    const [hover, setHover] = React.useState(false)
+    const [hover, setHover] = useState(false)
     return (
         <motion.div
             id="container"
@@ -45,7 +45,7 @@ const Box = () => {
     )
 }
 export const App = () => {
-    const [hover, setHover] = React.useState(false)
+    const [hover, setHover] = useState(false)
 
     return (
         <motion.div style={{ width: 400, height: 400, position: "relative" }}>

--- a/dev/tests/layout-repeat-new.tsx
+++ b/dev/tests/layout-repeat-new.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion"
-import * as React from "react"
 import { useState } from "react"
 
 function range(num: number) {

--- a/dev/tests/layout-resize.tsx
+++ b/dev/tests/layout-resize.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     return (
         <motion.div

--- a/dev/tests/layout-scaled-child-in-transformed-parent.tsx
+++ b/dev/tests/layout-scaled-child-in-transformed-parent.tsx
@@ -5,10 +5,10 @@
  * The issue is fixed in Version 94.0.4606.61 (Official Build) (x86_64).
  */
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
-    const [hover, setHover] = React.useState(false)
+    const [hover, setHover] = useState(false)
 
     return (
         <motion.div style={{ width: 400, height: 400, position: "relative" }}>

--- a/dev/tests/layout-shared-animate-presence.tsx
+++ b/dev/tests/layout-shared-animate-presence.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle, AnimatePresence } from "framer-motion"
 
 /**

--- a/dev/tests/layout-shared-clear-snapshots.tsx
+++ b/dev/tests/layout-shared-clear-snapshots.tsx
@@ -1,5 +1,4 @@
 import { motion, useCycle } from "framer-motion"
-import * as React from "react"
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)

--- a/dev/tests/layout-shared-crossfade-0-a-ab-0.tsx
+++ b/dev/tests/layout-shared-crossfade-0-a-ab-0.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.5 },
@@ -8,7 +8,7 @@ const transition = {
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [count, setCount] = React.useState(0)
+    const [count, setCount] = useState(0)
 
     return (
         <div

--- a/dev/tests/layout-shared-crossfade-0-a-b-0.tsx
+++ b/dev/tests/layout-shared-crossfade-0-a-b-0.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.5 },
@@ -8,7 +8,7 @@ const transition = {
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [count, setCount] = React.useState(0)
+    const [count, setCount] = useState(0)
 
     return (
         <div

--- a/dev/tests/layout-shared-crossfade-a-ab.tsx
+++ b/dev/tests/layout-shared-crossfade-a-ab.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.5 },
@@ -11,7 +11,7 @@ export const App = () => {
     const type = params.get("type") || true
     const size = params.get("size") || false
     const move = params.get("move") || "yes"
-    const [state, setState] = React.useState(false)
+    const [state, setState] = useState(false)
 
     const bStyle = size ? aLarge : b
     if (move === "no") {

--- a/dev/tests/layout-shared-crossfade-a-b-transform-template-change.tsx
+++ b/dev/tests/layout-shared-crossfade-a-b-transform-template-change.tsx
@@ -1,10 +1,10 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     const transformTemplate = state ? undefined : (_) => "translateY(-50%)"
     return (
         <motion.div

--- a/dev/tests/layout-shared-crossfade-a-b-transform-template.tsx
+++ b/dev/tests/layout-shared-crossfade-a-b-transform-template.tsx
@@ -1,10 +1,10 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     return (
         <motion.div

--- a/dev/tests/layout-shared-crossfade-a-b.tsx
+++ b/dev/tests/layout-shared-crossfade-a-b.tsx
@@ -1,10 +1,10 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     return (
         <motion.div

--- a/dev/tests/layout-shared-crossfade-nested-display-contents.tsx
+++ b/dev/tests/layout-shared-crossfade-nested-display-contents.tsx
@@ -1,11 +1,11 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = { duration: 0.2, ease: () => 0.5 }
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     return (
         <AnimatePresence>

--- a/dev/tests/layout-shared-crossfade-nested-drag.tsx
+++ b/dev/tests/layout-shared-crossfade-nested-drag.tsx
@@ -4,13 +4,13 @@ import {
     transform,
     useMotionValue,
 } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = { duration: 2 }
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     const x = useMotionValue(transform(50, [0, 100], [0, 100]))
     return (

--- a/dev/tests/layout-shared-crossfade-nested.tsx
+++ b/dev/tests/layout-shared-crossfade-nested.tsx
@@ -1,11 +1,11 @@
 import { motion, AnimatePresence } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = { duration: 0.2, ease: () => 0.5 }
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
 
     return (
         <AnimatePresence>

--- a/dev/tests/layout-shared-instant-transition-a-ab-a.tsx
+++ b/dev/tests/layout-shared-instant-transition-a-ab-a.tsx
@@ -3,7 +3,7 @@ import {
     useInstantLayoutTransition,
     AnimatePresence,
 } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.5 },
@@ -14,8 +14,8 @@ export const App = () => {
     const startTransition = useInstantLayoutTransition()
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [bgColor, setBgColor] = React.useState("#f00")
-    const [state, setState] = React.useState(false)
+    const [bgColor, setBgColor] = useState("#f00")
+    const [state, setState] = useState(false)
 
     const instantTransit = () => {
         startTransition(() => {

--- a/dev/tests/layout-shared-instant-transition.tsx
+++ b/dev/tests/layout-shared-instant-transition.tsx
@@ -1,12 +1,12 @@
 import { motion, useInstantLayoutTransition } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const startTransition = useInstantLayoutTransition()
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [bgColor, setBgColor] = React.useState("#f00")
-    const [state, setState] = React.useState(true)
+    const [bgColor, setBgColor] = useState("#f00")
+    const [state, setState] = useState(true)
 
     const handleClick = () => {
         startTransition(() => {

--- a/dev/tests/layout-shared-lightbox-crossfade.tsx
+++ b/dev/tests/layout-shared-lightbox-crossfade.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { CSSProperties, useState } from "react"
 import {
     motion,

--- a/dev/tests/layout-shared-rotate.tsx
+++ b/dev/tests/layout-shared-rotate.tsx
@@ -1,8 +1,8 @@
 import { motion, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
-    const [state, setState] = React.useState(false)
+    const [state, setState] = useState(false)
     const size = state ? 100 : 200
     return (
         <motion.div

--- a/dev/tests/layout-shared-switch-0-a-ab-0.tsx
+++ b/dev/tests/layout-shared-switch-0-a-ab-0.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.5 },
@@ -8,7 +8,7 @@ const transition = {
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [count, setCount] = React.useState(0)
+    const [count, setCount] = useState(0)
 
     return (
         <div

--- a/dev/tests/layout-shared-switch-0-a-b-0.tsx
+++ b/dev/tests/layout-shared-switch-0-a-b-0.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.5 },
@@ -8,7 +8,7 @@ const transition = {
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [count, setCount] = React.useState(0)
+    const [count, setCount] = useState(0)
 
     return (
         <div

--- a/dev/tests/layout-shared-switch-a-ab.tsx
+++ b/dev/tests/layout-shared-switch-a-ab.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 const transition = {
     default: { duration: 0.2, ease: () => 0.1 },
@@ -9,7 +9,7 @@ const transition = {
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(false)
+    const [state, setState] = useState(false)
 
     return (
         <>

--- a/dev/tests/layout-shared-switch-a-b.tsx
+++ b/dev/tests/layout-shared-switch-a-b.tsx
@@ -1,10 +1,10 @@
 import { motion, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     const backgroundColor = useMotionValue("#f00")
 
     return (

--- a/dev/tests/layout-svg.tsx
+++ b/dev/tests/layout-svg.tsx
@@ -1,10 +1,10 @@
 import { motion, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     const backgroundColor = useMotionValue("red")
 
     return (

--- a/dev/tests/layout-viewport-jump.tsx
+++ b/dev/tests/layout-viewport-jump.tsx
@@ -1,12 +1,12 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 /**
  * This test is designed to run at the Cypress default of 1000x660
  * It is scripted to scroll down 100px before triggering the layout change
  */
 export const App = () => {
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     const params = new URLSearchParams(window.location.search)
     const nested = params.get("nested") || false
 

--- a/dev/tests/layout.tsx
+++ b/dev/tests/layout.tsx
@@ -1,10 +1,10 @@
 import { motion, useMotionValue } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true
-    const [state, setState] = React.useState(true)
+    const [state, setState] = useState(true)
     const backgroundColor = useMotionValue("red")
 
     return (

--- a/dev/tests/scroll-container.tsx
+++ b/dev/tests/scroll-container.tsx
@@ -1,5 +1,4 @@
 import { useScroll, motion, useMotionValueEvent } from "framer-motion"
-import * as React from "react"
 import { useRef } from "react"
 
 export const App = () => {

--- a/dev/tests/scroll-projection.tsx
+++ b/dev/tests/scroll-projection.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion"
-import * as React from "react"
 import { useState } from "react"
 
 /**

--- a/dev/tests/svg-css-vars.tsx
+++ b/dev/tests/svg-css-vars.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion } from "framer-motion"
 
 /**
@@ -6,7 +6,7 @@ import { motion } from "framer-motion"
  */
 
 export const App = () => {
-    const [state, setState] = React.useState(false)
+    const [state, setState] = useState(false)
     return (
         <svg
             width="250"

--- a/dev/tests/svg.tsx
+++ b/dev/tests/svg.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, motionValue, MotionConfig } from "framer-motion"
 
 /**

--- a/dev/tests/unit-conversion-vh.tsx
+++ b/dev/tests/unit-conversion-vh.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion } from "framer-motion"
 
 /**

--- a/dev/tests/unit-conversion.tsx
+++ b/dev/tests/unit-conversion.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { motion, useCycle } from "framer-motion"
 
 /**

--- a/dev/tests/waapi-cancel.tsx
+++ b/dev/tests/waapi-cancel.tsx
@@ -1,5 +1,4 @@
 import { motion, animate } from "framer-motion"
-import * as React from "react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/waapi-immediate-stop.tsx
+++ b/dev/tests/waapi-immediate-stop.tsx
@@ -1,5 +1,4 @@
 import { motionValue, AcceleratedAnimation } from "framer-motion"
-import * as React from "react"
 import { useEffect, useRef } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/waapi-interrupt-pregenerated-keyframes.tsx
+++ b/dev/tests/waapi-interrupt-pregenerated-keyframes.tsx
@@ -1,5 +1,4 @@
 import { motion, animate } from "framer-motion"
-import * as React from "react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/waapi-interrupt.tsx
+++ b/dev/tests/waapi-interrupt.tsx
@@ -1,5 +1,4 @@
 import { motion, animate } from "framer-motion"
-import * as React from "react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/waapi-pregenerate-noop.tsx
+++ b/dev/tests/waapi-pregenerate-noop.tsx
@@ -1,5 +1,4 @@
 import { motion } from "framer-motion"
-import * as React from "react"
 import styled from "styled-components"
 
 const Container = styled.section`

--- a/dev/tests/waapi-zero-duration.tsx
+++ b/dev/tests/waapi-zero-duration.tsx
@@ -1,5 +1,4 @@
 import { motion, animate } from "framer-motion"
-import * as React from "react"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
 

--- a/dev/tests/while-in-view-custom-root.tsx
+++ b/dev/tests/while-in-view-custom-root.tsx
@@ -1,8 +1,8 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useRef } from "react";
 
 export const App = () => {
-    const containerRef = React.useRef(null)
+    const containerRef = useRef(null)
 
     return (
         <div id="container" style={container} ref={containerRef}>

--- a/dev/tests/while-in-view.tsx
+++ b/dev/tests/while-in-view.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion"
-import * as React from "react"
+import { useState } from "react";
 
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
@@ -8,7 +8,7 @@ export const App = () => {
     const margin = params.get("margin") || undefined
     const deleteObserver = params.get("delete") || undefined
     const disableFallback = params.get("disableFallback") || false
-    const [inViewport, setInViewport] = React.useState(false)
+    const [inViewport, setInViewport] = useState(false)
 
     if (deleteObserver) {
         window.IntersectionObserver = undefined

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -5,7 +5,7 @@
         "moduleResolution": "node",
         "isolatedModules": false,
         "importHelpers": true,
-        "jsx": "react",
+        "jsx": "react-jsxdev",
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,

--- a/dev/webpack/WrongModuleShape.tsx
+++ b/dev/webpack/WrongModuleShape.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { Code } from "../styled"
 
 export const WrongModuleShape = ({ path }: { path: string }) => (

--- a/dev/webpack/index.tsx
+++ b/dev/webpack/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client"
 import { Example, ExampleList } from "./examples"
 import { Test } from "./tests"
@@ -21,7 +21,7 @@ const App = () => {
 }
 
 createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
+    <StrictMode>
         <App />
-    </React.StrictMode>
+    </StrictMode>
 )

--- a/dev/webpack/tests.tsx
+++ b/dev/webpack/tests.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { fileName } from "../inc/file-name"
 import { WrongModuleShape } from "./WrongModuleShape"
 

--- a/packages/framer-motion-3d/jest.setup.tsx
+++ b/packages/framer-motion-3d/jest.setup.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom"
 // because @testing-library/react one switches out pointerEnter and pointerLeave
 import { fireEvent, getByTestId } from "@testing-library/dom"
 import { render as testRender, act } from "@testing-library/react"
-import * as React from "react"
+import { StrictMode } from "react";
 
 // Stub ResizeObserver
 if (!(global as any).ResizeObserver) {
@@ -45,14 +45,14 @@ export const blur = (element: HTMLElement, testId: string) =>
 
 export const render = (children: any) => {
     const renderReturn = testRender(
-        <React.StrictMode>{children}</React.StrictMode>
+        <StrictMode>{children}</StrictMode>
     )
 
     return {
         ...renderReturn,
         rerender: (children: any) =>
             renderReturn.rerender(
-                <React.StrictMode>{children}</React.StrictMode>
+                <StrictMode>{children}</StrictMode>
             ),
-    }
+    };
 }

--- a/packages/framer-motion-3d/rollup.config.mjs
+++ b/packages/framer-motion-3d/rollup.config.mjs
@@ -13,6 +13,7 @@ const external = [
     ...Object.keys(pkg.peerDependencies || {}),
     ...Object.keys(motionPkg.dependencies || {}),
     ...Object.keys(motionPkg.peerDependencies || {}),
+    "react/jsx-runtime",
 ]
 
 const cjs = Object.assign({}, config, {

--- a/packages/framer-motion-3d/src/components/LayoutCamera.tsx
+++ b/packages/framer-motion-3d/src/components/LayoutCamera.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef } from "react";
 import { PerspectiveCamera as PerspectiveCameraImpl } from "three"
 import { mergeRefs } from "react-merge-refs"
 import { LayoutCameraProps } from "./types"
@@ -16,7 +16,7 @@ type Props = JSX.IntrinsicElements["perspectiveCamera"] &
 /**
  * Adapted from https://github.com/pmndrs/drei/blob/master/src/core/PerspectiveCamera.tsx
  */
-export const LayoutCamera = React.forwardRef((props: Props, ref) => {
+export const LayoutCamera = forwardRef((props: Props, ref) => {
     const { cameraRef } = useLayoutCamera<PerspectiveCameraImpl>(
         props,
         (size) => {

--- a/packages/framer-motion-3d/src/components/LayoutOrthographicCamera.tsx
+++ b/packages/framer-motion-3d/src/components/LayoutOrthographicCamera.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { forwardRef } from "react";
 import { OrthographicCamera as OrthographicCameraImpl } from "three"
 import { mergeRefs } from "react-merge-refs"
 import { motion } from "../render/motion"
@@ -13,7 +13,7 @@ type Props = JSX.IntrinsicElements["orthographicCamera"] &
     LayoutCameraProps &
     ThreeMotionProps
 
-export const LayoutOrthographicCamera = React.forwardRef(
+export const LayoutOrthographicCamera = forwardRef(
     (props: Props, ref) => {
         const { size, cameraRef } = useLayoutCamera<OrthographicCameraImpl>(
             props,

--- a/packages/framer-motion-3d/src/render/__tests__/index.test.tsx
+++ b/packages/framer-motion-3d/src/render/__tests__/index.test.tsx
@@ -1,5 +1,4 @@
 import { ResolvedValues, frame } from "framer-motion"
-import * as React from "react"
 import { useEffect, useRef } from "react"
 import { Euler, Vector3 } from "three"
 import { Canvas, Object3DNode } from "@react-three/fiber"

--- a/packages/framer-motion-3d/tsconfig.json
+++ b/packages/framer-motion-3d/tsconfig.json
@@ -5,7 +5,7 @@
         "moduleResolution": "node",
         "isolatedModules": false,
         "importHelpers": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,

--- a/packages/framer-motion/jest.setup.tsx
+++ b/packages/framer-motion/jest.setup.tsx
@@ -3,7 +3,7 @@ import "@testing-library/jest-dom"
 // because @testing-library/react one switches out pointerEnter and pointerLeave
 import { fireEvent, getByTestId } from "@testing-library/dom"
 import { render as testRender, act } from "@testing-library/react"
-import * as React from "react"
+import { StrictMode, Fragment } from "react";
 
 /**
  * Stub PointerEvent - this is so we can pass through PointerEvent.isPrimary
@@ -93,7 +93,7 @@ export const blur = (element: HTMLElement, testId: string) =>
     })
 
 export const render = (children: any, isStrict = true) => {
-    const Wrapper = isStrict ? React.StrictMode : React.Fragment
+    const Wrapper = isStrict ? StrictMode : Fragment
 
     const renderReturn = testRender(<Wrapper>{children}</Wrapper>)
 

--- a/packages/framer-motion/rollup.config.mjs
+++ b/packages/framer-motion/rollup.config.mjs
@@ -28,6 +28,7 @@ const external = [
     ...Object.keys(pkg.dependencies || {}),
     ...Object.keys(pkg.peerDependencies || {}),
     ...Object.keys(pkg.optionalDependencies || {}),
+    "react/jsx-runtime",
 ]
 
 const pureClass = {
@@ -46,7 +47,7 @@ const umd = Object.assign({}, config, {
         exports: "named",
         globals: { react: "React" },
     },
-    external: ["react", "react-dom"],
+    external: ["react", "react-dom", "react/jsx-runtime"],
     plugins: [resolve(), replaceSettings("development")],
 })
 
@@ -63,7 +64,7 @@ const projection = Object.assign({}, config, {
         },
     },
     plugins: [resolve(), replaceSettings("development")],
-    external: ["react", "react-dom"],
+    external: ["react", "react-dom", "react/jsx-runtime"],
 })
 
 const umdProd = Object.assign({}, umd, {

--- a/packages/framer-motion/src/animation/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/animate.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
 import { useEffect } from "react"
 import { motion, MotionGlobalConfig } from "../.."
 import { animate } from "../animate"

--- a/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
+++ b/packages/framer-motion/src/animation/hooks/__tests__/use-animate.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect } from "react"
 import { render } from "@testing-library/react"
 import { useAnimate } from "../use-animate"

--- a/packages/framer-motion/src/animation/hooks/__tests__/use-animated-state.test.tsx
+++ b/packages/framer-motion/src/animation/hooks/__tests__/use-animated-state.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../../jest.setup"
-import * as React from "react"
 import { useEffect } from "react"
 import { useAnimatedState } from "../use-animated-state"
 

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../../jest.setup"
-import * as React from "react"
+import { createRef } from "react";
 import { act } from "react-dom/test-utils"
 import {
     AnimatePresence,
@@ -554,7 +554,7 @@ describe("AnimatePresence", () => {
 
     test("Handles external refs on a single child", async () => {
         const promise = new Promise((resolve) => {
-            const ref = React.createRef<HTMLDivElement>()
+            const ref = createRef<HTMLDivElement>()
             const Component = ({ id }: { id: number }) => {
                 return (
                     <AnimatePresence initial={false}>

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/use-presence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/use-presence.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../../jest.setup"
-import * as React from "react"
 import { useEffect } from "react"
 import { act } from "react-dom/test-utils"
 import { AnimatePresence } from ".."

--- a/packages/framer-motion/src/components/LayoutGroup/__tests__/LayoutGroup.test.tsx
+++ b/packages/framer-motion/src/components/LayoutGroup/__tests__/LayoutGroup.test.tsx
@@ -1,10 +1,10 @@
 import { render } from "@testing-library/react"
-import * as React from "react"
+import { useContext } from "react";
 import { LayoutGroup } from "../index"
 import { LayoutGroupContext } from "../../../context/LayoutGroupContext"
 
 const Consumer = ({ id = "1" }: any) => {
-    const value = React.useContext(LayoutGroupContext)
+    const value = useContext(LayoutGroupContext)
     return <div data-testid={id}>{value.id}</div>
 }
 it("if it's the first LayoutGroup it sets the group id", () => {

--- a/packages/framer-motion/src/components/LazyMotion/index.tsx
+++ b/packages/framer-motion/src/components/LazyMotion/index.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { useEffect, useRef, useState } from "react"
 import { LazyContext } from "../../context/LazyContext"
 import { loadFeatures } from "../../motion/features/load-features"

--- a/packages/framer-motion/src/components/MotionConfig/__tests__/MotionConfig.test.tsx
+++ b/packages/framer-motion/src/components/MotionConfig/__tests__/MotionConfig.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useContext } from "react";
 import { render } from "@testing-library/react"
 import { MotionConfig } from ".."
 import { MotionConfigContext } from "../../../context/MotionConfigContext"
@@ -6,7 +6,7 @@ import { MotionConfigContext } from "../../../context/MotionConfigContext"
 const consumerId = "consumer"
 
 const Consumer = () => {
-    const value = React.useContext(MotionConfigContext)
+    const value = useContext(MotionConfigContext)
     return <div data-testid={consumerId}>{value.transition!.type}</div>
 }
 

--- a/packages/framer-motion/src/components/MotionConfig/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/components/MotionConfig/__tests__/index.test.tsx
@@ -1,7 +1,6 @@
 import { render } from "../../../../jest.setup"
 import { motion } from "../../../render/dom/motion"
 import { MotionConfig } from "../"
-import * as React from "react"
 import { motionValue } from "../../../value"
 import { nextFrame } from "../../../gestures/__tests__/utils"
 

--- a/packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/components/Reorder/__tests__/index.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../../jest.setup"
-import * as React from "react"
 import { useRef, useLayoutEffect } from "react"
 import { Reorder } from ".."
 

--- a/packages/framer-motion/src/components/Reorder/__tests__/server.ssr.test.tsx
+++ b/packages/framer-motion/src/components/Reorder/__tests__/server.ssr.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { useState } from "react"
 import { Reorder } from ".."

--- a/packages/framer-motion/src/events/__tests__/use-event.test.tsx
+++ b/packages/framer-motion/src/events/__tests__/use-event.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { fireEvent } from "@testing-library/react"
-import * as React from "react"
 import { useRef, useEffect } from "react"
 import { useDomEvent } from "../use-dom-event"
 

--- a/packages/framer-motion/src/gestures/__tests__/focus.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/focus.test.tsx
@@ -1,5 +1,5 @@
 import { focus, blur, render } from "../../../jest.setup"
-import * as React from "react"
+import { createRef } from "react";
 import { motion, motionValue } from "../../"
 import { nextFrame } from "./utils"
 
@@ -7,7 +7,7 @@ describe("focus", () => {
     test("whileFocus applied", async () => {
         const promise = new Promise(async (resolve) => {
             const opacity = motionValue(1)
-            const ref = React.createRef<HTMLAnchorElement>()
+            const ref = createRef<HTMLAnchorElement>()
             const Component = () => (
                 <motion.a
                     ref={ref}
@@ -37,7 +37,7 @@ describe("focus", () => {
     test("whileFocus not applied when :focus-visible is false", async () => {
         const promise = new Promise((resolve) => {
             const opacity = motionValue(1)
-            const ref = React.createRef<HTMLAnchorElement>()
+            const ref = createRef<HTMLAnchorElement>()
             const Component = () => (
                 <motion.a
                     ref={ref}
@@ -65,7 +65,7 @@ describe("focus", () => {
     test("whileFocus applied if focus-visible selector throws unsupported", async () => {
         const promise = new Promise(async (resolve) => {
             const opacity = motionValue(1)
-            const ref = React.createRef<HTMLAnchorElement>()
+            const ref = createRef<HTMLAnchorElement>()
             const Component = () => (
                 <motion.a
                     ref={ref}
@@ -104,7 +104,7 @@ describe("focus", () => {
             const variant = {
                 hidden: { opacity: target },
             }
-            const ref = React.createRef<HTMLAnchorElement>()
+            const ref = createRef<HTMLAnchorElement>()
             const opacity = motionValue(1)
             const Component = () => (
                 <motion.a
@@ -135,7 +135,7 @@ describe("focus", () => {
 
     test("whileFocus is unapplied when blur", () => {
         const promise = new Promise(async (resolve) => {
-            const ref = React.createRef<HTMLAnchorElement>()
+            const ref = createRef<HTMLAnchorElement>()
             const variant = {
                 hidden: { opacity: 0.5, transitionEnd: { opacity: 0.75 } },
             }

--- a/packages/framer-motion/src/gestures/__tests__/hover.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/hover.test.tsx
@@ -4,7 +4,6 @@ import {
     pointerLeave,
     render,
 } from "../../../jest.setup"
-import * as React from "react"
 import { motion } from "../../"
 import { motionValue } from "../../value"
 import { frame } from "../../frameloop"

--- a/packages/framer-motion/src/gestures/__tests__/is-node-or-child.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/is-node-or-child.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { render } from "../../../jest.setup"
 import { isNodeOrChild } from "../utils/is-node-or-child"
 

--- a/packages/framer-motion/src/gestures/__tests__/pan.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/pan.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion } from "../../"
 import { render } from "../../../jest.setup"
 import {
@@ -13,7 +13,7 @@ describe("pan", () => {
         let count = 0
         const onPanEnd = deferred()
         const Component = () => {
-            const [increment, setIncrement] = React.useState(0)
+            const [increment, setIncrement] = useState(0)
             return (
                 <MockDrag>
                     <motion.div

--- a/packages/framer-motion/src/gestures/__tests__/press.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/press.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { motion } from "../.."
 import { motionValue } from "../../value"
 import {
@@ -534,7 +534,7 @@ describe("press", () => {
             }
 
             const Component = () => {
-                const [isPressed, setPressedState] = React.useState(false)
+                const [isPressed, setPressedState] = useState(false)
                 return (
                     <motion.div
                         data-testid="parent"

--- a/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/gestures/drag/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import { useState } from "react";
 import { pointerDown, render } from "../../../../jest.setup"
 import { BoundingBox, motion, motionValue, MotionValue } from "../../../"
 import { MockDrag, drag, deferred, dragFrame, Point, sleep } from "./utils"
@@ -124,7 +124,7 @@ describe("dragging", () => {
         let count = 0
         const onDragEnd = deferred()
         const Component = () => {
-            const [increment, setIncrement] = React.useState(1)
+            const [increment, setIncrement] = useState(1)
 
             return (
                 <MockDrag>

--- a/packages/framer-motion/src/gestures/drag/__tests__/use-drag-controls.test.tsx
+++ b/packages/framer-motion/src/gestures/drag/__tests__/use-drag-controls.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { render } from "../../../../jest.setup"
 import { motion, useDragControls } from "../../../"
 import { MockDrag, drag } from "./utils"

--- a/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
@@ -6,8 +6,7 @@ import {
     useMotionValue,
     useMotionValueEvent,
 } from "../../"
-import * as React from "react"
-import { createRef } from "react"
+import { useRef, createRef } from "react";
 import { nextFrame } from "../../gestures/__tests__/utils"
 
 describe("animate prop as object", () => {
@@ -963,7 +962,7 @@ describe("animate prop as object", () => {
     test("Correctly animates from RGB to HSLA", async () => {
         const element = await new Promise<HTMLDivElement>((resolve) => {
             const Component = () => {
-                const ref = React.useRef<HTMLDivElement>(null)
+                const ref = useRef<HTMLDivElement>(null)
                 return (
                     <motion.div
                         ref={ref}
@@ -988,7 +987,7 @@ describe("animate prop as object", () => {
     test("Correctly animates from HEX to HSLA", async () => {
         const element = await new Promise<HTMLDivElement>((resolve) => {
             const Component = () => {
-                const ref = React.useRef<HTMLDivElement>(null)
+                const ref = useRef<HTMLDivElement>(null)
                 return (
                     <motion.div
                         ref={ref}
@@ -1013,7 +1012,7 @@ describe("animate prop as object", () => {
     test("Correctly animates from HSLA to Hex", async () => {
         const element = await new Promise<HTMLDivElement>((resolve) => {
             const Component = () => {
-                const ref = React.useRef<HTMLDivElement>(null)
+                const ref = useRef<HTMLDivElement>(null)
                 return (
                     <motion.div
                         ref={ref}
@@ -1038,7 +1037,7 @@ describe("animate prop as object", () => {
     test("Correctly animates from HSLA to RGB", async () => {
         const element = await new Promise<HTMLDivElement>((resolve) => {
             const Component = () => {
-                const ref = React.useRef<HTMLDivElement>(null)
+                const ref = useRef<HTMLDivElement>(null)
                 return (
                     <motion.div
                         ref={ref}

--- a/packages/framer-motion/src/motion/__tests__/animated-values.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animated-values.test.tsx
@@ -6,7 +6,7 @@ import {
     useMotionValue,
     useTransform,
 } from "../.."
-import * as React from "react"
+import { createRef, useRef } from "react";
 
 const degreesToRadians = (degrees: number) => (degrees * Math.PI) / 180
 
@@ -14,7 +14,7 @@ describe("values prop", () => {
     test("Performs animations only on motion values provided via values", async () => {
         const promise = new Promise<[number, HTMLElement]>((resolve) => {
             const x = motionValue(0)
-            const ref = React.createRef<HTMLDivElement>()
+            const ref = createRef<HTMLDivElement>()
             const Component = () => (
                 <motion.div
                     ref={ref}
@@ -39,7 +39,7 @@ describe("values prop", () => {
     test("Still correctly renders values provided via style", async () => {
         const promise = new Promise<[number, HTMLElement]>((resolve) => {
             const x = motionValue(0)
-            const ref = React.createRef<HTMLDivElement>()
+            const ref = createRef<HTMLDivElement>()
             const Component = () => {
                 const doubleX = useTransform(x, [0, 1], [0, 2], {
                     clamp: false,
@@ -72,7 +72,7 @@ describe("values prop", () => {
     test("Doesn't render custom values", async () => {
         const promise = new Promise<[number, HTMLElement]>((resolve) => {
             const Component = () => {
-                const ref = React.useRef<HTMLDivElement>(null)
+                const ref = useRef<HTMLDivElement>(null)
                 const distance = useMotionValue(100)
                 const angle = useMotionValue(45)
 
@@ -122,7 +122,7 @@ describe("values prop", () => {
                 const x = useMotionValue(100)
                 const scale = useMotionValue(2)
                 const transform = useMotionTemplate`scale(${scale}) translateX(${x}px)`
-                const ref = React.useRef<HTMLDivElement>(null)
+                const ref = useRef<HTMLDivElement>(null)
 
                 return (
                     <motion.div

--- a/packages/framer-motion/src/motion/__tests__/child-motion-value.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/child-motion-value.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
 import { motion } from "../../render/dom/motion"
 import { motionValue } from "../../value"
 import { frame } from "../../frameloop"

--- a/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "../../../jest.setup"
 import { motion, motionValue, useMotionValue, useTransform } from "../../"
-import * as React from "react"
+import { useRef } from "react";
 import { nextFrame } from "../../gestures/__tests__/utils"
 
 describe("SVG", () => {
@@ -57,7 +57,7 @@ describe("SVG", () => {
 
     test("motion svg elements should be able to set correct type of ref", () => {
         const Component = () => {
-            const ref = React.useRef<SVGTextElement>(null)
+            const ref = useRef<SVGTextElement>(null)
             return (
                 <svg>
                     <motion.text ref={ref}>Framer Motion</motion.text>

--- a/packages/framer-motion/src/motion/__tests__/create-component.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/create-component.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
 import { motionValue } from "../../value"
 import { createDomMotionComponent } from "../../render/dom/motion"
 

--- a/packages/framer-motion/src/motion/__tests__/delay.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/delay.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { motion } from "../.."
-import * as React from "react"
 import { motionValue } from "../../value"
 
 describe("delay attr", () => {

--- a/packages/framer-motion/src/motion/__tests__/lazy.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/lazy.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { m, motion, LazyMotion, domAnimation, domMax } from "../.."
-import * as React from "react"
 import { motionValue } from "../../value"
 
 describe("Lazy feature loading", () => {

--- a/packages/framer-motion/src/motion/__tests__/motion-component.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/motion-component.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { isMotionComponent, motion, unwrapMotionComponent } from "../.."
 
 function CustomComp() {

--- a/packages/framer-motion/src/motion/__tests__/motion-context.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/motion-context.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { motion, MotionConfig } from "../../"
-import * as React from "react"
 import { motionValue } from "../../value"
 
 describe("MotionConfig.transition", () => {

--- a/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
+import { Fragment, useState } from "react";
 import { renderToString, renderToStaticMarkup } from "react-dom/server"
 import { motion, useMotionValue } from "../../"
 import { motionValue } from "../../value"
 import { AnimatePresence } from "../../components/AnimatePresence"
 import { Reorder } from "../../components/Reorder"
 
-const MotionFragment = motion(React.Fragment)
+const MotionFragment = motion(Fragment)
 
 function runTests(render: (components: any) => string) {
     test("doesn't throw", () => {
@@ -164,7 +164,7 @@ function runTests(render: (components: any) => string) {
 
     test("Reorder: Renders correct element", () => {
         function Component() {
-            const [state, setState] = React.useState([0])
+            const [state, setState] = useState([0])
             return (
                 <Reorder.Group onReorder={setState} values={state}>
                     <Reorder.Item value="a" />
@@ -180,7 +180,7 @@ function runTests(render: (components: any) => string) {
 
     test("Reorder: Doesn't render touch-scroll disabling styles if dragListener === false", () => {
         function Component() {
-            const [state, setState] = React.useState([0])
+            const [state, setState] = useState([0])
             return (
                 <Reorder.Group onReorder={setState} values={state}>
                     <Reorder.Item value="a" dragListener={false} />
@@ -196,7 +196,7 @@ function runTests(render: (components: any) => string) {
 
     test("Reorder: Renders provided element", () => {
         function Component() {
-            const [state, setState] = React.useState([0])
+            const [state, setState] = useState([0])
             return (
                 <Reorder.Group as="div" onReorder={setState} values={state}>
                     <Reorder.Item as="div" value="a" />

--- a/packages/framer-motion/src/motion/__tests__/static-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/static-prop.test.tsx
@@ -1,6 +1,6 @@
 import { render } from "../../../jest.setup"
 import { motion, useMotionValue } from "../.."
-import * as React from "react"
+import { useEffect } from "react";
 import { motionValue } from "../../value"
 import { MotionConfig } from "../../components/MotionConfig"
 import { globalProjectionState } from "../../projection/node/state"
@@ -204,7 +204,7 @@ describe("isStatic prop", () => {
         function Component() {
             const x = useMotionValue(10)
 
-            React.useEffect(() => x.set(20), [x])
+            useEffect(() => x.set(20), [x])
 
             return <motion.div data-testid="child" style={{ x }} />
         }

--- a/packages/framer-motion/src/motion/__tests__/style-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/style-prop.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { motion, MotionConfig, useMotionValue } from "../.."
-import * as React from "react"
 import { nextMicrotask } from "../../gestures/__tests__/utils"
 
 describe("style prop", () => {

--- a/packages/framer-motion/src/motion/__tests__/svg-path.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/svg-path.test.tsx
@@ -1,11 +1,11 @@
 import { render } from "../../../jest.setup"
 import { motion } from "../.."
-import * as React from "react"
+import { createRef } from "react";
 
 describe("SVG path", () => {
     test("accepts custom transition prop", async () => {
         const element = await new Promise((resolve) => {
-            const ref = React.createRef<SVGRectElement>()
+            const ref = createRef<SVGRectElement>()
             const Component = () => (
                 <motion.rect
                     ref={ref}

--- a/packages/framer-motion/src/motion/__tests__/transformTemplate.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/transformTemplate.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { motion } from "../../"
-import * as React from "react"
 import { frame } from "../../frameloop"
 import { nextMicrotask } from "../../gestures/__tests__/utils"
 

--- a/packages/framer-motion/src/motion/__tests__/transition-keyframes.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/transition-keyframes.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { motion, motionValue } from "../.."
-import * as React from "react"
 import { checkVariantsDidChange } from "../../render/utils/animation-state"
 
 describe("keyframes transition", () => {

--- a/packages/framer-motion/src/motion/__tests__/unit-type-shadow.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/unit-type-shadow.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { motion } from "../.."
-import * as React from "react"
 
 describe("box-shadow support", () => {
     test("box-shadow should animate correctly, even with no initial set", async () => {

--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -5,13 +5,12 @@ import {
     render,
 } from "../../../jest.setup"
 import { motion, MotionConfig, useMotionValue } from "../../"
-import * as React from "react"
+import { Fragment, useEffect, memo, useState } from "react";
 import { Variants } from "../../types"
 import { motionValue } from "../../value"
-import { useState } from "react"
 import { nextFrame } from "../../gestures/__tests__/utils"
 
-const MotionFragment = motion(React.Fragment)
+const MotionFragment = motion(Fragment)
 
 describe("animate prop as variant", () => {
     test("animates to set variant", async () => {
@@ -610,7 +609,7 @@ describe("animate prop as variant", () => {
                 const a = useMotionValue(0)
                 const b = useMotionValue(0)
 
-                React.useEffect(
+                useEffect(
                     () =>
                         a.on("change", (latest) => {
                             if (latest >= 1 && b.get() === 0) resolve(true)
@@ -663,7 +662,7 @@ describe("animate prop as variant", () => {
                 const a = useMotionValue(0)
                 const b = useMotionValue(0)
 
-                React.useEffect(
+                useEffect(
                     () =>
                         a.on("change", (latest) => {
                             if (latest >= 1 && b.get() === 0) resolve(true)
@@ -1100,7 +1099,7 @@ describe("animate prop as variant", () => {
     })
 
     test("Children correctly animate to removed values even when not rendering along with parents", async () => {
-        const Child = React.memo(() => (
+        const Child = memo(() => (
             <motion.div
                 variants={{
                     visible: { x: 100, opacity: 1 },

--- a/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
@@ -6,8 +6,7 @@ import {
     render,
 } from "../../../jest.setup"
 import { motion, useMotionValue } from "../../"
-import * as React from "react"
-import { createRef } from "react"
+import { useState, createRef } from "react";
 import { nextFrame } from "../../gestures/__tests__/utils"
 import "../../animation/animators/waapi/__tests__/setup"
 import { act } from "react-dom/test-utils"
@@ -286,7 +285,7 @@ describe("WAAPI animations", () => {
     test("WAAPI only receives expected number of calls in Framer configuration with hover gestures enabled", async () => {
         const ref = createRef<HTMLDivElement>()
         const Component = () => {
-            const [isHovered, setIsHovered] = React.useState(false)
+            const [isHovered, setIsHovered] = useState(false)
 
             return (
                 <motion.div
@@ -320,7 +319,7 @@ describe("WAAPI animations", () => {
     test("WAAPI only receives expected number of calls in Framer configuration with tap gestures enabled", async () => {
         const ref = createRef<HTMLDivElement>()
         const Component = () => {
-            const [isPressed, setIsPressed] = React.useState(false)
+            const [isPressed, setIsPressed] = useState(false)
 
             return (
                 <motion.div

--- a/packages/framer-motion/src/motion/features/layout/MeasureLayout.tsx
+++ b/packages/framer-motion/src/motion/features/layout/MeasureLayout.tsx
@@ -1,5 +1,5 @@
 import { frame } from "../../../frameloop"
-import React, { useContext } from "react"
+import { Component, useContext } from "react";
 import { usePresence } from "../../../components/AnimatePresence/use-presence"
 import {
     LayoutGroupContext,
@@ -24,7 +24,7 @@ interface MeasureContextProps {
 type MeasureProps = MotionProps &
     MeasureContextProps & { visualElement: VisualElement }
 
-class MeasureLayoutWithContext extends React.Component<MeasureProps> {
+class MeasureLayoutWithContext extends Component<MeasureProps> {
     /**
      * This only mounts projection nodes for components that
      * need measuring, we might want to do it for all components

--- a/packages/framer-motion/src/projection/use-reset-projection.ts
+++ b/packages/framer-motion/src/projection/use-reset-projection.ts
@@ -1,8 +1,8 @@
-import * as React from "react"
+import { useCallback } from "react";
 import { rootProjectionNode } from "./node/HTMLProjectionNode"
 
 export function useResetProjection() {
-    const reset = React.useCallback(() => {
+    const reset = useCallback(() => {
         const root = rootProjectionNode.current
         if (!root) return
         root.resetTree()

--- a/packages/framer-motion/src/utils/__tests__/use-animation-frame.test.tsx
+++ b/packages/framer-motion/src/utils/__tests__/use-animation-frame.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
 import { useAnimationFrame } from "../use-animation-frame"
-import * as React from "react"
 
 describe("useAnimationFrame", () => {
     test("Fires every animation frame", async () => {

--- a/packages/framer-motion/src/utils/__tests__/use-cycle.test.tsx
+++ b/packages/framer-motion/src/utils/__tests__/use-cycle.test.tsx
@@ -1,6 +1,6 @@
 import { render, click } from "../../../jest.setup"
 import { fireEvent } from "@testing-library/react"
-import * as React from "react"
+import { useEffect } from "react";
 import { useCycle } from "../use-cycle"
 
 describe("useCycle", () => {
@@ -9,7 +9,7 @@ describe("useCycle", () => {
 
         const Component = () => {
             const [latest, cycle] = useCycle(1, 2, 3, 4)
-            React.useEffect(() => {
+            useEffect(() => {
                 if (results[results.length - 1] !== latest) results.push(latest)
             }, [latest])
 

--- a/packages/framer-motion/src/utils/__tests__/use-in-view.test.tsx
+++ b/packages/framer-motion/src/utils/__tests__/use-in-view.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
+import { useRef, useEffect } from "react";
 import { useInView } from "../use-in-view"
 import { getActiveObserver } from "./mock-intersection-observer"
 import { act } from "react-dom/test-utils"
@@ -15,10 +15,10 @@ describe("useInView", () => {
         const results: boolean[] = []
 
         const Component = () => {
-            const ref = React.useRef(null)
+            const ref = useRef(null)
             const isInView = useInView(ref)
 
-            React.useEffect(() => {
+            useEffect(() => {
                 if (results[results.length - 1] !== isInView)
                     results.push(isInView)
             }, [isInView])
@@ -39,10 +39,10 @@ describe("useInView", () => {
         const results: boolean[] = []
 
         const Component = () => {
-            const ref = React.useRef(null)
+            const ref = useRef(null)
             const isInView = useInView(ref)
 
-            React.useEffect(() => {
+            useEffect(() => {
                 if (results[results.length - 1] !== isInView)
                     results.push(isInView)
             }, [isInView])
@@ -64,10 +64,10 @@ describe("useInView", () => {
         const results: boolean[] = []
 
         const Component = () => {
-            const ref = React.useRef(null)
+            const ref = useRef(null)
             const isInView = useInView(ref)
 
-            React.useEffect(() => {
+            useEffect(() => {
                 if (results[results.length - 1] !== isInView)
                     results.push(isInView)
             }, [isInView])
@@ -90,10 +90,10 @@ describe("useInView", () => {
         const results: boolean[] = []
 
         const Component = () => {
-            const ref = React.useRef(null)
+            const ref = useRef(null)
             const isInView = useInView(ref, { once: true })
 
-            React.useEffect(() => {
+            useEffect(() => {
                 if (results[results.length - 1] !== isInView)
                     results.push(isInView)
             }, [isInView])

--- a/packages/framer-motion/src/utils/__tests__/use-instant-transition.test.tsx
+++ b/packages/framer-motion/src/utils/__tests__/use-instant-transition.test.tsx
@@ -1,8 +1,7 @@
 import { render } from "../../../jest.setup"
 import { motion, motionValue } from "../.."
-import * as React from "react"
+import { useState, useEffect } from "react";
 import { useInstantTransition } from "../use-instant-transition"
-import { useEffect } from "react"
 import { act } from "@testing-library/react"
 import { renderHook } from "@testing-library/react"
 import { instantAnimationState } from "../use-instant-transition-state"
@@ -15,7 +14,7 @@ describe("useInstantTransition", () => {
             const xChild = motionValue(0)
 
             const Parent = () => {
-                const [state, setState] = React.useState(false)
+                const [state, setState] = useState(false)
 
                 return (
                     <motion.div
@@ -79,7 +78,7 @@ describe("useInstantTransition", () => {
             const xChild = motionValue(0)
 
             const Parent = () => {
-                const [state, setState] = React.useState(0)
+                const [state, setState] = useState(0)
                 const xTargets = [0, 50, 100]
                 return (
                     <motion.div

--- a/packages/framer-motion/src/utils/__tests__/use-motion-value-event.test.tsx
+++ b/packages/framer-motion/src/utils/__tests__/use-motion-value-event.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { render } from "../../../jest.setup"
 import { useMotionValue } from "../../value/use-motion-value"
 import { useMotionValueEvent } from "../use-motion-value-event"

--- a/packages/framer-motion/src/value/__tests__/use-motion-template.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-motion-template.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
+import { useEffect } from "react";
 import { motion } from "../../"
 import { useMotionValue } from "../use-motion-value"
 import { useMotionTemplate } from "../use-motion-template"
@@ -28,7 +28,7 @@ describe("useMotionTemplate", () => {
             const y = useMotionValue(2)
             const transform = useMotionTemplate`translateX(${x}px) translateY(${y}px)`
 
-            React.useEffect(() => {
+            useEffect(() => {
                 x.set(10)
             }, [])
 

--- a/packages/framer-motion/src/value/__tests__/use-motion-value.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-motion-value.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
 import { motion } from "../../"
 import { useMotionValue } from "../use-motion-value"
 import { motionValue, MotionValue } from ".."

--- a/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-spring.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
+import { useEffect } from "react";
 import { useSpring } from "../use-spring"
 import { useMotionValue } from "../use-motion-value"
 import { motionValue, MotionValue } from ".."
@@ -12,7 +12,7 @@ describe("useSpring", () => {
             const Component = () => {
                 const x = useSpring(0)
 
-                React.useEffect(() => {
+                useEffect(() => {
                     x.on("change", (v) => resolve(v))
                     x.set(100)
                 })
@@ -36,7 +36,7 @@ describe("useSpring", () => {
                 const x = useMotionValue(0)
                 const y = useSpring(x)
 
-                React.useEffect(() => {
+                useEffect(() => {
                     y.on("change", (v) => resolve(v))
                     x.set(100)
                 })
@@ -63,7 +63,7 @@ describe("useSpring", () => {
                     driver: syncDriver(10),
                 } as any)
 
-                React.useEffect(() => {
+                useEffect(() => {
                     return y.on("change", (v) => {
                         if (output.length >= 10) {
                             resolve(output)
@@ -73,7 +73,7 @@ describe("useSpring", () => {
                     })
                 })
 
-                React.useEffect(() => {
+                useEffect(() => {
                     x.set(100)
                 }, [])
 
@@ -105,7 +105,7 @@ describe("useSpring", () => {
                     driver: syncDriver(10),
                 } as any)
 
-                React.useEffect(() => {
+                useEffect(() => {
                     return y.on("change", (v) => {
                         if (output.length >= 10) {
                         } else {
@@ -114,7 +114,7 @@ describe("useSpring", () => {
                     })
                 })
 
-                React.useEffect(() => {
+                useEffect(() => {
                     y.jump(100)
 
                     setTimeout(() => {

--- a/packages/framer-motion/src/value/__tests__/use-transform.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-transform.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
+import { useEffect } from "react";
 import { cancelFrame, frame, motion } from "../../"
 import { useMotionValue } from "../use-motion-value"
 import { useTransform } from "../use-transform"
@@ -101,7 +101,7 @@ describe("as input/output range", () => {
             const x = useMotionValue(100)
             const opacity = useTransform(x, [0, 200], [0, 1])
 
-            React.useEffect(() => {
+            useEffect(() => {
                 x.set(20)
             }, [])
 
@@ -157,7 +157,7 @@ describe("as input/output range", () => {
                 [new Custom(100), new Custom(200)]
             )
 
-            React.useEffect(() => {
+            useEffect(() => {
                 x.set(20)
             }, [])
 
@@ -192,7 +192,7 @@ test("frame scheduling", async () => {
             const y = useMotionValue(0)
             const z = useTransform(() => x.get() + y.get())
 
-            React.useEffect(() => {
+            useEffect(() => {
                 const setX = () => {
                     x.set(1)
                     frame.update(setY)
@@ -221,7 +221,7 @@ test("frame scheduling", async () => {
 
         const { container, rerender } = render(<Component />)
         rerender(<Component />)
-    })
+    });
 })
 
 test("can be re-pointed to another `MotionValue`", async () => {

--- a/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
+++ b/packages/framer-motion/src/value/__tests__/use-velocity.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../../jest.setup"
-import * as React from "react"
+import { useEffect } from "react";
 import { useVelocity } from "../use-velocity"
 import { useMotionValue } from "../use-motion-value"
 import { animate } from "../../animation/animate"
@@ -65,7 +65,7 @@ describe("useVelocity", () => {
                     outputAcceleration.push(Math.round(v))
                 })
 
-                React.useEffect(() => {
+                useEffect(() => {
                     const animation = animate(x, 1000, {
                         duration: 0.1,
                         ease: mirrorEasing((v) => v * v),

--- a/packages/framer-motion/src/value/use-will-change/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/value/use-will-change/__tests__/index.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { render } from "../../../../jest.setup"
 import { useWillChange } from ".."
 import { motion, useMotionValue } from "../../.."

--- a/packages/framer-motion/tsconfig.json
+++ b/packages/framer-motion/tsconfig.json
@@ -5,7 +5,7 @@
         "moduleResolution": "node",
         "isolatedModules": false,
         "importHelpers": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8332,8 +8332,8 @@ __metadata:
     babel-loader: ^8.2.3
     cache-loader: ^1.2.5
     convert-tsconfig-paths-to-webpack-aliases: ^0.9.2
-    framer-motion: ^11.0.28
-    framer-motion-3d: ^11.0.28
+    framer-motion: ^11.1.0
+    framer-motion-3d: ^11.1.0
     path-browserify: ^1.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -8406,14 +8406,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion-3d@^11.0.28, framer-motion-3d@workspace:packages/framer-motion-3d":
+"framer-motion-3d@^11.1.0, framer-motion-3d@workspace:packages/framer-motion-3d":
   version: 0.0.0-use.local
   resolution: "framer-motion-3d@workspace:packages/framer-motion-3d"
   dependencies:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^11.0.28
+    framer-motion: ^11.1.0
     react-merge-refs: ^2.0.1
   peerDependencies:
     "@react-three/fiber": ^8.2.2
@@ -8423,7 +8423,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^11.0.28, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^11.1.0, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:


### PR DESCRIPTION
This PR updates the jsx transform to the one introduced with React 17: https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

Starting with React 19, there will be a warning when using the old one (see https://github.com/facebook/react/pull/28781), plus the new transform gives a nice speed-bump with React 19: https://github.com/facebook/react/pull/28781

I've also run `npx react-codemod update-react-imports .` to update / remove imports where not needed. I've split those into two commits so that the config changes and the autofixes can be looked at separately.