### PR TITLE
Resume optimised animations where possible

### DIFF
--- a/dev/html/public/optimized-appear/defer-handoff-block.html
+++ b/dev/html/public/optimized-appear/defer-handoff-block.html
@@ -36,7 +36,7 @@
             const { matchViewportBox } = window.Assert
             const root = document.getElementById("root")
 
-            const duration = 4
+            const duration = 1
             const x = motionValue(0)
             const xTarget = 500
 
@@ -85,7 +85,7 @@
                             )
 
                             const startTime = performance.now()
-                            while (performance.now() - startTime < 1000) {}
+                            while (performance.now() - startTime < 200) {}
                         })
 
                         /**

--- a/dev/html/public/optimized-appear/defer-handoff-layout-ancestor-suspend.html
+++ b/dev/html/public/optimized-appear/defer-handoff-layout-ancestor-suspend.html
@@ -64,18 +64,13 @@
                             // Cypress browser doesn't support getAnimations
                             if (!optimisedBox.getAnimations) return
 
-                            console.log(
-                                optimisedBox.getAnimations().length,
-                                layoutBox.getAnimations().length
-                            )
-
                             // TODO: Uncomment with follow up PR to resume cancelled WAAPI animations
-                            // if (optimisedBox.getAnimations().length !== 1) {
-                            //     showError(
-                            //         optimisedBox,
-                            //         `Optimised parent should have resumed WAAPI animation`
-                            //     )
-                            // }
+                            if (optimisedBox.getAnimations().length !== 1) {
+                                showError(
+                                    optimisedBox,
+                                    `Optimised parent should have resumed WAAPI animation`
+                                )
+                            }
 
                             if (layoutBox.getAnimations().length !== 0) {
                                 showError(

--- a/dev/html/public/optimized-appear/defer-handoff-layout-ancestor-suspend.html
+++ b/dev/html/public/optimized-appear/defer-handoff-layout-ancestor-suspend.html
@@ -64,7 +64,6 @@
                             // Cypress browser doesn't support getAnimations
                             if (!optimisedBox.getAnimations) return
 
-                            // TODO: Uncomment with follow up PR to resume cancelled WAAPI animations
                             if (optimisedBox.getAnimations().length !== 1) {
                                 showError(
                                     optimisedBox,

--- a/packages/framer-motion/src/animation/optimized-appear/handoff.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/handoff.ts
@@ -16,6 +16,19 @@ export function handoffOptimizedAppearAnimation(
 
     const { animation, startTime } = optimisedAnimation
 
+    function cancelAnimation() {
+        window.MotionCancelOptimisedAnimation?.(elementId, valueName, frame)
+    }
+
+    /**
+     * We can cancel the animation once it's finished now that we've synced
+     * with Motion.
+     *
+     * Prefer onfinish over finished as onfinish is backwards compatible with
+     * older browsers.
+     */
+    animation.onfinish = cancelAnimation
+
     if (startTime === null || window.MotionHandoffIsComplete) {
         /**
          * If the startTime is null, this animation is the Paint Ready detection animation
@@ -24,16 +37,7 @@ export function handoffOptimizedAppearAnimation(
          * Or if we've already handed off the animation then we're now interrupting it.
          * In which case we need to cancel it.
          */
-        appearAnimationStore.delete(storeId)
-
-        frame.render(() =>
-            frame.render(() => {
-                try {
-                    animation.cancel()
-                } catch (error) {}
-            })
-        )
-
+        cancelAnimation()
         return null
     } else {
         return startTime

--- a/packages/framer-motion/src/animation/optimized-appear/start.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/start.ts
@@ -3,7 +3,11 @@ import { animateStyle } from "../animators/waapi"
 import { NativeAnimationOptions } from "../animators/waapi/types"
 import { optimizedAppearDataId } from "./data-id"
 import { handoffOptimizedAppearAnimation } from "./handoff"
-import { appearAnimationStore, elementsWithAppearAnimations } from "./store"
+import {
+    appearAnimationStore,
+    AppearStoreEntry,
+    elementsWithAppearAnimations,
+} from "./store"
 import { noop } from "../../utils/noop"
 import "./types"
 import { getOptimisedAppearId } from "./get-appear-id"
@@ -25,6 +29,20 @@ let startFrameTime: number
  * https://bugs.chromium.org/p/chromium/issues/detail?id=1406850
  */
 let readyAnimation: Animation
+
+/**
+ * Keep track of animations that were suspended vs cancelled so we
+ * can easily resume them when we're done measuring layout.
+ */
+const suspendedAnimations = new Set<AppearStoreEntry>()
+
+function resumeSuspendedAnimations() {
+    suspendedAnimations.forEach((data) => {
+        data.animation.play()
+        data.animation.startTime = data.startTime
+    })
+    suspendedAnimations.clear()
+}
 
 export function startOptimizedAppearAnimation(
     element: HTMLElement,
@@ -100,25 +118,33 @@ export function startOptimizedAppearAnimation(
         window.MotionCancelOptimisedAnimation = (
             elementId: string,
             valueName: string,
-            frame: Batcher
+            frame?: Batcher,
+            canResume?: boolean
         ) => {
             const animationId = appearStoreId(elementId, valueName)
             const data = appearAnimationStore.get(animationId)
 
-            if (data) {
-                if (frame) {
-                    // Wait until the end of the subsequent frame to cancel the animation
-                    // to ensure we don't remove the animation before the main thread has
-                    // had a chance to resolve keyframes and render.
-                    frame.postRender(() => {
-                        frame.postRender(() => {
-                            data.animation.cancel()
-                        })
-                    })
-                } else {
-                    data.animation.cancel()
-                }
+            if (!data) return
 
+            if (frame && canResume === undefined) {
+                /**
+                 * Wait until the end of the subsequent frame to cancel the animation
+                 * to ensure we don't remove the animation before the main thread has
+                 * had a chance to resolve keyframes and render.
+                 */
+                frame.postRender(() => {
+                    frame.postRender(() => {
+                        data.animation.cancel()
+                    })
+                })
+            } else {
+                data.animation.cancel()
+            }
+
+            if (frame && canResume) {
+                suspendedAnimations.add(data)
+                frame.render(resumeSuspendedAnimations)
+            } else {
                 appearAnimationStore.delete(animationId)
 
                 /**

--- a/packages/framer-motion/src/animation/optimized-appear/types.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/types.ts
@@ -36,7 +36,8 @@ declare global {
         MotionCancelOptimisedAnimation?: (
             elementId?: string,
             valueName?: string,
-            frame?: Batcher
+            frame?: Batcher,
+            canResume?: boolean
         ) => void
         MotionCheckAppearSync?: (
             visualElement: WithAppearProps,

--- a/packages/framer-motion/src/animation/optimized-appear/types.ts
+++ b/packages/framer-motion/src/animation/optimized-appear/types.ts
@@ -35,7 +35,8 @@ declare global {
         ) => boolean
         MotionCancelOptimisedAnimation?: (
             elementId?: string,
-            valueName?: string
+            valueName?: string,
+            frame?: Batcher
         ) => void
         MotionCheckAppearSync?: (
             visualElement: WithAppearProps,

--- a/packages/framer-motion/src/projection/node/create-projection-node.ts
+++ b/packages/framer-motion/src/projection/node/create-projection-node.ts
@@ -121,7 +121,13 @@ function cancelTreeOptimisedTransformAnimations(
     const appearId = getOptimisedAppearId(visualElement)
 
     if (window.MotionHasOptimisedAnimation!(appearId, "transform")) {
-        window.MotionCancelOptimisedAnimation!(appearId, "transform")
+        const { layout, layoutId } = projectionNode.options
+        window.MotionCancelOptimisedAnimation!(
+            appearId,
+            "transform",
+            frame,
+            !(layout || layoutId)
+        )
     }
 
     const { parent } = projectionNode

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -397,11 +397,7 @@ export abstract class VisualElement<
             this.removeFromVariantTree = this.parent.addVariantChild(this)
         }
 
-        this.values.forEach((value, key) => {
-            if (!this.valueSubscriptions.has(key)) {
-                this.bindToMotionValue(key, value)
-            }
-        })
+        this.values.forEach((value, key) => this.bindToMotionValue(key, value))
 
         if (!hasReducedMotionListener.current) {
             initPrefersReducedMotion()

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -452,14 +452,13 @@ export abstract class VisualElement<
         }
 
         const valueIsTransform = transformProps.has(key)
-
-        const appearId = getOptimisedAppearId(this)
-
+        console.log(key)
+        console.trace()
         const removeOnChange = value.on(
             "change",
             (latestValue: string | number) => {
                 this.latestValues[key] = latestValue
-
+                console.log("on change", key, latestValue)
                 this.props.onUpdate && frame.preRender(this.notifyUpdate)
 
                 if (valueIsTransform && this.projection) {
@@ -467,24 +466,6 @@ export abstract class VisualElement<
                 }
             }
         )
-
-        const valueIsOptimised = window.MotionHasOptimisedAnimation?.(
-            appearId,
-            key
-        )
-        const externalAnimationValue = this.props.values?.[key]
-        let removeSyncCheck: VoidFunction
-        if (valueIsOptimised && externalAnimationValue) {
-            removeSyncCheck = value.on(
-                "change",
-                (latestValue: string | number) => {
-                    if (externalAnimationValue.get() === latestValue) {
-                        window.MotionCancelOptimisedAnimation?.(appearId, key)
-                        removeSyncCheck()
-                    }
-                }
-            )
-        }
 
         const removeOnRenderRequest = value.on(
             "renderRequest",
@@ -499,7 +480,6 @@ export abstract class VisualElement<
         this.valueSubscriptions.set(key, () => {
             removeOnChange()
             removeOnRenderRequest()
-            if (removeSyncCheck) removeSyncCheck()
             if (value.owner) value.stop()
         })
     }
@@ -722,6 +702,27 @@ export abstract class VisualElement<
     addValue(key: string, value: MotionValue) {
         // Remove existing value if it exists
         const existingValue = this.values.get(key)
+
+        // const appearId = getOptimisedAppearId(this)
+        // const valueIsOptimised = window.MotionHasOptimisedAnimation?.(
+        //     appearId,
+        //     key
+        // )
+        // const externalAnimationValue = this.props.values?.[key]
+        // console.log(key, externalAnimationValue, valueIsOptimised)
+
+        // let removeSyncCheck: VoidFunction
+        // if (valueIsOptimised && externalAnimationValue) {
+        //     removeSyncCheck = value.on(
+        //         "change",
+        //         (latestValue: string | number) => {
+        //             if (externalAnimationValue.get() === latestValue) {
+        //                 window.MotionCancelOptimisedAnimation?.(appearId, key)
+        //                 removeSyncCheck()
+        //             }
+        //         }
+        //     )
+        // }
 
         if (value !== existingValue) {
             if (existingValue) this.removeValue(key)

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -450,20 +450,17 @@ export abstract class VisualElement<
     }
 
     private bindToMotionValue(key: string, value: MotionValue) {
-        console.log("binding to ", key)
         if (this.valueSubscriptions.has(key)) {
             this.valueSubscriptions.get(key)!()
         }
 
         const valueIsTransform = transformProps.has(key)
 
-        if (key === "x") console.trace()
-
         const removeOnChange = value.on(
             "change",
             (latestValue: string | number) => {
                 this.latestValues[key] = latestValue
-                if (key === "x") console.log("on change", key, latestValue)
+
                 this.props.onUpdate && frame.preRender(this.notifyUpdate)
 
                 if (valueIsTransform && this.projection) {
@@ -749,7 +746,6 @@ export abstract class VisualElement<
         defaultValue?: string | number | null
     ): MotionValue | undefined {
         if (this.props.values && this.props.values[key]) {
-            console.log("returning from values prop")
             return this.props.values[key]
         }
 

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -43,7 +43,6 @@ import { findValueType } from "./dom/value-types/find"
 import { complex } from "../value/types/complex"
 import { getAnimatableNone } from "./dom/value-types/animatable-none"
 import { createBox } from "../projection/geometry/models"
-import { getOptimisedAppearId } from "../animation/optimized-appear/get-appear-id"
 
 const propEventHandlers = [
     "AnimationStart",
@@ -398,7 +397,11 @@ export abstract class VisualElement<
             this.removeFromVariantTree = this.parent.addVariantChild(this)
         }
 
-        this.values.forEach((value, key) => this.bindToMotionValue(key, value))
+        this.values.forEach((value, key) => {
+            if (!this.valueSubscriptions.has(key)) {
+                this.bindToMotionValue(key, value)
+            }
+        })
 
         if (!hasReducedMotionListener.current) {
             initPrefersReducedMotion()
@@ -447,18 +450,20 @@ export abstract class VisualElement<
     }
 
     private bindToMotionValue(key: string, value: MotionValue) {
+        console.log("binding to ", key)
         if (this.valueSubscriptions.has(key)) {
             this.valueSubscriptions.get(key)!()
         }
 
         const valueIsTransform = transformProps.has(key)
-        console.log(key)
-        console.trace()
+
+        if (key === "x") console.trace()
+
         const removeOnChange = value.on(
             "change",
             (latestValue: string | number) => {
                 this.latestValues[key] = latestValue
-                console.log("on change", key, latestValue)
+                if (key === "x") console.log("on change", key, latestValue)
                 this.props.onUpdate && frame.preRender(this.notifyUpdate)
 
                 if (valueIsTransform && this.projection) {
@@ -480,6 +485,7 @@ export abstract class VisualElement<
         this.valueSubscriptions.set(key, () => {
             removeOnChange()
             removeOnRenderRequest()
+            if (removeSyncCheck) removeSyncCheck()
             if (value.owner) value.stop()
         })
     }
@@ -703,27 +709,6 @@ export abstract class VisualElement<
         // Remove existing value if it exists
         const existingValue = this.values.get(key)
 
-        // const appearId = getOptimisedAppearId(this)
-        // const valueIsOptimised = window.MotionHasOptimisedAnimation?.(
-        //     appearId,
-        //     key
-        // )
-        // const externalAnimationValue = this.props.values?.[key]
-        // console.log(key, externalAnimationValue, valueIsOptimised)
-
-        // let removeSyncCheck: VoidFunction
-        // if (valueIsOptimised && externalAnimationValue) {
-        //     removeSyncCheck = value.on(
-        //         "change",
-        //         (latestValue: string | number) => {
-        //             if (externalAnimationValue.get() === latestValue) {
-        //                 window.MotionCancelOptimisedAnimation?.(appearId, key)
-        //                 removeSyncCheck()
-        //             }
-        //         }
-        //     )
-        // }
-
         if (value !== existingValue) {
             if (existingValue) this.removeValue(key)
             this.bindToMotionValue(key, value)
@@ -764,6 +749,7 @@ export abstract class VisualElement<
         defaultValue?: string | number | null
     ): MotionValue | undefined {
         if (this.props.values && this.props.values[key]) {
+            console.log("returning from values prop")
             return this.props.values[key]
         }
 

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -43,6 +43,7 @@ import { findValueType } from "./dom/value-types/find"
 import { complex } from "../value/types/complex"
 import { getAnimatableNone } from "./dom/value-types/animatable-none"
 import { createBox } from "../projection/geometry/models"
+import { getOptimisedAppearId } from "../animation/optimized-appear/get-appear-id"
 
 const propEventHandlers = [
     "AnimationStart",
@@ -452,6 +453,8 @@ export abstract class VisualElement<
 
         const valueIsTransform = transformProps.has(key)
 
+        const appearId = getOptimisedAppearId(this)
+
         const removeOnChange = value.on(
             "change",
             (latestValue: string | number) => {
@@ -464,6 +467,24 @@ export abstract class VisualElement<
                 }
             }
         )
+
+        const valueIsOptimised = window.MotionHasOptimisedAnimation?.(
+            appearId,
+            key
+        )
+        const externalAnimationValue = this.props.values?.[key]
+        let removeSyncCheck: VoidFunction
+        if (valueIsOptimised && externalAnimationValue) {
+            removeSyncCheck = value.on(
+                "change",
+                (latestValue: string | number) => {
+                    if (externalAnimationValue.get() === latestValue) {
+                        window.MotionCancelOptimisedAnimation?.(appearId, key)
+                        removeSyncCheck()
+                    }
+                }
+            )
+        }
 
         const removeOnRenderRequest = value.on(
             "renderRequest",


### PR DESCRIPTION
When cancelling optimised appear animations we can encounter two visual artefacts:

"Slippage" in Safari caused by its incorrect timing model on accelerated animations
Stutter induced by main thread jank
The prior PR ensures we only cancel WAAPI animations on trees where layout animations take place. This PR resumes those animations immediately after measurement on nodes where we aren't performing layout animations, decreasing the period of time on jank and reducing the number of nodes with visible slippage.

Replaces https://github.com/framer/motion/pull/2767 