### PR TITLE
Render loop optimisations

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -85,11 +85,11 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "33.4 kB"
+            "maxSize": "33.45 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "5.8 kB"
+            "maxSize": "5.85 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -33,9 +33,8 @@ export function createRenderBatcher(
         return acc
     }, {} as Steps)
 
-    const processStep = (stepId: StepId) => {
-        steps[stepId].process(state)
-    }
+    const { read, resolveKeyframes, update, preRender, render, postRender } =
+        steps
 
     const processBatch = () => {
         const timestamp = MotionGlobalConfig.useManualTiming
@@ -51,12 +50,12 @@ export function createRenderBatcher(
         state.isProcessing = true
 
         // Unrolled render loop for better per-frame performance
-        processStep(stepsOrder[0])
-        processStep(stepsOrder[1])
-        processStep(stepsOrder[2])
-        processStep(stepsOrder[3])
-        processStep(stepsOrder[4])
-        processStep(stepsOrder[5])
+        read.process(state)
+        resolveKeyframes.process(state)
+        update.process(state)
+        preRender.process(state)
+        render.process(state)
+        postRender.process(state)
 
         state.isProcessing = false
 
@@ -85,8 +84,11 @@ export function createRenderBatcher(
         return acc
     }, {} as Batcher)
 
-    const cancel = (process: Process) =>
-        stepsOrder.forEach((key) => steps[key].cancel(process))
+    const cancel = (process: Process) => {
+        for (let i = 0; i < stepsOrder.length; i++) {
+            steps[stepsOrder[i]].cancel(process)
+        }
+    }
 
     return { schedule, cancel, state, steps }
 }

--- a/packages/framer-motion/src/frameloop/batcher.ts
+++ b/packages/framer-motion/src/frameloop/batcher.ts
@@ -26,8 +26,10 @@ export function createRenderBatcher(
         isProcessing: false,
     }
 
+    const flagRunNextFrame = () => (runNextFrame = true)
+
     const steps = stepsOrder.reduce((acc, key) => {
-        acc[key] = createRenderStep(() => (runNextFrame = true))
+        acc[key] = createRenderStep(flagRunNextFrame)
         return acc
     }, {} as Steps)
 
@@ -47,7 +49,15 @@ export function createRenderBatcher(
 
         state.timestamp = timestamp
         state.isProcessing = true
-        stepsOrder.forEach(processStep)
+
+        // Unrolled render loop for better per-frame performance
+        processStep(stepsOrder[0])
+        processStep(stepsOrder[1])
+        processStep(stepsOrder[2])
+        processStep(stepsOrder[3])
+        processStep(stepsOrder[4])
+        processStep(stepsOrder[5])
+
         state.isProcessing = false
 
         if (runNextFrame && allowKeepAlive) {


### PR DESCRIPTION
Closes https://github.com/framer/motion/pull/2720

This takes a similar but slightly different approach to the linked PR.

The frameloop was originally a very small standalone library (and could be again?) so there's a focus on filesize where performance isn't really affected.

As the `.reduce` was the smallest implementation and is only called twice, this was chosen here.

The linked PR introduces a hoisted `runNextFrame` which is a good idea, probably the source of the "hot" function so makes sense to define it just once.

Here I've taken the linked PR's idea of unrolling the render steps but, instead of doing it in performance-insensitive areas where there's that trade of bundlesize, doing in the render loop itself which runs every frame and is highly performance sensitive.

Finally I've taken the linked PR's approach of replacing the `forEach` in the `cancel` function with a `for` loop, removing a function assignment. It should be that `cancel` is performed quite infrequently but it's also true that you never know.