### PR TITLE
fix: prevent stop or pause when drag constraints

### DIFF
--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -98,7 +98,7 @@ export class VisualElementDragControls {
         const onSessionStart = (event: PointerEvent) => {
             const { dragSnapToOrigin, dragConstraints } = this.getProps()
 
-            // Stop or pause any animations on both axis values immediately when not using dragConstraints. 
+            // Stop or pause any animations on both axis values immediately when not using dragConstraints.
             // This allows the user to throw and catch the component.
             if (!dragConstraints) {
                 dragSnapToOrigin ? this.pauseAnimation() : this.stopAnimation()
@@ -456,7 +456,6 @@ export class VisualElementDragControls {
         transition: Transition
     ) {
         const axisValue = this.getAxisMotionValue(axis)
-        console.log("axisValue", axisValue)
 
         return axisValue.start(
             animateMotionValue(
@@ -472,12 +471,10 @@ export class VisualElementDragControls {
     }
 
     private stopAnimation() {
-        console.log("stopAnimation")
         eachAxis((axis) => this.getAxisMotionValue(axis).stop())
     }
 
     private pauseAnimation() {
-        console.log("pauseAnimation")
         eachAxis((axis) => this.getAxisMotionValue(axis).animation?.pause())
     }
 

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -96,11 +96,13 @@ export class VisualElementDragControls {
         if (presenceContext && presenceContext.isPresent === false) return
 
         const onSessionStart = (event: PointerEvent) => {
-            const { dragSnapToOrigin } = this.getProps()
+            const { dragSnapToOrigin, dragConstraints } = this.getProps()
 
-            // Stop or pause any animations on both axis values immediately. This allows the user to throw and catch
-            // the component.
-            dragSnapToOrigin ? this.pauseAnimation() : this.stopAnimation()
+            // Stop or pause any animations on both axis values immediately when not using dragConstraints. 
+            // This allows the user to throw and catch the component.
+            if (!dragConstraints) {
+                dragSnapToOrigin ? this.pauseAnimation() : this.stopAnimation()
+            }
 
             if (snapToCursor) {
                 this.snapToCursor(extractEventInfo(event, "page").point)
@@ -454,6 +456,7 @@ export class VisualElementDragControls {
         transition: Transition
     ) {
         const axisValue = this.getAxisMotionValue(axis)
+        console.log("axisValue", axisValue)
 
         return axisValue.start(
             animateMotionValue(
@@ -469,10 +472,12 @@ export class VisualElementDragControls {
     }
 
     private stopAnimation() {
+        console.log("stopAnimation")
         eachAxis((axis) => this.getAxisMotionValue(axis).stop())
     }
 
     private pauseAnimation() {
+        console.log("pauseAnimation")
         eachAxis((axis) => this.getAxisMotionValue(axis).animation?.pause())
     }
 


### PR DESCRIPTION
fix #2697 

Hello there!

I appreciat your great works 👍 

BTW I found some issue at above

## as is

https://github.com/user-attachments/assets/1e7a6144-e3bd-4cc1-b45f-f029dda00b74

Element pause or stop when click it while dragging

https://github.com/framer/motion/blob/f59114d4d48f4fbd6a611aba62cd9ebab13e06ab/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts#L101-L103

I think it was problem


## to be

https://github.com/user-attachments/assets/cbb9e925-30d1-4122-8ac6-eede4ef80765

So I prevent stop or pause animation when having `dragConstraints`

```tsx
            // Stop or pause any animations on both axis values immediately when not using dragConstraints.
            // This allows the user to throw and catch the component.
            if (!dragConstraints) {
                dragSnapToOrigin ? this.pauseAnimation() : this.stopAnimation()
            }
```

If you think of any related issues, please share them with me!

Thank you! 😄 
