### PR TITLE
Fix animations in re-suspended components

### DIFF
--- a/dev/react/src/tests/drag-tabs.tsx
+++ b/dev/react/src/tests/drag-tabs.tsx
@@ -321,6 +321,7 @@ li {
 }
 
 li span {
+  color: black;
   flex-shrink: 1;
   flex-grow: 1;
   white-space: nowrap;

--- a/dev/react/src/tests/layout-shared-crossfade-nested.tsx
+++ b/dev/react/src/tests/layout-shared-crossfade-nested.tsx
@@ -1,7 +1,7 @@
 import { motion, AnimatePresence } from "framer-motion"
-import { useState } from "react";
+import { useState } from "react"
 
-const transition = { duration: 0.2, ease: () => 0.5 }
+const transition = { duration: 1, ease: () => 0.5 }
 export const App = () => {
     const params = new URLSearchParams(window.location.search)
     const type = params.get("type") || true

--- a/packages/framer-motion/cypress/integration/drag-tabs.ts
+++ b/packages/framer-motion/cypress/integration/drag-tabs.ts
@@ -88,7 +88,7 @@ describe("Tabs demo", () => {
         cy.visit("?test=drag-tabs")
             .get("#Tomato-remove")
             .click()
-            .wait(150)
+            .wait(400)
             .get("#Lettuce-tab")
             .trigger("pointerdown", 40, 10)
             .wait(30)

--- a/packages/framer-motion/cypress/integration/layout-shared.ts
+++ b/packages/framer-motion/cypress/integration/layout-shared.ts
@@ -872,7 +872,6 @@ describe("Shared layout: nested crossfade transition", () => {
             .get("#a")
             .trigger("click")
             .wait(50)
-            .get("#a")
             .should(([$box]: any) => {
                 expectBbox($box, {
                     top: 200,

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -589,7 +589,7 @@ export class VisualElementDragControls {
 
         const measureDragConstraints = () => {
             const { dragConstraints } = this.getProps()
-            if (isRefObject(dragConstraints)) {
+            if (isRefObject(dragConstraints) && dragConstraints.current) {
                 this.constraints = this.resolveRefConstraints()
             }
         }
@@ -606,7 +606,7 @@ export class VisualElementDragControls {
             projection.updateLayout()
         }
 
-        measureDragConstraints()
+        frame.read(measureDragConstraints)
 
         /**
          * Attach a window resize listener to scale the draggable target within its defined

--- a/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/ssr.test.tsx
@@ -12,15 +12,18 @@ function runTests(render: (components: any) => string) {
         function Component() {
             const ref = useRef<HTMLDivElement>(null)
             return (
-                <motion.div
-                    ref={ref}
-                    initial={{ x: 100 }}
-                    whileTap={{ opacity: 0 }}
-                    drag
-                    layout
-                    layoutId="a"
-                    style={{ opacity: 1 }}
-                />
+                <>
+                    <motion.div
+                        ref={ref}
+                        initial={{ x: 100 }}
+                        whileTap={{ opacity: 0 }}
+                        drag
+                        layout
+                        layoutId="a"
+                        style={{ opacity: 1 }}
+                    />
+                    <motion.button disabled />
+                </>
             )
         }
         render(<Component />)

--- a/packages/framer-motion/src/motion/features/animation/index.ts
+++ b/packages/framer-motion/src/motion/features/animation/index.ts
@@ -18,7 +18,6 @@ export class AnimationFeature extends Feature<unknown> {
 
     updateAnimationControlsSubscription() {
         const { animate } = this.node.getProps()
-        this.unmount()
         if (isAnimationControls(animate)) {
             this.unmountControls = animate.subscribe(this.node)
         }

--- a/packages/framer-motion/src/motion/features/animation/index.ts
+++ b/packages/framer-motion/src/motion/features/animation/index.ts
@@ -4,6 +4,8 @@ import { VisualElement } from "../../../render/VisualElement"
 import { Feature } from "../Feature"
 
 export class AnimationFeature extends Feature<unknown> {
+    unmountControls?: () => void
+
     /**
      * We dynamically generate the AnimationState manager as it contains a reference
      * to the underlying animation library. We only want to load that if we load this,
@@ -18,7 +20,7 @@ export class AnimationFeature extends Feature<unknown> {
         const { animate } = this.node.getProps()
         this.unmount()
         if (isAnimationControls(animate)) {
-            this.unmount = animate.subscribe(this.node)
+            this.unmountControls = animate.subscribe(this.node)
         }
     }
 
@@ -37,5 +39,8 @@ export class AnimationFeature extends Feature<unknown> {
         }
     }
 
-    unmount() {}
+    unmount() {
+        this.node.animationState!.reset()
+        this.unmountControls?.()
+    }
 }

--- a/packages/framer-motion/src/motion/features/layout/MeasureLayout.tsx
+++ b/packages/framer-motion/src/motion/features/layout/MeasureLayout.tsx
@@ -1,5 +1,5 @@
 import { frame } from "../../../frameloop"
-import { Component, useContext } from "react";
+import { Component, useContext } from "react"
 import { usePresence } from "../../../components/AnimatePresence/use-presence"
 import {
     LayoutGroupContext,

--- a/packages/framer-motion/src/motion/features/types.ts
+++ b/packages/framer-motion/src/motion/features/types.ts
@@ -37,7 +37,7 @@ export type FeatureDefinition = {
 }
 
 export type FeatureDefinitions = {
-    [K in keyof HydratedFeatureDefinition]: FeatureDefinition
+    [K in keyof HydratedFeatureDefinitions]: FeatureDefinition
 }
 
 export type FeaturePackage = {

--- a/packages/framer-motion/src/motion/index.tsx
+++ b/packages/framer-motion/src/motion/index.tsx
@@ -14,7 +14,7 @@ import { LayoutGroupContext } from "../context/LayoutGroupContext"
 import { LazyContext } from "../context/LazyContext"
 import { motionComponentSymbol } from "./utils/symbol"
 import { CreateVisualElement } from "../render/types"
-import { invariant, warning } from "../dom-entry"
+import { invariant, warning } from "../utils/errors"
 import { featureDefinitions } from "./features/definitions"
 
 export interface MotionComponentConfig<Instance, RenderState> {

--- a/packages/framer-motion/src/motion/utils/use-motion-ref.ts
+++ b/packages/framer-motion/src/motion/utils/use-motion-ref.ts
@@ -18,9 +18,11 @@ export function useMotionRef<Instance, RenderState>(
             instance && visualState.mount && visualState.mount(instance)
 
             if (visualElement) {
-                instance
-                    ? visualElement.mount(instance)
-                    : visualElement.unmount()
+                if (instance) {
+                    visualElement.mount(instance)
+                } else {
+                    visualElement.unmount()
+                }
             }
 
             if (externalRef) {

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -11,12 +11,21 @@ import { MotionConfigContext } from "../../context/MotionConfigContext"
 import type { VisualElement } from "../../render/VisualElement"
 import { optimizedAppearDataAttribute } from "../../animation/optimized-appear/data-id"
 import { microtask } from "../../frameloop/microtask"
+import {
+    InitialPromotionConfig,
+    SwitchLayoutGroupContext,
+} from "../../context/SwitchLayoutGroupContext"
+import { IProjectionNode } from "../../projection/node/types"
+import { isRefObject } from "../../utils/is-ref-object"
+
+let scheduleHandoffComplete = false
 
 export function useVisualElement<Instance, RenderState>(
     Component: string | React.ComponentType<React.PropsWithChildren<unknown>>,
     visualState: VisualState<Instance, RenderState>,
     props: MotionProps & Partial<MotionConfigContext>,
-    createVisualElement?: CreateVisualElement<Instance>
+    createVisualElement?: CreateVisualElement<Instance>,
+    ProjectionNodeConstructor?: any
 ): VisualElement<Instance> | undefined {
     const { visualElement: parent } = useContext(MotionContext)
     const lazyContext = useContext(LazyContext)
@@ -45,6 +54,26 @@ export function useVisualElement<Instance, RenderState>(
 
     const visualElement = visualElementRef.current
 
+    /**
+     * Load Motion gesture and animation features. These are rendered as renderless
+     * components so each feature can optionally make use of React lifecycle methods.
+     */
+    const initialLayoutGroupConfig = useContext(SwitchLayoutGroupContext)
+
+    if (
+        visualElement &&
+        !visualElement.projection &&
+        ProjectionNodeConstructor &&
+        (visualElement.type === "html" || visualElement.type === "svg")
+    ) {
+        createProjectionNode(
+            visualElementRef.current!,
+            props,
+            ProjectionNodeConstructor,
+            initialLayoutGroupConfig
+        )
+    }
+
     useInsertionEffect(() => {
         visualElement && visualElement.update(props, presenceContext)
     })
@@ -62,6 +91,8 @@ export function useVisualElement<Instance, RenderState>(
 
     useIsomorphicLayoutEffect(() => {
         if (!visualElement) return
+
+        visualElement.updateFeatures()
 
         microtask.render(visualElement.render)
 
@@ -83,8 +114,6 @@ export function useVisualElement<Instance, RenderState>(
     useEffect(() => {
         if (!visualElement) return
 
-        visualElement.updateFeatures()
-
         if (!wantsHandoff.current && visualElement.animationState) {
             visualElement.animationState.animateChanges()
         }
@@ -92,9 +121,73 @@ export function useVisualElement<Instance, RenderState>(
         if (wantsHandoff.current) {
             wantsHandoff.current = false
             // This ensures all future calls to animateChanges() will run in useEffect
-            window.HandoffComplete = true
+            if (!scheduleHandoffComplete) {
+                scheduleHandoffComplete = true
+                queueMicrotask(completeHandoff)
+            }
         }
     })
 
     return visualElement
+}
+
+function completeHandoff() {
+    window.HandoffComplete = true
+}
+
+function createProjectionNode(
+    visualElement: VisualElement<any>,
+    props: MotionProps,
+    ProjectionNodeConstructor: any,
+    initialPromotionConfig?: InitialPromotionConfig
+) {
+    const {
+        layoutId,
+        layout,
+        drag,
+        dragConstraints,
+        layoutScroll,
+        layoutRoot,
+    } = props
+
+    visualElement.projection = new ProjectionNodeConstructor(
+        visualElement.latestValues,
+        props["data-framer-portal-id"]
+            ? undefined
+            : getClosestProjectingNode(visualElement.parent)
+    ) as IProjectionNode
+
+    visualElement.projection.setOptions({
+        layoutId,
+        layout,
+        alwaysMeasureLayout:
+            Boolean(drag) || (dragConstraints && isRefObject(dragConstraints)),
+        visualElement,
+        scheduleRender: () => visualElement.scheduleRender(),
+        /**
+         * TODO: Update options in an effect. This could be tricky as it'll be too late
+         * to update by the time layout animations run.
+         * We also need to fix this safeToRemove by linking it up to the one returned by usePresence,
+         * ensuring it gets called if there's no potential layout animations.
+         *
+         */
+        animationType: typeof layout === "string" ? layout : "both",
+        initialPromotionConfig,
+        layoutScroll,
+        layoutRoot,
+    })
+}
+
+function getClosestProjectingNode(
+    visualElement?: VisualElement<
+        unknown,
+        unknown,
+        { allowProjection?: boolean }
+    >
+): IProjectionNode | undefined {
+    if (!visualElement) return undefined
+
+    return visualElement.options.allowProjection !== false
+        ? visualElement.projection
+        : getClosestProjectingNode(visualElement.parent)
 }

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -11,12 +11,12 @@ import { MotionConfigContext } from "../../context/MotionConfigContext"
 import type { VisualElement } from "../../render/VisualElement"
 import { optimizedAppearDataAttribute } from "../../animation/optimized-appear/data-id"
 import { microtask } from "../../frameloop/microtask"
+import { IProjectionNode } from "../../projection/node/types"
+import { isRefObject } from "../../utils/is-ref-object"
 import {
     InitialPromotionConfig,
     SwitchLayoutGroupContext,
 } from "../../context/SwitchLayoutGroupContext"
-import { IProjectionNode } from "../../projection/node/types"
-import { isRefObject } from "../../utils/is-ref-object"
 
 let scheduleHandoffComplete = false
 

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -726,10 +726,12 @@ export function createProjectionNode<I>({
             frameData.isProcessing = false
         }
 
+        scheduleUpdate = () => this.update()
+
         didUpdate() {
             if (!this.updateScheduled) {
                 this.updateScheduled = true
-                microtask.read(() => this.update())
+                microtask.read(this.scheduleUpdate)
             }
         }
 

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -1,16 +1,13 @@
 import { frame, cancelFrame } from "../frameloop"
-import { invariant, warning } from "../utils/errors"
 import {
     MotionConfigContext,
     ReducedMotionConfig,
 } from "../context/MotionConfigContext"
-import { SwitchLayoutGroupContext } from "../context/SwitchLayoutGroupContext"
-import { FeatureBundle, FeatureDefinitions } from "../motion/features/types"
+import { FeatureDefinitions } from "../motion/features/types"
 import { MotionProps, MotionStyle } from "../motion/types"
 import { createBox } from "../projection/geometry/models"
 import { Box } from "../projection/geometry/types"
 import { IProjectionNode } from "../projection/node/types"
-import { isRefObject } from "../utils/is-ref-object"
 import { initPrefersReducedMotion } from "../utils/reduced-motion"
 import {
     hasReducedMotionListener,
@@ -52,9 +49,6 @@ import { findValueType } from "./dom/value-types/find"
 import { complex } from "../value/types/complex"
 import { getAnimatableNone } from "./dom/value-types/animatable-none"
 
-const featureNames = Object.keys(featureDefinitions)
-const numFeatures = featureNames.length
-
 const propEventHandlers = [
     "AnimationStart",
     "AnimationComplete",
@@ -66,20 +60,6 @@ const propEventHandlers = [
 ] as const
 
 const numVariantProps = variantProps.length
-
-function getClosestProjectingNode(
-    visualElement?: VisualElement<
-        unknown,
-        unknown,
-        { allowProjection?: boolean }
-    >
-): IProjectionNode | undefined {
-    if (!visualElement) return undefined
-
-    return visualElement.options.allowProjection !== false
-        ? visualElement.projection
-        : getClosestProjectingNode(visualElement.parent)
-}
 
 /**
  * A VisualElement is an imperative abstraction around UI elements such as
@@ -476,7 +456,11 @@ export abstract class VisualElement<
             this.events[key].clear()
         }
         for (const key in this.features) {
-            this.features[key as keyof typeof this.features]?.unmount()
+            const feature = this.features[key as keyof typeof this.features]
+            if (feature) {
+                feature.unmount()
+                feature.isMounted = false
+            }
         }
         this.current = null
     }
@@ -527,108 +511,38 @@ export abstract class VisualElement<
         )
     }
 
-    loadFeatures(
-        { children, ...renderedProps }: MotionProps,
-        isStrict: boolean,
-        preloadedFeatures?: FeatureBundle,
-        initialLayoutGroupConfig?: SwitchLayoutGroupContext
-    ) {
-        let ProjectionNodeConstructor: any
-        let MeasureLayout: undefined | React.ComponentType<MotionProps>
-
-        /**
-         * If we're in development mode, check to make sure we're not rendering a motion component
-         * as a child of LazyMotion, as this will break the file-size benefits of using it.
-         */
-        if (
-            process.env.NODE_ENV !== "production" &&
-            preloadedFeatures &&
-            isStrict
-        ) {
-            const strictMessage =
-                "You have rendered a `motion` component within a `LazyMotion` component. This will break tree shaking. Import and render a `m` component instead."
-            renderedProps.ignoreStrict
-                ? warning(false, strictMessage)
-                : invariant(false, strictMessage)
-        }
-
-        for (let i = 0; i < numFeatures; i++) {
-            const name = featureNames[i] as keyof typeof featureDefinitions
-            const {
-                isEnabled,
-                Feature: FeatureConstructor,
-                ProjectionNode,
-                MeasureLayout: MeasureLayoutComponent,
-            } = featureDefinitions[name]!
-
-            if (ProjectionNode) ProjectionNodeConstructor = ProjectionNode
-
-            if (isEnabled(renderedProps)) {
-                if (!this.features[name] && FeatureConstructor) {
-                    this.features[name] = new (FeatureConstructor as any)(this)
-                }
-                if (MeasureLayoutComponent) {
-                    MeasureLayout = MeasureLayoutComponent
-                }
-            }
-        }
-
-        if (
-            (this.type === "html" || this.type === "svg") &&
-            !this.projection &&
-            ProjectionNodeConstructor
-        ) {
-            const {
-                layoutId,
-                layout,
-                drag,
-                dragConstraints,
-                layoutScroll,
-                layoutRoot,
-            } = renderedProps
-
-            this.projection = new ProjectionNodeConstructor(
-                this.latestValues,
-                renderedProps["data-framer-portal-id"]
-                    ? undefined
-                    : getClosestProjectingNode(this.parent)
-            ) as IProjectionNode
-
-            this.projection.setOptions({
-                layoutId,
-                layout,
-                alwaysMeasureLayout:
-                    Boolean(drag) ||
-                    (dragConstraints && isRefObject(dragConstraints)),
-                visualElement: this,
-                scheduleRender: () => this.scheduleRender(),
-                /**
-                 * TODO: Update options in an effect. This could be tricky as it'll be too late
-                 * to update by the time layout animations run.
-                 * We also need to fix this safeToRemove by linking it up to the one returned by usePresence,
-                 * ensuring it gets called if there's no potential layout animations.
-                 *
-                 */
-                animationType: typeof layout === "string" ? layout : "both",
-                initialPromotionConfig: initialLayoutGroupConfig,
-                layoutScroll,
-                layoutRoot,
-            })
-        }
-
-        return MeasureLayout
-    }
-
     updateFeatures() {
-        for (const key in this.features) {
-            const feature = this.features[
-                key as keyof typeof this.features
-            ] as Feature<any>
-            if (feature.isMounted) {
-                feature.update()
-            } else {
-                feature.mount()
-                feature.isMounted = true
+        let key: keyof typeof featureDefinitions = "animation"
+
+        for (key in featureDefinitions) {
+            const featureDefinition = featureDefinitions[key]
+
+            if (!featureDefinition) continue
+
+            const { isEnabled, Feature: FeatureConstructor } = featureDefinition
+
+            /**
+             * If this feature is enabled but not active, make a new instance.
+             */
+            if (
+                !this.features[key] &&
+                FeatureConstructor &&
+                isEnabled(this.props)
+            ) {
+                this.features[key] = new FeatureConstructor(this)
+            }
+
+            /**
+             * If we have a feature, mount or update it.
+             */
+            if (this.features[key]) {
+                const feature = this.features[key]!
+                if (feature.isMounted) {
+                    feature.update()
+                } else {
+                    feature.mount()
+                    feature.isMounted = true
+                }
             }
         }
     }

--- a/packages/framer-motion/src/render/utils/animation-state.ts
+++ b/packages/framer-motion/src/render/utils/animation-state.ts
@@ -22,6 +22,7 @@ export interface AnimationState {
     ) => Promise<any>
     setAnimateFunction: (fn: any) => void
     getState: () => { [key: string]: AnimationTypeState }
+    reset: () => void
 }
 
 interface DefinitionAndOptions {
@@ -47,7 +48,7 @@ export function createAnimationState(
     visualElement: VisualElement
 ): AnimationState {
     let animate = animateList(visualElement)
-    const state = createState()
+    let state = createState()
     let isInitialRender = true
 
     /**
@@ -387,6 +388,10 @@ export function createAnimationState(
         setActive,
         setAnimateFunction,
         getState: () => state,
+        reset: () => {
+            state = createState()
+            isInitialRender = true
+        },
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/2269

As the [React 19 upgrade branch](https://github.com/framer/motion/pull/2667) could be open for a while, with two versions maintained (`11.x` for React 18 and `12.x` for React 19) this PR cherrypicks the logic changes to keep rebases simpler and fix Suspense animations sooner.