### PR TITLE
fix: window is not defined in nextjs

### DIFF
--- a/packages/framer-motion/src/projection/node/HTMLProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/HTMLProjectionNode.ts
@@ -14,7 +14,9 @@ export const HTMLProjectionNode = createProjectionNode<HTMLElement>({
     defaultParent: () => {
         if (!rootProjectionNode.current) {
             const documentNode = new DocumentProjectionNode({})
-            documentNode.mount(window)
+            if(typeof window != 'undefined'){
+                documentNode.mount(window);
+            }
             documentNode.setOptions({ layoutScroll: true })
             rootProjectionNode.current = documentNode
         }

--- a/packages/framer-motion/src/projection/node/HTMLProjectionNode.ts
+++ b/packages/framer-motion/src/projection/node/HTMLProjectionNode.ts
@@ -14,8 +14,8 @@ export const HTMLProjectionNode = createProjectionNode<HTMLElement>({
     defaultParent: () => {
         if (!rootProjectionNode.current) {
             const documentNode = new DocumentProjectionNode({})
-            if(typeof window != 'undefined'){
-                documentNode.mount(window);
+            if (typeof window !== 'undefined') {
+                documentNode.mount(window)
             }
             documentNode.setOptions({ layoutScroll: true })
             rootProjectionNode.current = documentNode


### PR DESCRIPTION
My env is next@14.2.3, next-intl@3.13.0, and i use in client component, i don't kown why it trigger this line "documentNode.mount(window)", i have drop to next@13 but it still trigger
![微信截图_20240624142023](https://github.com/framer/motion/assets/36807043/a92ae020-18d9-424e-8be3-daa34908d9c5)


![微信截图_20240624143220](https://github.com/framer/motion/assets/36807043/050e41b4-4964-49eb-825a-ae7f2a2b1d3a)
