### PR TITLE
`AnimatePresence` 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Framer Motion adheres to [Semantic Versioning](http://semver.org/).
 
 Undocumented APIs should be considered internal and may change without warning.
 
+## [11.3.18] 2024-07-29
+
+### Fixed
+
+-   Improved correctness of `AnimatePresence` and made safe to use with concurrent rendering.
+
 ## [11.3.17] 2024-07-24
 
 ### Added

--- a/dev/react/package.json
+++ b/dev/react/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react",
     "private": true,
-    "version": "11.3.17",
+    "version": "11.3.18-alpha.0",
     "type": "module",
     "scripts": {
         "dev": "vite",
@@ -11,7 +11,7 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "framer-motion": "^11.3.17",
+        "framer-motion": "^11.3.18-alpha.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },

--- a/dev/react/src/examples/AnimatePresence-siblings.tsx
+++ b/dev/react/src/examples/AnimatePresence-siblings.tsx
@@ -17,16 +17,15 @@ const style = {
 
 function ExitComponent({ id }) {
     return (
-        <>
-            <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 1 }}
-                style={style}
-                id={id}
-            />
-        </>
+        <motion.div
+            key={id}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 1 }}
+            style={style}
+            id={id}
+        />
     )
 }
 

--- a/dev/react/src/examples/AnimatePresence-switch.tsx
+++ b/dev/react/src/examples/AnimatePresence-switch.tsx
@@ -18,7 +18,6 @@ export const App = () => {
     return (
         <div
             onClick={() => {
-                console.log("========= click =========")
                 setKey(key === "a" ? "b" : "a")
             }}
         >

--- a/dev/react/src/examples/AnimatePresence-switch.tsx
+++ b/dev/react/src/examples/AnimatePresence-switch.tsx
@@ -1,0 +1,43 @@
+import { motion, AnimatePresence } from "framer-motion"
+import { useState } from "react"
+
+/**
+ * An example of a single-child AnimatePresence animation
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "red",
+    opacity: 1,
+}
+
+export const App = () => {
+    const [key, setKey] = useState("a")
+
+    return (
+        <div
+            onClick={() => {
+                console.log("========= click =========")
+                setKey(key === "a" ? "b" : "a")
+            }}
+        >
+            <AnimatePresence
+                initial={false}
+                onExitComplete={() => console.log("rest")}
+            >
+                <motion.div
+                    key={key}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 1 }}
+                    style={{
+                        ...style,
+                        background: key === "a" ? "green" : "blue",
+                    }}
+                />
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/dev/react/src/examples/AnimatePresence-variants.tsx
+++ b/dev/react/src/examples/AnimatePresence-variants.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion"
-import { useEffect, useState } from "react";
+import { useEffect, useState } from "react"
 
 /**
  * An example of AnimatePresence with exit defined as a variant through a tree.

--- a/dev/react/src/examples/AnimatePresence-wait.tsx
+++ b/dev/react/src/examples/AnimatePresence-wait.tsx
@@ -1,0 +1,43 @@
+import { motion, AnimatePresence } from "framer-motion"
+import { useState } from "react"
+
+/**
+ * An example of a single-child AnimatePresence animation
+ */
+
+const style = {
+    width: 100,
+    height: 100,
+    background: "red",
+    opacity: 1,
+}
+
+export const App = () => {
+    const [key, setKey] = useState(0)
+
+    return (
+        <div
+            onClick={() => {
+                setKey(key + 1)
+            }}
+        >
+            <AnimatePresence
+                initial={false}
+                mode="wait"
+                onExitComplete={() => console.log("rest")}
+            >
+                <motion.div
+                    key={key}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 1 }}
+                    style={{
+                        ...style,
+                        background: `hsla(${key * 15}, 100%, 50%, 1)`,
+                    }}
+                />
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/dev/react/src/examples/AnimatePresence.tsx
+++ b/dev/react/src/examples/AnimatePresence.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from "framer-motion"
-import { useEffect, useState } from "react";
+import { useState } from "react"
 
 /**
  * An example of a single-child AnimatePresence animation
@@ -15,26 +15,23 @@ const style = {
 export const App = () => {
     const [isVisible, setVisible] = useState(true)
 
-    useEffect(() => {
-        setTimeout(() => {
-            setVisible(!isVisible)
-        }, 1500)
-    })
-
     return (
-        <AnimatePresence
-            initial={false}
-            onExitComplete={() => console.log("rest")}
-        >
-            {isVisible && (
-                <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 1 }}
-                    style={style}
-                />
-            )}
-        </AnimatePresence>
+        <div onClick={() => setVisible(!isVisible)}>
+            <AnimatePresence
+                initial={false}
+                onExitComplete={() => console.log("rest")}
+            >
+                {isVisible && (
+                    <motion.div
+                        key="a"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 1 }}
+                        style={style}
+                    />
+                )}
+            </AnimatePresence>
+        </div>
     )
 }

--- a/dev/react/src/tests/animate-presence-pop.tsx
+++ b/dev/react/src/tests/animate-presence-pop.tsx
@@ -49,7 +49,7 @@ export const App = () => {
                             opacity: 1,
                             transition: { duration: 0.001 },
                         }}
-                        exit={{ opacity: 0, transition: { duration: 10 } }}
+                        exit={{ opacity: 0 }}
                         layout
                         style={{ ...itemStyle, backgroundColor: "green" }}
                     />

--- a/dev/react/src/tests/animate-presence-pop.tsx
+++ b/dev/react/src/tests/animate-presence-pop.tsx
@@ -49,7 +49,7 @@ export const App = () => {
                             opacity: 1,
                             transition: { duration: 0.001 },
                         }}
-                        exit={{ opacity: 0 }}
+                        exit={{ opacity: 0, transition: { duration: 10 } }}
                         layout
                         style={{ ...itemStyle, backgroundColor: "green" }}
                     />

--- a/dev/react/src/tests/animate-presence-switch-waapi.tsx
+++ b/dev/react/src/tests/animate-presence-switch-waapi.tsx
@@ -1,0 +1,31 @@
+import { AnimatePresence, motion } from "framer-motion"
+import { useState } from "react"
+
+export const App = () => {
+    const [state, setState] = useState(0)
+
+    return (
+        <>
+            <button
+                id="switch"
+                onClick={() => {
+                    state === 0 ? setState(1) : setState(0)
+                }}
+            >
+                Switch
+            </button>
+            <AnimatePresence initial={false}>
+                <motion.div
+                    className="item"
+                    key={state}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.2 }}
+                >
+                    {state}
+                </motion.div>
+            </AnimatePresence>
+        </>
+    )
+}

--- a/dev/react/src/tests/animate-presence-switch-waapi.tsx
+++ b/dev/react/src/tests/animate-presence-switch-waapi.tsx
@@ -16,11 +16,11 @@ export const App = () => {
                 Switch
             </button>
             <div>
-                Animation count:{" "}
-                <motion.span id="animation-counter">{count}</motion.span>
+                Animation count: <motion.span id="count">{count}</motion.span>
             </div>
             <AnimatePresence initial={false}>
                 <motion.div
+                    id={state.toString()}
                     className="item"
                     key={state}
                     initial={{ opacity: 0 }}

--- a/dev/react/src/tests/animate-presence-switch-waapi.tsx
+++ b/dev/react/src/tests/animate-presence-switch-waapi.tsx
@@ -1,7 +1,8 @@
-import { AnimatePresence, motion } from "framer-motion"
+import { AnimatePresence, motion, useMotionValue } from "framer-motion"
 import { useState } from "react"
 
 export const App = () => {
+    const count = useMotionValue(0)
     const [state, setState] = useState(0)
 
     return (
@@ -14,6 +15,10 @@ export const App = () => {
             >
                 Switch
             </button>
+            <div>
+                Animation count:{" "}
+                <motion.span id="animation-counter">{count}</motion.span>
+            </div>
             <AnimatePresence initial={false}>
                 <motion.div
                     className="item"
@@ -22,6 +27,7 @@ export const App = () => {
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.2 }}
+                    onAnimationStart={() => count.set(count.get() + 1)}
                 >
                     {state}
                 </motion.div>

--- a/dev/react/src/tests/layout-exit.tsx
+++ b/dev/react/src/tests/layout-exit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from "react"
 import { motion, AnimatePresence } from "framer-motion"
 
 export const App = () => {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "11.3.17",
+    "version": "11.3.18-alpha.0",
     "packages": [
         "packages/*"
     ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "test-e2e": "turbo run test-e2e",
         "test-ci": "turbo run test-ci --no-cache",
         "measure": "turbo run measure",
-        "prepare": "turbo run build measure test test-e2e",
+        "prepare": "",
         "new": "lerna publish from-package",
         "new-alpha": "turbo run build && lerna publish from-package --canary --preid alpha"
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "test-e2e": "turbo run test-e2e",
         "test-ci": "turbo run test-ci --no-cache",
         "measure": "turbo run measure",
-        "prepare": "",
+        "prepare": "turbo run build measure test test-e2e",
         "new": "lerna publish from-package",
         "new-alpha": "turbo run build && lerna publish from-package --canary --preid alpha"
     },

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion-3d",
-    "version": "11.3.17",
+    "version": "11.3.18-alpha.0",
     "description": "A simple and powerful React animation library for @react-three/fiber",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",
@@ -47,7 +47,7 @@
         "postpublish": "git push --tags"
     },
     "dependencies": {
-        "framer-motion": "^11.3.17",
+        "framer-motion": "^11.3.18-alpha.0",
         "react-merge-refs": "^2.0.1"
     },
     "peerDependencies": {

--- a/packages/framer-motion-3d/package.json
+++ b/packages/framer-motion-3d/package.json
@@ -62,5 +62,5 @@
         "@rollup/plugin-commonjs": "^22.0.1",
         "three": "^0.137.0"
     },
-    "gitHead": "7ce78149a4f0587c409a660214131a04fca04c51"
+    "gitHead": "f3c9de1ba4eb913f36e1f3e816f9c86784714910"
 }

--- a/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
@@ -1,0 +1,60 @@
+describe("AnimatePresence with WAAPI animations", () => {
+    it("Interrupting exiting animation doesn't break exit", () => {
+        cy.visit("?test=animate-presence-switch-waapi")
+            .wait(50)
+            .get(".item")
+            .should((items: any) => {
+                expect(items.length).to.equal(1)
+                expect(items[0].textContent).to.equal("0")
+            })
+            .get("#switch")
+            .trigger("click", 10, 10, { force: true })
+            .wait(50)
+            .get(".item")
+            .should((items: any) => {
+                expect(items.length).to.equal(2)
+                expect(items[0].textContent).to.equal("0")
+                expect(items[1].textContent).to.equal("1")
+            })
+            .wait(200)
+            .get(".item")
+            .should((items: any) => {
+                expect(items.length).to.equal(1)
+                expect(items[0].textContent).to.equal("1")
+            })
+            .get("#switch")
+            .trigger("click", 10, 10, { force: true })
+            .wait(20)
+            .get("#switch")
+            .trigger("click", 10, 10, { force: true })
+            .wait(20)
+            .get("#switch")
+            .trigger("click", 10, 10, { force: true })
+            .wait(300)
+            .get(".item")
+            .should((items: any) => {
+                expect(items.length).to.equal(1)
+            })
+        // .wait(50)
+        // .get("#b")
+        // .should(([$a]: any) => {
+        //     expectBbox($a, {
+        //         top: 200,
+        //         left: 100,
+        //         width: 100,
+        //         height: 100,
+        //     })
+        // })
+        // .get("#c")
+        // .should(([$a]: any) => {
+        //     expectBbox($a, {
+        //         top: 300,
+        //         left: 100,
+        //         width: 100,
+        //         height: 100,
+        //     })
+        // })
+        // .trigger("click", 60, 60, { force: true })
+        // .wait(100)
+    })
+})

--- a/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
@@ -37,4 +37,24 @@ describe("AnimatePresence with WAAPI animations", () => {
                 expect(items[0].textContent).to.equal("0")
             })
     })
+
+    it("Interrupting exiting animation fire more animations than expected", () => {
+        cy.visit("?test=animate-presence-switch-waapi")
+            .wait(50)
+            .get(".item")
+            .should((items: any) => {
+                expect(items.length).to.equal(1)
+                expect(items[0].textContent).to.equal("0")
+            })
+            .get("#switch")
+            .trigger("click", 10, 10, { force: true })
+            .wait(20)
+            .get("#switch")
+            .trigger("click", 10, 10, { force: true })
+            .wait(300)
+            .get("#count")
+            .should((count: any) => {
+                expect(count[0].textContent).to.equal("4")
+            })
+    })
 })

--- a/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
@@ -34,6 +34,7 @@ describe("AnimatePresence with WAAPI animations", () => {
             .get(".item")
             .should((items: any) => {
                 expect(items.length).to.equal(1)
+                expect(items[0].textContent).to.equal("0")
             })
     })
 })

--- a/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-switch-waapi.ts
@@ -35,26 +35,5 @@ describe("AnimatePresence with WAAPI animations", () => {
             .should((items: any) => {
                 expect(items.length).to.equal(1)
             })
-        // .wait(50)
-        // .get("#b")
-        // .should(([$a]: any) => {
-        //     expectBbox($a, {
-        //         top: 200,
-        //         left: 100,
-        //         width: 100,
-        //         height: 100,
-        //     })
-        // })
-        // .get("#c")
-        // .should(([$a]: any) => {
-        //     expectBbox($a, {
-        //         top: 300,
-        //         left: 100,
-        //         width: 100,
-        //         height: 100,
-        //     })
-        // })
-        // .trigger("click", 60, 60, { force: true })
-        // .wait(100)
     })
 })

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -1,6 +1,6 @@
 {
     "name": "framer-motion",
-    "version": "11.3.17",
+    "version": "11.3.18-alpha.0",
     "description": "A simple and powerful JavaScript animation library",
     "main": "dist/cjs/index.js",
     "module": "dist/es/index.mjs",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -104,5 +104,5 @@
             "maxSize": "18 kB"
         }
     ],
-    "gitHead": "7ce78149a4f0587c409a660214131a04fca04c51"
+    "gitHead": "f3c9de1ba4eb913f36e1f3e816f9c86784714910"
 }

--- a/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
@@ -313,6 +313,9 @@ export class AcceleratedAnimation<
         this.isStopped = true
         if (this.state === "idle") return
 
+        this.resolveFinishedPromise()
+        this.updateFinishedPromise()
+
         const { resolved } = this
         if (!resolved) return
 

--- a/packages/framer-motion/src/animation/interfaces/visual-element.ts
+++ b/packages/framer-motion/src/animation/interfaces/visual-element.ts
@@ -1,4 +1,3 @@
-import { frame } from "../../frameloop"
 import { resolveVariant } from "../../render/utils/resolve-dynamic-variants"
 import { VisualElement } from "../../render/VisualElement"
 import { AnimationDefinition } from "../types"
@@ -33,8 +32,6 @@ export function animateVisualElement(
     }
 
     return animation.then(() => {
-        frame.postRender(() => {
-            visualElement.notify("AnimationComplete", definition)
-        })
+        visualElement.notify("AnimationComplete", definition)
     })
 }

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -192,6 +192,7 @@ describe("AnimatePresence", () => {
             const { rerender } = render(<Component isVisible />)
             rerender(<Component isVisible />)
             await nextFrame()
+            await nextFrame()
             rerender(<Component isVisible={false} />)
             rerender(<Component isVisible={false} />)
         })
@@ -398,6 +399,7 @@ describe("AnimatePresence", () => {
                 return (
                     <AnimatePresence mode="wait">
                         <motion.div
+                            initial={false}
                             key={i}
                             data-testid={i}
                             exit={{ opacity: 0 }}
@@ -414,14 +416,15 @@ describe("AnimatePresence", () => {
             rerender(<Component i={0} />)
             setTimeout(() => {
                 rerender(<Component i={1} />)
-            }, 50)
-            setTimeout(() => {
-                rerender(<Component i={2} />)
-                // wait for the exit animation to check the DOM again
+
                 setTimeout(() => {
-                    resolve(getByTestId("2").textContent === "2")
-                }, 200)
-            }, 200)
+                    rerender(<Component i={2} />)
+                    // wait for the exit animation to check the DOM again
+                    setTimeout(() => {
+                        resolve(getByTestId("2").textContent === "2")
+                    }, 250)
+                }, 50)
+            }, 50)
         })
 
         return await expect(promise).resolves.toBeTruthy()

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -153,7 +153,7 @@ describe("AnimatePresence", () => {
     })
 
     test("when: afterChildren fires correctly", async () => {
-        const child = await new Promise<number>((resolve) => {
+        const child = await new Promise<number>(async (resolve) => {
             const parentOpacityOutput: ResolvedValues[] = []
 
             const variants = {
@@ -191,6 +191,7 @@ describe("AnimatePresence", () => {
 
             const { rerender } = render(<Component isVisible />)
             rerender(<Component isVisible />)
+            await nextFrame()
             rerender(<Component isVisible={false} />)
             rerender(<Component isVisible={false} />)
         })
@@ -419,7 +420,7 @@ describe("AnimatePresence", () => {
                 // wait for the exit animation to check the DOM again
                 setTimeout(() => {
                     resolve(getByTestId("2").textContent === "2")
-                }, 150)
+                }, 200)
             }, 200)
         })
 

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -242,9 +242,10 @@ export const AnimatePresence: React.FunctionComponent<
     // the same tree between renders
     childrenToRender = childrenToRender.map((child) => {
         const key = child.key as string | number
+        const exitingChild = exitingChildren.get(key)
 
-        return exitingChildren.get(key) ? (
-            exitingChildren.get(key)!
+        return exitingChild ? (
+            exitingChild
         ) : (
             <PresenceChild
                 key={getChildKey(child)}

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -198,6 +198,7 @@ export const AnimatePresence: React.FunctionComponent<
                     if (isEveryExitComplete) {
                         forceRender?.()
                         setRenderedChildren(pendingPresentChildren.current)
+
                         onExitComplete && onExitComplete()
                     }
                 }

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -270,5 +270,5 @@ export const AnimatePresence: React.FunctionComponent<
         )
     }
 
-    return childrenToRender
+    return <>{childrenToRender}</>
 }

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -1,45 +1,12 @@
-import {
-    useRef,
-    isValidElement,
-    Children,
-    ReactElement,
-    ReactNode,
-    useContext,
-} from "react"
+import { useContext, useState, useMemo, useRef } from "react"
 import * as React from "react"
 import { AnimatePresenceProps } from "./types"
-import { useForceUpdate } from "../../utils/use-force-update"
-import { useIsMounted } from "../../utils/use-is-mounted"
 import { PresenceChild } from "./PresenceChild"
 import { LayoutGroupContext } from "../../context/LayoutGroupContext"
-import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
-import { useUnmountEffect } from "../../utils/use-unmount-effect"
 import { invariant } from "../../utils/errors"
-
-type ComponentKey = string | number
-
-const getChildKey = (child: ReactElement<any>): ComponentKey => child.key || ""
-
-function updateChildLookup(
-    children: ReactElement<any>[],
-    allChildren: Map<ComponentKey, ReactElement<any>>
-) {
-    children.forEach((child) => {
-        const key = getChildKey(child)
-        allChildren.set(key, child)
-    })
-}
-
-function onlyElements(children: ReactNode): ReactElement<any>[] {
-    const filtered: ReactElement<any>[] = []
-
-    // We use forEach here instead of map as map mutates the component key by preprending `.$`
-    Children.forEach(children, (child) => {
-        if (isValidElement(child)) filtered.push(child)
-    })
-
-    return filtered
-}
+import { useIsomorphicLayoutEffect } from "../../three-entry"
+import { useConstant } from "../../utils/use-constant"
+import { ComponentKey, arrayEquals, getChildKey, onlyElements } from "./utils"
 
 /**
  * `AnimatePresence` enables the animation of components that have been removed from the tree.
@@ -78,197 +45,181 @@ export const AnimatePresence: React.FunctionComponent<
     React.PropsWithChildren<AnimatePresenceProps>
 > = ({
     children,
+    exitBeforeEnter,
     custom,
     initial = true,
     onExitComplete,
-    exitBeforeEnter,
     presenceAffectsLayout = true,
     mode = "sync",
 }) => {
     invariant(!exitBeforeEnter, "Replace exitBeforeEnter with mode='wait'")
 
-    // We want to force a re-render once all exiting animations have finished. We
-    // either use a local forceRender function, or one from a parent context if it exists.
-    const forceRender =
-        useContext(LayoutGroupContext).forceRender || useForceUpdate()[0]
+    /**
+     * Filter any children that aren't ReactElements. We can only track components
+     * between renders with a props.key.
+     */
+    const presentChildren = useMemo(() => onlyElements(children), [children])
 
-    const isMounted = useIsMounted()
+    /**
+     * Track the keys of the currently rendered children. This is used to
+     * determine which children are exiting.
+     */
+    const presentKeys = presentChildren.map(getChildKey)
 
-    // Filter out any children that aren't ReactElements. We can only track ReactElements with a props.key
-    const filteredChildren = onlyElements(children)
-    let childrenToRender = filteredChildren
-
-    const exitingChildren = useRef(
-        new Map<ComponentKey, ReactElement<any> | undefined>()
-    ).current
-
-    // Keep a living record of the children we're actually rendering so we
-    // can diff to figure out which are entering and exiting
-    const presentChildren = useRef(childrenToRender)
-
-    // A lookup table to quickly reference components by key
-    const allChildren = useRef(
-        new Map<ComponentKey, ReactElement<any>>()
-    ).current
-
-    // If this is the initial component render, just deal with logic surrounding whether
-    // we play onMount animations or not.
+    /**
+     * If `initial={false}` we only want to pass this to components in the first render.
+     */
     const isInitialRender = useRef(true)
+
+    /**
+     * A ref containing the currently present children. When all exit animations
+     * are complete, we use this to re-render the component with the latest children
+     * *committed* rather than the latest children *rendered*.
+     */
+    const pendingPresentChildren = useRef(presentChildren)
+
+    /**
+     * Track which exiting children have finished animating out.
+     */
+    const exitComplete = useConstant(() => new Map<ComponentKey, boolean>())
+
+    /**
+     * Save children to render as React state. To ensure this component is concurrent-safe,
+     * we check for exiting children via an effect.
+     */
+    const [diffedChildren, setDiffedChildren] = useState(presentChildren)
+    const [renderedChildren, setRenderedChildren] = useState(presentChildren)
 
     useIsomorphicLayoutEffect(() => {
         isInitialRender.current = false
+        pendingPresentChildren.current = presentChildren
 
-        updateChildLookup(filteredChildren, allChildren)
-        presentChildren.current = childrenToRender
-    })
+        /**
+         * Update complete status of exiting children.
+         */
+        for (let i = 0; i < renderedChildren.length; i++) {
+            const key = getChildKey(renderedChildren[i])
 
-    useUnmountEffect(() => {
-        isInitialRender.current = true
-        allChildren.clear()
-        exitingChildren.clear()
-    })
-
-    if (isInitialRender.current) {
-        return (
-            <>
-                {childrenToRender.map((child) => (
-                    <PresenceChild
-                        key={getChildKey(child)}
-                        isPresent
-                        initial={initial ? undefined : false}
-                        presenceAffectsLayout={presenceAffectsLayout}
-                        mode={mode}
-                    >
-                        {child}
-                    </PresenceChild>
-                ))}
-            </>
-        )
-    }
-
-    // If this is a subsequent render, deal with entering and exiting children
-    childrenToRender = [...childrenToRender]
-
-    // Diff the keys of the currently-present and target children to update our
-    // exiting list.
-    const presentKeys = presentChildren.current.map(getChildKey)
-    const targetKeys = filteredChildren.map(getChildKey)
-
-    // Diff the present children with our target children and mark those that are exiting
-    const numPresent = presentKeys.length
-    for (let i = 0; i < numPresent; i++) {
-        const key = presentKeys[i]
-
-        if (targetKeys.indexOf(key) === -1 && !exitingChildren.has(key)) {
-            exitingChildren.set(key, undefined)
-        }
-    }
-
-    // If we currently have exiting children, and we're deferring rendering incoming children
-    // until after all current children have exiting, empty the childrenToRender array
-    if (mode === "wait" && exitingChildren.size) {
-        childrenToRender = []
-    }
-
-    // Loop through all currently exiting components and clone them to overwrite `animate`
-    // with any `exit` prop they might have defined.
-    exitingChildren.forEach((exitingComponent, key) => {
-        // If this component is actually entering again, early return
-        if (targetKeys.indexOf(key) !== -1) return
-
-        const child = allChildren.get(key)
-
-        if (!child) return
-
-        const insertionIndex = presentKeys.indexOf(key)
-
-        if (!exitingComponent) {
-            const onExit = () => {
-                // clean up the exiting children map
-                exitingChildren.delete(key)
-
-                // compute the keys of children that were rendered once but are no longer present
-                // this could happen in case of too many fast consequent renderings
-                // @link https://github.com/framer/motion/issues/2023
-                const leftOverKeys = Array.from(allChildren.keys()).filter(
-                    (childKey) => !targetKeys.includes(childKey)
-                )
-
-                // clean up the all children map
-                leftOverKeys.forEach((leftOverKey) =>
-                    allChildren.delete(leftOverKey)
-                )
-
-                // make sure to render only the children that are actually visible
-                presentChildren.current = filteredChildren.filter(
-                    (presentChild) => {
-                        const presentChildKey = getChildKey(presentChild)
-
-                        return (
-                            // filter out the node exiting
-                            presentChildKey === key ||
-                            // filter out the leftover children
-                            leftOverKeys.includes(presentChildKey)
-                        )
-                    }
-                )
-
-                // Defer re-rendering until all exiting children have indeed left
-                if (!exitingChildren.size) {
-                    if (isMounted.current === false) return
-
-                    forceRender()
-                    onExitComplete && onExitComplete()
+            if (!presentKeys.includes(key)) {
+                if (exitComplete.get(key) !== true) {
+                    exitComplete.set(key, false)
                 }
+            } else {
+                exitComplete.delete(key)
             }
+        }
+    }, [renderedChildren, presentKeys.length, presentKeys.join("-")])
 
-            exitingComponent = (
-                <PresenceChild
-                    key={getChildKey(child)}
-                    isPresent={false}
-                    onExitComplete={onExit}
-                    custom={custom}
-                    presenceAffectsLayout={presenceAffectsLayout}
-                    mode={mode}
-                >
-                    {child}
-                </PresenceChild>
-            )
-            exitingChildren.set(key, exitingComponent)
+    const exitingChildren = []
+
+    if (presentChildren !== diffedChildren) {
+        let nextChildren = [...presentChildren]
+
+        /**
+         * Loop through all the currently rendered components and decide which
+         * are exiting.
+         */
+        for (let i = 0; i < renderedChildren.length; i++) {
+            const child = renderedChildren[i]
+            const key = getChildKey(child)
+
+            if (!presentKeys.includes(key)) {
+                nextChildren.splice(i, 0, child)
+                exitingChildren.push(child)
+            }
         }
 
-        childrenToRender.splice(insertionIndex, 0, exitingComponent)
-    })
+        /**
+         * If we're in "wait" mode, and we have exiting children, we want to
+         * only render these until they've all exited.
+         */
+        if (mode === "wait" && exitingChildren.length) {
+            nextChildren = exitingChildren
+        }
 
-    // Add `MotionContext` even to children that don't need it to ensure we're rendering
-    // the same tree between renders
-    childrenToRender = childrenToRender.map((child) => {
-        const key = child.key as string | number
-        const exitingChild = exitingChildren.get(key)
+        nextChildren = onlyElements(nextChildren)
 
-        return exitingChild ? (
-            exitingChild
-        ) : (
-            <PresenceChild
-                key={getChildKey(child)}
-                isPresent
-                presenceAffectsLayout={presenceAffectsLayout}
-                mode={mode}
-            >
-                {child}
-            </PresenceChild>
+        const childrenHaveChanged = !arrayEquals(
+            nextChildren.map(getChildKey),
+            renderedChildren.map(getChildKey)
         )
-    })
+
+        if (childrenHaveChanged) {
+            setRenderedChildren(nextChildren)
+        }
+
+        setDiffedChildren(presentChildren)
+
+        /**
+         * Early return to ensure once we've set state with the latest diffed
+         * children, we can immediately re-render.
+         */
+        return
+    }
 
     if (
         process.env.NODE_ENV !== "production" &&
         mode === "wait" &&
-        childrenToRender.length > 1
+        renderedChildren.length > 1
     ) {
         console.warn(
             `You're attempting to animate multiple children within AnimatePresence, but its mode is set to "wait". This will lead to odd visual behaviour.`
         )
     }
 
-    return <>{childrenToRender}</>
+    /**
+     * If we've been provided a forceRender function by the LayoutGroupContext,
+     * we can use it to force a re-render amongst all surrounding components once
+     * all components have finished animating out.
+     */
+    const { forceRender } = useContext(LayoutGroupContext)
+
+    return (
+        <>
+            {renderedChildren.map((child) => {
+                const key = getChildKey(child)
+
+                const isPresent =
+                    presentChildren === renderedChildren ||
+                    presentKeys.includes(key)
+
+                const onExit = () => {
+                    if (exitComplete.has(key)) {
+                        exitComplete.set(key, true)
+                    } else {
+                        return
+                    }
+
+                    let isEveryExitComplete = true
+                    exitComplete.forEach((isExitComplete) => {
+                        if (!isExitComplete) isEveryExitComplete = false
+                    })
+
+                    if (isEveryExitComplete) {
+                        forceRender?.()
+                        setRenderedChildren(pendingPresentChildren.current)
+                        onExitComplete && onExitComplete()
+                    }
+                }
+
+                return (
+                    <PresenceChild
+                        key={key}
+                        isPresent={isPresent}
+                        initial={
+                            !isInitialRender.current || initial
+                                ? undefined
+                                : false
+                        }
+                        custom={isPresent ? undefined : custom}
+                        presenceAffectsLayout={presenceAffectsLayout}
+                        mode={mode}
+                        onExitComplete={isPresent ? undefined : onExit}
+                    >
+                        {child}
+                    </PresenceChild>
+                )
+            })}
+        </>
+    )
 }

--- a/packages/framer-motion/src/components/AnimatePresence/utils.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/utils.ts
@@ -1,0 +1,27 @@
+import { isValidElement, Children, ReactElement, ReactNode } from "react"
+
+export type ComponentKey = string | number
+
+export const getChildKey = (child: ReactElement<any>): ComponentKey =>
+    child.key || ""
+
+export function onlyElements(children: ReactNode): ReactElement<any>[] {
+    const filtered: ReactElement<any>[] = []
+
+    // We use forEach here instead of map as map mutates the component key by preprending `.$`
+    Children.forEach(children, (child) => {
+        if (isValidElement(child)) filtered.push(child)
+    })
+
+    return filtered
+}
+
+export function arrayEquals(a: any[], b: any[]) {
+    if (a.length !== b.length) return false
+
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false
+    }
+
+    return true
+}

--- a/packages/framer-motion/src/gestures/__tests__/focus.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/focus.test.tsx
@@ -1,6 +1,6 @@
 import { focus, blur, render } from "../../../jest.setup"
-import { createRef } from "react";
-import { motion, motionValue } from "../../"
+import { createRef } from "react"
+import { frame, motion, motionValue } from "../../"
 import { nextFrame } from "./utils"
 
 describe("focus", () => {
@@ -142,7 +142,9 @@ describe("focus", () => {
             const opacity = motionValue(1)
 
             let blurred = false
-            const onComplete = () => blurred && resolve(opacity.get())
+            const onComplete = () => {
+                frame.postRender(() => blurred && resolve(opacity.get()))
+            }
 
             const Component = ({ onAnimationComplete }: any) => (
                 <motion.a

--- a/packages/framer-motion/src/gestures/__tests__/hover.test.tsx
+++ b/packages/framer-motion/src/gestures/__tests__/hover.test.tsx
@@ -4,7 +4,7 @@ import {
     pointerLeave,
     render,
 } from "../../../jest.setup"
-import { motion } from "../../"
+import { frame, motion } from "../../"
 import { motionValue } from "../../value"
 import { nextFrame } from "./utils"
 
@@ -140,7 +140,9 @@ describe("hover", () => {
             const opacity = motionValue(1)
 
             let hasMousedOut = false
-            const onComplete = () => hasMousedOut && resolve(opacity.get())
+            const onComplete = () => {
+                frame.postRender(() => hasMousedOut && resolve(opacity.get()))
+            }
 
             const Component = ({ onAnimationComplete }: any) => (
                 <motion.div

--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -158,7 +158,9 @@ describe("animate prop as variant", () => {
                 },
             }
             const display = motionValue("block")
-            const onComplete = () => resolve(display.get())
+            const onComplete = () => {
+                frame.postRender(() => resolve(display.get()))
+            }
             const Component = () => (
                 <motion.div
                     initial="hidden"

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -455,6 +455,7 @@ export abstract class VisualElement<
         for (const key in this.events) {
             this.events[key].clear()
         }
+
         for (const key in this.features) {
             const feature = this.features[key as keyof typeof this.features]
             if (feature) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7186,7 +7186,7 @@ __metadata:
     "@react-three/fiber": ^8.2.2
     "@react-three/test-renderer": ^9.0.0
     "@rollup/plugin-commonjs": ^22.0.1
-    framer-motion: ^11.3.17
+    framer-motion: ^11.3.18-alpha.0
     react-merge-refs: ^2.0.1
     three: ^0.137.0
   peerDependencies:
@@ -7197,7 +7197,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"framer-motion@^11.3.17, framer-motion@workspace:packages/framer-motion":
+"framer-motion@^11.3.18-alpha.0, framer-motion@workspace:packages/framer-motion":
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:
@@ -12212,7 +12212,7 @@ __metadata:
     "@typescript-eslint/parser": ^7.2.0
     "@vitejs/plugin-react-swc": ^3.5.0
     eslint-plugin-react-refresh: ^0.4.6
-    framer-motion: ^11.3.17
+    framer-motion: ^11.3.18-alpha.0
     react: ^18.2.0
     react-dom: ^18.2.0
     styled-components: ^6.1.11


### PR DESCRIPTION
Fixes https://github.com/framer/motion/issues/2554
Fixes https://github.com/framer/motion/issues/2693
Fixes https://github.com/framer/motion/issues/2618
Fixes https://github.com/framer/motion/issues/2639
Fixes https://github.com/framer/motion/issues/2673
Fixes https://github.com/framer/motion/issues/2690
Fixes https://github.com/framer/motion/issues/1983

Improves correctness of `AnimatePresence` and makes safe for concurrent rendering by replacing mutable data structures with two-pass render.