### PR TITLE
Fix velocity check if motion value initialised with undefined

### DIFF
--- a/dev/examples/useSpring.tsx
+++ b/dev/examples/useSpring.tsx
@@ -47,25 +47,7 @@ function RerenderExample() {
     const { x, y } = useMousePosition()
     const size = 40
     const ref = useRef<HTMLDivElement>(null)
-    const onMove = useRef<(event: MouseEvent) => void>(
-        ({ clientX, clientY }: MouseEvent) => {
-            const element = ref.current!
-
-            setPoint({
-                x: clientX - element.offsetLeft - element.offsetWidth / 2,
-                y: clientY - element.offsetTop - element.offsetHeight / 2,
-            })
-        }
-    )
-
-    function startPointer() {
-        window.addEventListener("pointermove", onMove.current)
-    }
-
-    function cancelPointer() {
-        window.removeEventListener("pointermove", onMove.current)
-    }
-
+    console.log(x)
     return (
         <motion.div
             ref={ref}
@@ -78,9 +60,6 @@ function RerenderExample() {
                 position: "absolute",
                 inset: 0,
             }}
-            onTapStart={startPointer}
-            onTapCancel={cancelPointer}
-            onTap={cancelPointer}
         >
             Rerender
         </motion.div>

--- a/packages/framer-motion/src/value/__tests__/index.test.ts
+++ b/packages/framer-motion/src/value/__tests__/index.test.ts
@@ -221,4 +221,15 @@ describe("MotionValue velocity calculations", () => {
         value.setWithVelocity(200, 100, 10)
         expect(Math.round(value.getVelocity())).toBe(-10000)
     })
+
+    test("Velocity can be measured even if initialised with undefined", async () => {
+        const value = motionValue<undefined | number>(undefined)
+        expect((value as any).canTrackVelocity).toBe(null)
+        value.set(1)
+        expect((value as any).canTrackVelocity).toBe(true)
+
+        const value2 = motionValue<undefined | string>(undefined)
+        value2.set("test")
+        expect((value2 as any).canTrackVelocity).toBe(false)
+    })
 })

--- a/packages/framer-motion/src/value/index.ts
+++ b/packages/framer-motion/src/value/index.ts
@@ -123,7 +123,7 @@ export class MotionValue<V = any> {
      *
      * @internal
      */
-    private canTrackVelocity = false
+    private canTrackVelocity: boolean | null = null
 
     /**
      * Tracks whether this value should be removed
@@ -141,13 +141,16 @@ export class MotionValue<V = any> {
      */
     constructor(init: V, options: MotionValueOptions = {}) {
         this.setCurrent(init)
-        this.canTrackVelocity = isFloat(this.current)
         this.owner = options.owner
     }
 
     setCurrent(current: V) {
         this.current = current
         this.updatedAt = time.now()
+
+        if (this.canTrackVelocity === null && current !== undefined) {
+            this.canTrackVelocity = isFloat(this.current)
+        }
     }
 
     setPrevFrameValue(prevFrameValue: V | undefined = this.current) {


### PR DESCRIPTION
When a deferred keyframe animation is started, we might not have resolved an initial keyframe for the `MotionValue`. This ensures the `canTrackVelocity` check only happens after we have a valid value.