### PR TITLE
Skip get value state

### DIFF
--- a/packages/framer-motion/src/render/utils/resolve-dynamic-variants.ts
+++ b/packages/framer-motion/src/render/utils/resolve-dynamic-variants.ts
@@ -1,13 +1,6 @@
-import { frame } from "../../frameloop"
 import { TargetAndTransition, TargetResolver } from "../../types"
 import type { VisualElement } from "../VisualElement"
 import { resolveVariantFromProps } from "./resolve-variants"
-
-let totalTime = 0
-
-function log() {
-    console.log(totalTime)
-}
 
 /**
  * Resovles a variant if it's a variant resolver
@@ -27,18 +20,11 @@ export function resolveVariant(
     definition?: string | TargetAndTransition | TargetResolver,
     custom?: any
 ) {
-    const startTime = performance.now()
-
     const props = visualElement.getProps()
-    const variant = resolveVariantFromProps(
+    return resolveVariantFromProps(
         props,
         definition,
         custom !== undefined ? custom : props.custom,
         visualElement
     )
-
-    totalTime += performance.now() - startTime
-
-    frame.postRender(log)
-    return variant
 }

--- a/packages/framer-motion/src/render/utils/resolve-dynamic-variants.ts
+++ b/packages/framer-motion/src/render/utils/resolve-dynamic-variants.ts
@@ -1,27 +1,14 @@
+import { frame } from "../../frameloop"
 import { TargetAndTransition, TargetResolver } from "../../types"
 import type { VisualElement } from "../VisualElement"
-import { ResolvedValues } from "../types"
 import { resolveVariantFromProps } from "./resolve-variants"
 
-/**
- * Creates an object containing the latest state of every MotionValue on a VisualElement
- */
-function getCurrent(visualElement: VisualElement) {
-    const current: ResolvedValues = {}
-    visualElement.values.forEach((value, key) => (current[key] = value.get()))
-    return current
+let totalTime = 0
+
+function log() {
+    console.log(totalTime)
 }
 
-/**
- * Creates an object containing the latest velocity of every MotionValue on a VisualElement
- */
-function getVelocity(visualElement: VisualElement) {
-    const velocity: ResolvedValues = {}
-    visualElement.values.forEach(
-        (value, key) => (velocity[key] = value.getVelocity())
-    )
-    return velocity
-}
 /**
  * Resovles a variant if it's a variant resolver
  */
@@ -40,12 +27,18 @@ export function resolveVariant(
     definition?: string | TargetAndTransition | TargetResolver,
     custom?: any
 ) {
+    const startTime = performance.now()
+
     const props = visualElement.getProps()
-    return resolveVariantFromProps(
+    const variant = resolveVariantFromProps(
         props,
         definition,
         custom !== undefined ? custom : props.custom,
-        getCurrent(visualElement),
-        getVelocity(visualElement)
+        visualElement
     )
+
+    totalTime += performance.now() - startTime
+
+    frame.postRender(log)
+    return variant
 }

--- a/packages/framer-motion/src/render/utils/resolve-variants.ts
+++ b/packages/framer-motion/src/render/utils/resolve-variants.ts
@@ -1,36 +1,48 @@
 import type { MotionProps } from "../../motion/types"
 import type { TargetAndTransition, TargetResolver } from "../../types"
+import { VisualElement } from "../VisualElement"
 import type { ResolvedValues } from "../types"
+
+function getValueState(
+    visualElement?: VisualElement
+): [ResolvedValues, ResolvedValues] {
+    const state: [ResolvedValues, ResolvedValues] = [{}, {}]
+
+    visualElement?.values.forEach((value, key) => {
+        state[0][key] = value.get()
+        state[1][key] = value.getVelocity()
+    })
+
+    return state
+}
 
 export function resolveVariantFromProps(
     props: MotionProps,
     definition: TargetAndTransition | TargetResolver,
     custom?: any,
-    currentValues?: ResolvedValues,
-    currentVelocity?: ResolvedValues
+    visualElement?: VisualElement
 ): TargetAndTransition
 export function resolveVariantFromProps(
     props: MotionProps,
     definition?: string | TargetAndTransition | TargetResolver,
     custom?: any,
-    currentValues?: ResolvedValues,
-    currentVelocity?: ResolvedValues
+    visualElement?: VisualElement
 ): undefined | TargetAndTransition
 export function resolveVariantFromProps(
     props: MotionProps,
     definition?: string | TargetAndTransition | TargetResolver,
     custom?: any,
-    currentValues: ResolvedValues = {},
-    currentVelocity: ResolvedValues = {}
+    visualElement?: VisualElement
 ) {
     /**
      * If the variant definition is a function, resolve.
      */
     if (typeof definition === "function") {
+        const [current, velocity] = getValueState(visualElement)
         definition = definition(
             custom !== undefined ? custom : props.custom,
-            currentValues,
-            currentVelocity
+            current,
+            velocity
         )
     }
 
@@ -48,10 +60,11 @@ export function resolveVariantFromProps(
      * If so, resolve. This can only have returned a valid target object.
      */
     if (typeof definition === "function") {
+        const [current, velocity] = getValueState(visualElement)
         definition = definition(
             custom !== undefined ? custom : props.custom,
-            currentValues,
-            currentVelocity
+            current,
+            velocity
         )
     }
 


### PR DESCRIPTION
This PR unifies getting the current value state into a single loop, and skips it until we have a dynamic variant (which is the minority of variant definitions)