### PR TITLE
Smart `startTime`

### DIFF
--- a/packages/framer-motion/src/animation/__tests__/css-variables.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/css-variables.test.tsx
@@ -107,11 +107,6 @@ describe("css variables", () => {
                 "--color": "rgba(0, 0, 0, 1)",
                 willChange: "auto",
             },
-            {
-                "--a": "20px",
-                "--color": "rgba(0, 0, 0, 1)",
-                willChange: "auto",
-            },
         ])
     })
 

--- a/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
@@ -1,5 +1,4 @@
 import { EasingDefinition } from "../../easing/types"
-import { time } from "../../frameloop/sync-time"
 import { DOMKeyframesResolver } from "../../render/dom/DOMKeyframesResolver"
 import { ResolvedKeyframes } from "../../render/utils/KeyframesResolver"
 import { memo } from "../../utils/memo"
@@ -185,7 +184,7 @@ export class AcceleratedAnimation<
 
         // Override the browser calculated startTime with one synchronised to other JS
         // and WAAPI animations starting this event loop.
-        animation.startTime = time.now()
+        animation.startTime = this.calcStartTime()
 
         if (this.pendingTimeline) {
             animation.timeline = this.pendingTimeline

--- a/packages/framer-motion/src/animation/animators/BaseAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/BaseAnimation.ts
@@ -1,3 +1,4 @@
+import { time } from "../../frameloop/sync-time"
 import {
     KeyframeResolver,
     ResolvedKeyframes,
@@ -11,6 +12,16 @@ import {
 } from "../types"
 import { canAnimate } from "./utils/can-animate"
 import { getFinalKeyframe } from "./waapi/utils/get-final-keyframe"
+
+/**
+ * Maximum time allowed between an animation being created and it being
+ * resolved for us to use the latter as the start time.
+ *
+ * This is to ensure that while we prefer to "start" an animation as soon
+ * as it's triggered, we also want to avoid a visual jump if there's a big delay
+ * between these two moments.
+ */
+const MAX_RESOLVE_DELAY = 40
 
 export interface ValueAnimationOptionsWithDefaults<T extends string | number>
     extends ValueAnimationOptions<T> {
@@ -44,6 +55,10 @@ export abstract class BaseAnimation<T extends string | number, Resolved>
     // Reference to the active keyframes resolver.
     protected resolver: KeyframeResolver<T>
 
+    private createdAt: number
+
+    private resolvedAt: number | undefined
+
     constructor({
         autoplay = true,
         delay = 0,
@@ -53,6 +68,8 @@ export abstract class BaseAnimation<T extends string | number, Resolved>
         repeatType = "loop",
         ...options
     }: ValueAnimationOptions<T>) {
+        this.createdAt = time.now()
+
         this.options = {
             autoplay,
             delay,
@@ -64,6 +81,24 @@ export abstract class BaseAnimation<T extends string | number, Resolved>
         }
 
         this.updateFinishedPromise()
+    }
+
+    /**
+     * This method uses the createdAt and resolvedAt to calculate the
+     * animation startTime. *Ideally*, we would use the createdAt time as t=0
+     * as the following frame would then be the first frame of the animation in
+     * progress, which would feel snappier.
+     *
+     * However, if there's a delay (main thread work) between the creation of
+     * the animation and the first commited frame, we prefer to use resolvedAt
+     * to avoid a sudden jump into the animation.
+     */
+    calcStartTime() {
+        if (!this.resolvedAt) return this.createdAt
+
+        return this.resolvedAt - this.createdAt > MAX_RESOLVE_DELAY
+            ? this.resolvedAt
+            : this.createdAt
     }
 
     protected abstract initPlayback(
@@ -110,6 +145,7 @@ export abstract class BaseAnimation<T extends string | number, Resolved>
         keyframes: ResolvedKeyframes<T>,
         finalKeyframe?: T
     ) {
+        this.resolvedAt = time.now()
         this.hasAttemptedResolve = true
         const {
             name,

--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -447,12 +447,10 @@ export class MainThreadAnimation<
 
         onPlay && onPlay()
 
-        const now = this.driver.now()
-
         if (this.holdTime !== null) {
-            this.startTime = now - this.holdTime
+            this.startTime = this.driver.now() - this.holdTime
         } else if (!this.startTime || this.state === "finished") {
-            this.startTime = now
+            this.startTime = this.calcStartTime()
         }
 
         if (this.state === "finished") {

--- a/packages/framer-motion/src/animation/animators/__tests__/utils.ts
+++ b/packages/framer-motion/src/animation/animators/__tests__/utils.ts
@@ -1,9 +1,17 @@
+import { frameData } from "../../../frameloop"
+import { time } from "../../../frameloop/sync-time"
 import { KeyframeGenerator } from "../../generators/types"
 
 export const syncDriver = (interval = 10) => {
+    time.set(0)
+
     const driver = (update: (v: number) => void) => {
         let isRunning = true
         let elapsed = 0
+
+        frameData.isProcessing = true
+        frameData.delta = interval
+        frameData.timestamp = elapsed
 
         return {
             start: () => {
@@ -17,6 +25,7 @@ export const syncDriver = (interval = 10) => {
                 }, 0)
             },
             stop: () => {
+                frameData.isProcessing = false
                 isRunning = false
             },
             now: () => elapsed,


### PR DESCRIPTION
This PR improves the calculation of `startTime`. It prefers the immediacy of animation creation, but when detecting a potential perceptual jump, will defer the startTime until keyframe resolution.