### PR TITLE
Fix animating between unit type and `0` with keyframes

### DIFF
--- a/dev/tests/unit-conversion-to-zero.tsx
+++ b/dev/tests/unit-conversion-to-zero.tsx
@@ -1,0 +1,23 @@
+import { animate } from "framer-motion"
+import { useEffect } from "react"
+
+/**
+ * An example of animating between different value types
+ */
+
+export const App = () => {
+    useEffect(() => {
+        animate("#box", { y: ["100%", 0] }, { duration: 10, ease: () => 0 })
+    }, [])
+
+    return (
+        <div
+            style={{
+                width: 100,
+                height: 100,
+                background: "#ffaa00",
+            }}
+            id="box"
+        />
+    )
+}

--- a/packages/framer-motion/cypress/integration/unit-conversion.ts
+++ b/packages/framer-motion/cypress/integration/unit-conversion.ts
@@ -34,4 +34,15 @@ describe("Unit conversion", () => {
                 expect($box.textContent).to.equal("Success")
             })
     })
+
+    it("Coerces none keyframes before measuring", () => {
+        cy.viewport(400, 400)
+            .visit("?test=unit-conversion-to-zero")
+            .wait(100)
+            .get("#box")
+            .should(([$box]: any) => {
+                const { top } = $box.getBoundingClientRect()
+                expect(top).to.equal(100)
+            })
+    })
 })

--- a/packages/framer-motion/src/render/dom/DOMKeyframesResolver.ts
+++ b/packages/framer-motion/src/render/dom/DOMKeyframesResolver.ts
@@ -72,8 +72,9 @@ export class DOMKeyframesResolver<
          * Skip if we have more than two keyframes or this isn't a positional value.
          * TODO: We can throw if there are multiple keyframes and the value type changes.
          */
+        this.resolveNoneKeyframes()
         if (!positionalKeys.has(name) || unresolvedKeyframes.length !== 2) {
-            return this.resolveNoneKeyframes()
+            return
         }
 
         const [origin, target] = unresolvedKeyframes

--- a/packages/framer-motion/src/render/dom/DOMKeyframesResolver.ts
+++ b/packages/framer-motion/src/render/dom/DOMKeyframesResolver.ts
@@ -67,12 +67,18 @@ export class DOMKeyframesResolver<
         }
 
         /**
+         * Resolve "none" values. We do this potentially twice - once before and once after measuring keyframes.
+         * This could be seen as inefficient but it's a trade-off to avoid measurements in more situations, which
+         * have a far bigger performance impact.
+         */
+        this.resolveNoneKeyframes()
+
+        /**
          * Check to see if unit type has changed. If so schedule jobs that will
          * temporarily set styles to the destination keyframes.
          * Skip if we have more than two keyframes or this isn't a positional value.
          * TODO: We can throw if there are multiple keyframes and the value type changes.
          */
-        this.resolveNoneKeyframes()
         if (!positionalKeys.has(name) || unresolvedKeyframes.length !== 2) {
             return
         }

--- a/packages/framer-motion/src/render/html/utils/make-none-animatable.ts
+++ b/packages/framer-motion/src/render/html/utils/make-none-animatable.ts
@@ -7,6 +7,8 @@ import { UnresolvedKeyframes } from "../../utils/KeyframesResolver"
  * the "none" keyframes. In this case "#fff" or "200px 200px" - then these get turned into
  * zero equivalents, i.e. "#fff0" or "0px 0px".
  */
+const invalidTemplates = new Set(["auto", "none", "0"])
+
 export function makeNoneKeyframesAnimatable(
     unresolvedKeyframes: UnresolvedKeyframes<string | number>,
     noneKeyframeIndexes: number[],
@@ -15,11 +17,8 @@ export function makeNoneKeyframesAnimatable(
     let i = 0
     let animatableTemplate: string | undefined = undefined
     while (i < unresolvedKeyframes.length && !animatableTemplate) {
-        if (
-            typeof unresolvedKeyframes[i] === "string" &&
-            unresolvedKeyframes[i] !== "none" &&
-            unresolvedKeyframes[i] !== "0"
-        ) {
+        const keyframe = unresolvedKeyframes[i]
+        if (typeof keyframe === "string" && !invalidTemplates.has(keyframe)) {
             animatableTemplate = unresolvedKeyframes[i] as string
         }
         i++


### PR DESCRIPTION
This PR fixes animating between `0` and unit types when multiple keyframes are defined:

```
animate({ y: ["100%", 0] })
```

There has always been a bug (unfixed by this PR) where, when multiple keyframes of mixed type are provided, Motion will perform measurements to convert the types to the same, animatable, type.

The bug is that the initial state will be measured as the element currently is, *not* what the explicit initial keyframe has been provided as (in this case `"100%"`).

This PR fixes this situation by ensuring `0` is converted to the same value type (in this case `%`) and also brings the performance benefit of skipping measurements in this case.