### PR TITLE
Require and return a numeric MotionValue in useSpring types

### DIFF
--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -31,7 +31,7 @@ import {
  * @public
  */
 export function useSpring(
-    source: MotionValue | number,
+    source: MotionValue<number> | number,
     config: SpringOptions = {}
 ) {
     const { isStatic } = useContext(MotionConfigContext)
@@ -90,7 +90,7 @@ export function useSpring(
 
     useIsomorphicLayoutEffect(() => {
         if (isMotionValue(source)) {
-            return source.on("change", (v) => value.set(parseFloat(v)))
+            return source.on("change", (v) => value.set(v))
         }
     }, [value])
 

--- a/packages/framer-motion/src/value/use-spring.ts
+++ b/packages/framer-motion/src/value/use-spring.ts
@@ -11,6 +11,13 @@ import {
     animateValue,
 } from "../animation/animators/MainThreadAnimation"
 
+// typescript wants only strings passed to parseFloat
+function safeParseFloat(v: unknown) {
+    if (typeof v === "number") return v
+    if (v === null || v === undefined) return NaN
+    return parseFloat(v.toString())
+}
+
 /**
  * Creates a `MotionValue` that, when `set`, will use a spring animation to animate to its new state.
  *
@@ -31,14 +38,14 @@ import {
  * @public
  */
 export function useSpring(
-    source: MotionValue<number> | number,
+    source: MotionValue<unknown> | number,
     config: SpringOptions = {}
 ) {
     const { isStatic } = useContext(MotionConfigContext)
     const activeSpringAnimation = useRef<MainThreadAnimation<number> | null>(
         null
     )
-    const value = useMotionValue(isMotionValue(source) ? source.get() : source)
+    const value = useMotionValue(isMotionValue(source) ? safeParseFloat(source.get()) : source)
     const latestValue = useRef<number>(value.get())
     const latestSetter = useRef<(v: number) => void>(() => {})
 
@@ -90,7 +97,7 @@ export function useSpring(
 
     useIsomorphicLayoutEffect(() => {
         if (isMotionValue(source)) {
-            return source.on("change", (v) => value.set(v))
+            return source.on("change", (v) => value.set(safeParseFloat(v)))
         }
     }, [value])
 


### PR DESCRIPTION
The current types for `useSpring` use `MotionValue<any>`, even though in practice `useSpring` only handles numeric MotionValues.

Since `useSpring` only accepts numeric inputs and only returns a numeric MotionValue, it should be typed with `MotionValue<number>` in order to be as specific as possible, and encourage as much type safety as possible.

It’s common for developers to enable linter rules that protect against unsafe uses of `any` values in TypeScript, since those values are prone to break type safety guarantees. The current types for `useSpring` create such “unsafe” types even though in practice, the value is always a number. See the following example:

<img width="1203" alt="Screenshot 2024-06-17 at 12 06 09 PM" src="https://github.com/framer/motion/assets/10377391/02d56d43-55a0-4cfb-b10d-88d849f607e1">

Closes #2495