### PR TITLE
Export `createDomVisualElement`

### DIFF
--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -13,7 +13,11 @@ export * from "./dom-entry"
 export * from "./three-entry"
 
 /**
- * Features
+ * To create a custom FeatureBundle (ex. part of domAnimation), we expose renderer (createDomVisualElement)
+ */
+export { createDomVisualElement } from "./render/dom/create-visual-element"
+/**
+ * Features (groups of features exposed for convenience)
  */
 export { domAnimation } from "./render/dom/features-animation"
 export { domMax } from "./render/dom/features-max"


### PR DESCRIPTION
Currently, it's impossible to create a custom `FeatureBundle` (smaller version of `domAnimation`) because `createDomVisualElement` is not exported.

https://github.com/framer/motion/blob/df6ccaf61a59c0b835234830685222c632139444/packages/framer-motion/src/render/dom/features-animation.ts#L10

By exporting `createDomVisualElement`, users would then be able to create a smaller `FeatureBundle`, for example:

```ts
export default {
  renderer: createDomMotionComponent,
  ...animations, // `animations` variable is already exposed
} satisfies FeatureBundle
```