### PR TITLE
Binding `stop()` to animation

### DIFF
--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -481,7 +481,11 @@ export class MainThreadAnimation<
         this.holdTime = this.currentTime ?? 0
     }
 
-    stop() {
+    /**
+     * This method is bound to the instance to fix a pattern where
+     * animation.stop is returned as a reference from a useEffect.
+     */
+    stop = () => {
         this.resolver.cancel()
         this.isStopped = true
         if (this.state === "idle") return


### PR DESCRIPTION
This PR binds `stop` to the animation to fix a pattern where `animation.stop` is passed back from `useEffect`.

```
useEffect(() => {
  const animation = animate()
  return animation.stop
})
```
