### PR TITLE
fix(framer-motion-3d): call invalidate when an update is happening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.3.6] 2024-07-16
+
+### Fixed
+
+-   Call `invalidate` from `@react-three/fiber` when updaging values in framer-motion-3d, this is required to support on demand rendering
+
 ## [11.3.5] 2024-07-16
 
 ### Fixed

--- a/packages/framer-motion-3d/src/render/utils/set-value.ts
+++ b/packages/framer-motion-3d/src/render/utils/set-value.ts
@@ -1,4 +1,4 @@
-import { Object3DNode } from "@react-three/fiber"
+import { invalidate, Object3DNode } from "@react-three/fiber"
 import { Euler, Vector3, Color } from "three"
 import { ThreeRenderState } from "../../types"
 
@@ -69,6 +69,7 @@ export function setThreeValue(
     key: string,
     values: ThreeRenderState
 ): void {
+    invalidate()
     if (key in setters) {
         setters[key](instance, values[key])
     } else {


### PR DESCRIPTION
fixes #2730 

Call `invalidate` from `@react-three/fiber` when updating values in framer-motion-3d. 
This is required to support on demand rendering. 

Libraries like [@react-three/drei](https://github.com/pmndrs/drei) have this built into their components as well when required. 

More info on this can be found here in [the docs](https://docs.pmnd.rs/react-three-fiber/advanced/scaling-performance#on-demand-rendering)