### PR TITLE
Fixing springs with same origin/target

### DIFF
--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -374,7 +374,7 @@ export class MainThreadAnimation<
             this.holdTime === null &&
             (this.state === "finished" || (this.state === "running" && done))
 
-        if (isAnimationFinished) {
+        if (isAnimationFinished && finalKeyframe !== undefined) {
             state.value = getFinalKeyframe(
                 keyframes,
                 this.options,

--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -374,7 +374,7 @@ export class MainThreadAnimation<
             this.holdTime === null &&
             (this.state === "finished" || (this.state === "running" && done))
 
-        if (isAnimationFinished && finalKeyframe !== undefined) {
+        if (isAnimationFinished) {
             state.value = getFinalKeyframe(
                 keyframes,
                 this.options,

--- a/packages/framer-motion/src/animation/generators/__tests__/spring.test.ts
+++ b/packages/framer-motion/src/animation/generators/__tests__/spring.test.ts
@@ -1,6 +1,7 @@
 import { ValueAnimationOptions } from "../../types"
 import { spring } from "../spring"
 import { animateSync } from "../../animators/__tests__/utils"
+import { calcGeneratorDuration } from "../utils/calc-duration"
 
 describe("spring", () => {
     test("Runs animations with default values ", () => {
@@ -8,6 +9,7 @@ describe("spring", () => {
             0, 1, 1, 1, 1, 1, 1, 1,
         ])
     })
+
     test("Underdamped spring", () => {
         expect(
             animateSync(
@@ -149,5 +151,18 @@ describe("spring", () => {
 
         expect(resolvedSpring.next(0).value).toBe(500)
         expect(Math.floor(resolvedSpring.next(100).value)).toBe(420)
+    })
+
+    test("Spring animating back to same number returns correct duration", () => {
+        const duration = calcGeneratorDuration(
+            spring({
+                keyframes: [1, 1],
+                velocity: 5,
+                stiffness: 200,
+                damping: 15,
+            })
+        )
+
+        expect(duration).toBe(850)
     })
 })

--- a/packages/framer-motion/src/animation/generators/__tests__/spring.test.ts
+++ b/packages/framer-motion/src/animation/generators/__tests__/spring.test.ts
@@ -163,6 +163,6 @@ describe("spring", () => {
             })
         )
 
-        expect(duration).toBe(850)
+        expect(duration).toBe(600)
     })
 })

--- a/packages/framer-motion/src/animation/generators/spring/index.ts
+++ b/packages/framer-motion/src/animation/generators/spring/index.ts
@@ -145,6 +145,11 @@ export function spring({
             if (!isResolvedFromDuration) {
                 let currentVelocity = 0.0
 
+                /**
+                 * We only need to calculate velocity for under-damped springs
+                 * as over- and critically-damped springs can't overshoot, so
+                 * checking only for displacement is enough.
+                 */
                 if (dampingRatio < 1) {
                     currentVelocity =
                         t === 0

--- a/packages/framer-motion/src/animation/generators/spring/index.ts
+++ b/packages/framer-motion/src/animation/generators/spring/index.ts
@@ -1,4 +1,7 @@
-import { millisecondsToSeconds } from "../../../utils/time-conversion"
+import {
+    millisecondsToSeconds,
+    secondsToMilliseconds,
+} from "../../../utils/time-conversion"
 import { ValueAnimationOptions, SpringOptions } from "../../types"
 import { AnimationState, KeyframeGenerator } from "../types"
 import { calcGeneratorVelocity } from "../utils/velocity"
@@ -20,7 +23,6 @@ function getSpringOptions(options: SpringOptions) {
         isResolvedFromDuration: false,
         ...options,
     }
-
     // stiffness/damping/mass overrides duration/bounce
     if (
         !isSpringType(options, physicsKeys) &&
@@ -65,6 +67,7 @@ export function spring({
         ...options,
         velocity: -millisecondsToSeconds(options.velocity || 0),
     })
+
     const initialVelocity = velocity || 0.0
     const dampingRatio = damping / (2 * Math.sqrt(stiffness * mass))
 
@@ -140,23 +143,13 @@ export function spring({
             const current = resolveSpring(t)
 
             if (!isResolvedFromDuration) {
-                let currentVelocity = initialVelocity
+                let currentVelocity = 0.0
 
-                if (t !== 0) {
-                    /**
-                     * We only need to calculate velocity for under-damped springs
-                     * as over- and critically-damped springs can't overshoot, so
-                     * checking only for displacement is enough.
-                     */
-                    if (dampingRatio < 1) {
-                        currentVelocity = calcGeneratorVelocity(
-                            resolveSpring,
-                            t,
-                            current
-                        )
-                    } else {
-                        currentVelocity = 0
-                    }
+                if (dampingRatio < 1) {
+                    currentVelocity =
+                        t === 0
+                            ? secondsToMilliseconds(initialVelocity)
+                            : calcGeneratorVelocity(resolveSpring, t, current)
                 }
 
                 const isBelowVelocityThreshold =


### PR DESCRIPTION
This PR fixes two bugs:
1. Spring animations with finalKeyframe not ending on the snapped final keyframe
2. Spring animations with a velocity but same origin/target not running correctly