### PR TITLE
Perf: Lazy render

### DIFF
--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -554,6 +554,7 @@ export abstract class VisualElement<
     }
 
     render = () => {
+        this.isRenderScheduled = false
         if (!this.current) return
         this.triggerBuild()
         this.renderInstance(
@@ -564,7 +565,13 @@ export abstract class VisualElement<
         )
     }
 
-    scheduleRender = () => frame.render(this.render, false, true)
+    private isRenderScheduled = false
+    scheduleRender = () => {
+        if (!this.isRenderScheduled) {
+            this.isRenderScheduled = true
+            frame.render(this.render, false, true)
+        }
+    }
 
     /**
      * Measure the current viewport box with or without transforms.


### PR DESCRIPTION
We never schedule the same job twice but this involves a `Set` lookup. By manually tracking render we can save the lookup here and this improves framerates a little.