### PR TITLE
fix: value of isColorString can be undefined or null

### DIFF
--- a/packages/framer-motion/src/value/types/color/utils.ts
+++ b/packages/framer-motion/src/value/types/color/utils.ts
@@ -6,6 +6,8 @@ import { floatRegex, isString, singleColorRegex } from "../utils"
  * but false if a number or multiple colors
  */
 export const isColorString = (type: string, testProp?: string) => (v: any) => {
+    if (v === undefined || v === null) return false
+
     return Boolean(
         (isString(v) && singleColorRegex.test(v) && v.startsWith(type)) ||
             (testProp && Object.prototype.hasOwnProperty.call(v, testProp))


### PR DESCRIPTION
Sometimes the value can be null or undefined and this causes an error in some applications.

![image](https://github.com/framer/motion/assets/39312595/a027e412-d72c-40d6-99ea-9c55dce0e3be)
![image](https://github.com/framer/motion/assets/39312595/c9fc483d-50e0-4c70-b5ea-56965c0297ac)
