### PR TITLE
fix: Improve types to include css variables

### DIFF
--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -119,6 +119,10 @@ export type ResolveLayoutTransition = (
     info: RelayoutInfo
 ) => Transition | boolean
 
+type CSSVariables = {
+  [key: `--${string}`]: string;
+};
+
 /**
  * @public
  */
@@ -142,7 +146,7 @@ export interface AnimationProps {
      * <motion.div initial={false} animate={{ opacity: 0 }} />
      * ```
      */
-    initial?: boolean | Target | VariantLabels
+    initial?: boolean | Target | VariantLabels | CSSVariables
 
     /**
      * Values to animate to, variant label(s), or `AnimationControls`.
@@ -161,7 +165,7 @@ export interface AnimationProps {
      * <motion.div animate={animation} />
      * ```
      */
-    animate?: AnimationControls | TargetAndTransition | VariantLabels | boolean
+    animate?: AnimationControls | TargetAndTransition | VariantLabels | boolean | CSSVariables  
 
     /**
      * A target to animate to when this component is removed from the tree.
@@ -189,7 +193,7 @@ export interface AnimationProps {
      * }
      * ```
      */
-    exit?: TargetAndTransition | VariantLabels
+    exit?: TargetAndTransition | VariantLabels | CSSVariables
 
     /**
      * Variants allow you to define animation states and organise them by name. They allow

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -1,206 +1,201 @@
-import { CSSProperties } from "react";
-import { MotionValue } from "../value";
-import { AnimationControls } from "../animation/types";
+import { CSSProperties } from "react"
+import { MotionValue } from "../value"
+import { AnimationControls } from "../animation/types"
 import {
-  Variants,
-  Target,
-  Transition,
-  TargetAndTransition,
-  Omit,
-  MakeCustomValueType,
-} from "../types";
-import { DraggableProps } from "../gestures/drag/types";
-import { LayoutProps } from "./features/layout/types";
-import { EventProps } from "../render/types";
+    Variants,
+    Target,
+    Transition,
+    TargetAndTransition,
+    Omit,
+    MakeCustomValueType,
+} from "../types"
+import { DraggableProps } from "../gestures/drag/types"
+import { LayoutProps } from "./features/layout/types"
+import { EventProps } from "../render/types"
 import {
-  PanHandlers,
-  TapHandlers,
-  HoverHandlers,
-  FocusHandlers,
-} from "../gestures/types";
-import { ViewportProps } from "./features/viewport/types";
+    PanHandlers,
+    TapHandlers,
+    HoverHandlers,
+    FocusHandlers,
+} from "../gestures/types"
+import { ViewportProps } from "./features/viewport/types"
 
-export type MotionStyleProp = string | number | MotionValue;
+export type MotionStyleProp = string | number | MotionValue
 
 /**
  * Either a string, or array of strings, that reference variants defined via the `variants` prop.
  * @public
  */
-export type VariantLabels = string | string[];
+export type VariantLabels = string | string[]
 
 export interface TransformProperties {
-  x?: string | number;
-  y?: string | number;
-  z?: string | number;
-  translateX?: string | number;
-  translateY?: string | number;
-  translateZ?: string | number;
-  rotate?: string | number;
-  rotateX?: string | number;
-  rotateY?: string | number;
-  rotateZ?: string | number;
-  scale?: string | number;
-  scaleX?: string | number;
-  scaleY?: string | number;
-  scaleZ?: string | number;
-  skew?: string | number;
-  skewX?: string | number;
-  skewY?: string | number;
-  originX?: string | number;
-  originY?: string | number;
-  originZ?: string | number;
-  perspective?: string | number;
-  transformPerspective?: string | number;
+    x?: string | number
+    y?: string | number
+    z?: string | number
+    translateX?: string | number
+    translateY?: string | number
+    translateZ?: string | number
+    rotate?: string | number
+    rotateX?: string | number
+    rotateY?: string | number
+    rotateZ?: string | number
+    scale?: string | number
+    scaleX?: string | number
+    scaleY?: string | number
+    scaleZ?: string | number
+    skew?: string | number
+    skewX?: string | number
+    skewY?: string | number
+    originX?: string | number
+    originY?: string | number
+    originZ?: string | number
+    perspective?: string | number
+    transformPerspective?: string | number
 }
 
 /**
  * @public
  */
 export interface SVGPathProperties {
-  pathLength?: number;
-  pathOffset?: number;
-  pathSpacing?: number;
+    pathLength?: number
+    pathOffset?: number
+    pathSpacing?: number
 }
 
 export interface CustomStyles {
-  /**
-   * Framer Library custom prop types. These are not actually supported in Motion - preferably
-   * we'd have a way of external consumers injecting supported styles into this library.
-   */
-  size?: string | number;
-  radius?: string | number;
-  shadow?: string;
-  image?: string;
+    /**
+     * Framer Library custom prop types. These are not actually supported in Motion - preferably
+     * we'd have a way of external consumers injecting supported styles into this library.
+     */
+    size?: string | number
+    radius?: string | number
+    shadow?: string
+    image?: string
 }
 
 export type MakeMotion<T> = MakeCustomValueType<{
-  [K in keyof T]:
-    | T[K]
-    | MotionValue<number>
-    | MotionValue<string>
-    | MotionValue<any>; // A permissive type for Custom value types
-}>;
+    [K in keyof T]:
+        | T[K]
+        | MotionValue<number>
+        | MotionValue<string>
+        | MotionValue<any> // A permissive type for Custom value types
+}>
 
 export type MotionCSS = MakeMotion<
-  Omit<CSSProperties, "rotate" | "scale" | "perspective">
->;
+    Omit<CSSProperties, "rotate" | "scale" | "perspective">
+>
 
 /**
  * @public
  */
-export type MotionTransform = MakeMotion<TransformProperties>;
+export type MotionTransform = MakeMotion<TransformProperties>
 
 /**
  * @public
  */
 export type MotionStyle = MotionCSS &
-  MotionTransform &
-  MakeMotion<SVGPathProperties> &
-  MakeCustomValueType<CustomStyles>;
+    MotionTransform &
+    MakeMotion<SVGPathProperties> &
+    MakeCustomValueType<CustomStyles>
 
-export type OnUpdate = (v: Target) => void;
+export type OnUpdate = (v: Target) => void
 
 /**
  * @public
  */
 export interface RelayoutInfo {
-  delta: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  };
+    delta: {
+        x: number
+        y: number
+        width: number
+        height: number
+    }
 }
 
 /**
  * @public
  */
 export type ResolveLayoutTransition = (
-  info: RelayoutInfo
-) => Transition | boolean;
+    info: RelayoutInfo
+) => Transition | boolean
 
 type CSSVariables = {
-  [key: `--${string}`]: string | number;
+  [key: `--${string}`]: string | number
 };
 
 /**
  * @public
  */
 export interface AnimationProps {
-  /**
-   * Properties, variant label or array of variant labels to start in.
-   *
-   * Set to `false` to initialise with the values in `animate` (disabling the mount animation)
-   *
-   * ```jsx
-   * // As values
-   * <motion.div initial={{ opacity: 1 }} />
-   *
-   * // As variant
-   * <motion.div initial="visible" variants={variants} />
-   *
-   * // Multiple variants
-   * <motion.div initial={["visible", "active"]} variants={variants} />
-   *
-   * // As false (disable mount animation)
-   * <motion.div initial={false} animate={{ opacity: 0 }} />
-   * ```
-   */
-  initial?: boolean | Target | VariantLabels | CSSVariables;
+    /**
+     * Properties, variant label or array of variant labels to start in.
+     *
+     * Set to `false` to initialise with the values in `animate` (disabling the mount animation)
+     *
+     * ```jsx
+     * // As values
+     * <motion.div initial={{ opacity: 1 }} />
+     *
+     * // As variant
+     * <motion.div initial="visible" variants={variants} />
+     *
+     * // Multiple variants
+     * <motion.div initial={["visible", "active"]} variants={variants} />
+     *
+     * // As false (disable mount animation)
+     * <motion.div initial={false} animate={{ opacity: 0 }} />
+     * ```
+     */
+    initial?: boolean | Target | VariantLabels | CSSVariables
 
-  /**
-   * Values to animate to, variant label(s), or `AnimationControls`.
-   *
-   * ```jsx
-   * // As values
-   * <motion.div animate={{ opacity: 1 }} />
-   *
-   * // As variant
-   * <motion.div animate="visible" variants={variants} />
-   *
-   * // Multiple variants
-   * <motion.div animate={["visible", "active"]} variants={variants} />
-   *
-   * // AnimationControls
-   * <motion.div animate={animation} />
-   * ```
-   */
-  animate?:
-    | AnimationControls
-    | TargetAndTransition
-    | VariantLabels
-    | boolean
-    | CSSVariables;
+    /**
+     * Values to animate to, variant label(s), or `AnimationControls`.
+     *
+     * ```jsx
+     * // As values
+     * <motion.div animate={{ opacity: 1 }} />
+     *
+     * // As variant
+     * <motion.div animate="visible" variants={variants} />
+     *
+     * // Multiple variants
+     * <motion.div animate={["visible", "active"]} variants={variants} />
+     *
+     * // AnimationControls
+     * <motion.div animate={animation} />
+     * ```
+     */
+    animate?: AnimationControls | TargetAndTransition | VariantLabels | boolean | CSSVariables  
 
-  /**
-   * A target to animate to when this component is removed from the tree.
-   *
-   * This component **must** be the first animatable child of an `AnimatePresence` to enable this exit animation.
-   *
-   * This limitation exists because React doesn't allow components to defer unmounting until after
-   * an animation is complete. Once this limitation is fixed, the `AnimatePresence` component will be unnecessary.
-   *
-   * ```jsx
-   * import { AnimatePresence, motion } from 'framer-motion'
-   *
-   * export const MyComponent = ({ isVisible }) => {
-   *   return (
-   *     <AnimatePresence>
-   *        {isVisible && (
-   *          <motion.div
-   *            initial={{ opacity: 0 }}
-   *            animate={{ opacity: 1 }}
-   *            exit={{ opacity: 0 }}
-   *          />
-   *        )}
-   *     </AnimatePresence>
-   *   )
-   * }
-   * ```
-   */
-  exit?: TargetAndTransition | VariantLabels | CSSVariables;
+    /**
+     * A target to animate to when this component is removed from the tree.
+     *
+     * This component **must** be the first animatable child of an `AnimatePresence` to enable this exit animation.
+     *
+     * This limitation exists because React doesn't allow components to defer unmounting until after
+     * an animation is complete. Once this limitation is fixed, the `AnimatePresence` component will be unnecessary.
+     *
+     * ```jsx
+     * import { AnimatePresence, motion } from 'framer-motion'
+     *
+     * export const MyComponent = ({ isVisible }) => {
+     *   return (
+     *     <AnimatePresence>
+     *        {isVisible && (
+     *          <motion.div
+     *            initial={{ opacity: 0 }}
+     *            animate={{ opacity: 1 }}
+     *            exit={{ opacity: 0 }}
+     *          />
+     *        )}
+     *     </AnimatePresence>
+     *   )
+     * }
+     * ```
+     */
+    exit?: TargetAndTransition | VariantLabels | CSSVariables
 
-  /**
+    /**
      * Variants allow you to define animation states and organise them by name. They allow
      * you to control animations throughout a component tree by switching a single `animate` prop.
      *
@@ -225,63 +220,63 @@ export interface AnimationProps {
      * <motion.div variants={variants} animate="active" />
      * ```
      */
-  variants?: Variants;
+    variants?: Variants
 
-  /**
-   * Default transition. If no `transition` is defined in `animate`, it will use the transition defined here.
-   * ```jsx
-   * const spring = {
-   *   type: "spring",
-   *   damping: 10,
-   *   stiffness: 100
-   * }
-   *
-   * <motion.div transition={spring} animate={{ scale: 1.2 }} />
-   * ```
-   */
-  transition?: Transition;
+    /**
+     * Default transition. If no `transition` is defined in `animate`, it will use the transition defined here.
+     * ```jsx
+     * const spring = {
+     *   type: "spring",
+     *   damping: 10,
+     *   stiffness: 100
+     * }
+     *
+     * <motion.div transition={spring} animate={{ scale: 1.2 }} />
+     * ```
+     */
+    transition?: Transition
 }
 
 /**
  * @public
  */
 export interface MotionAdvancedProps {
-  /**
-   * Custom data to use to resolve dynamic variants differently for each animating component.
-   *
-   * ```jsx
-   * const variants = {
-   *   visible: (custom) => ({
-   *     opacity: 1,
-   *     transition: { delay: custom * 0.2 }
-   *   })
-   * }
-   *
-   * <motion.div custom={0} animate="visible" variants={variants} />
-   * <motion.div custom={1} animate="visible" variants={variants} />
-   * <motion.div custom={2} animate="visible" variants={variants} />
-   * ```
-   *
-   * @public
-   */
-  custom?: any;
+    /**
+     * Custom data to use to resolve dynamic variants differently for each animating component.
+     *
+     * ```jsx
+     * const variants = {
+     *   visible: (custom) => ({
+     *     opacity: 1,
+     *     transition: { delay: custom * 0.2 }
+     *   })
+     * }
+     *
+     * <motion.div custom={0} animate="visible" variants={variants} />
+     * <motion.div custom={1} animate="visible" variants={variants} />
+     * <motion.div custom={2} animate="visible" variants={variants} />
+     * ```
+     *
+     * @public
+     */
+    custom?: any
 
-  /**
-   * @public
-   * Set to `false` to prevent inheriting variant changes from its parent.
-   */
-  inherit?: boolean;
+    /**
+     * @public
+     * Set to `false` to prevent inheriting variant changes from its parent.
+     */
+    inherit?: boolean
 
-  /**
-   * @public
-   * Set to `false` to prevent throwing an error when a `motion` component is used within a `LazyMotion` set to strict.
-   */
-  ignoreStrict?: boolean;
+    /**
+     * @public
+     * Set to `false` to prevent throwing an error when a `motion` component is used within a `LazyMotion` set to strict.
+     */
+    ignoreStrict?: boolean
 }
 
 type ExternalMotionValues = {
-  [key: string]: MotionValue<number> | MotionValue<string>;
-};
+    [key: string]: MotionValue<number> | MotionValue<string>
+}
 
 /**
  * Props for `motion` components.
@@ -289,66 +284,66 @@ type ExternalMotionValues = {
  * @public
  */
 export interface MotionProps
-  extends AnimationProps,
-    EventProps,
-    PanHandlers,
-    TapHandlers,
-    HoverHandlers,
-    FocusHandlers,
-    ViewportProps,
-    DraggableProps,
-    LayoutProps,
-    MotionAdvancedProps {
-  /**
-   *
-   * The React DOM `style` prop, enhanced with support for `MotionValue`s and separate `transform` values.
-   *
-   * ```jsx
-   * export const MyComponent = () => {
-   *   const x = useMotionValue(0)
-   *
-   *   return <motion.div style={{ x, opacity: 1, scale: 0.5 }} />
-   * }
-   * ```
-   */
-  style?: MotionStyle;
+    extends AnimationProps,
+        EventProps,
+        PanHandlers,
+        TapHandlers,
+        HoverHandlers,
+        FocusHandlers,
+        ViewportProps,
+        DraggableProps,
+        LayoutProps,
+        MotionAdvancedProps {
+    /**
+     *
+     * The React DOM `style` prop, enhanced with support for `MotionValue`s and separate `transform` values.
+     *
+     * ```jsx
+     * export const MyComponent = () => {
+     *   const x = useMotionValue(0)
+     *
+     *   return <motion.div style={{ x, opacity: 1, scale: 0.5 }} />
+     * }
+     * ```
+     */
+    style?: MotionStyle
 
-  /**
-   * Provide a set of motion values to perform animations on.
-   *
-   * @internal
-   */
-  values?: ExternalMotionValues;
+    /**
+     * Provide a set of motion values to perform animations on.
+     *
+     * @internal
+     */
+    values?: ExternalMotionValues
 
-  /**
-   * By default, Framer Motion generates a `transform` property with a sensible transform order. `transformTemplate`
-   * can be used to create a different order, or to append/preprend the automatically generated `transform` property.
-   *
-   * ```jsx
-   * <motion.div
-   *   style={{ x: 0, rotate: 180 }}
-   *   transformTemplate={
-   *     ({ x, rotate }) => `rotate(${rotate}deg) translateX(${x}px)`
-   *   }
-   * />
-   * ```
-   *
-   * @param transform - The latest animated transform props.
-   * @param generatedTransform - The transform string as automatically generated by Framer Motion
-   *
-   * @public
-   */
-  transformTemplate?(
-    transform: TransformProperties,
-    generatedTransform: string
-  ): string;
+    /**
+     * By default, Framer Motion generates a `transform` property with a sensible transform order. `transformTemplate`
+     * can be used to create a different order, or to append/preprend the automatically generated `transform` property.
+     *
+     * ```jsx
+     * <motion.div
+     *   style={{ x: 0, rotate: 180 }}
+     *   transformTemplate={
+     *     ({ x, rotate }) => `rotate(${rotate}deg) translateX(${x}px)`
+     *   }
+     * />
+     * ```
+     *
+     * @param transform - The latest animated transform props.
+     * @param generatedTransform - The transform string as automatically generated by Framer Motion
+     *
+     * @public
+     */
+    transformTemplate?(
+        transform: TransformProperties,
+        generatedTransform: string
+    ): string
 
-  children?: React.ReactNode | MotionValue<number> | MotionValue<string>;
+    children?: React.ReactNode | MotionValue<number> | MotionValue<string>
 
-  "data-framer-appear-id"?: string;
+    "data-framer-appear-id"?: string
 }
 
 export type TransformTemplate = (
-  transform: TransformProperties,
-  generatedTransform: string
-) => string;
+    transform: TransformProperties,
+    generatedTransform: string
+) => string

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -1,201 +1,206 @@
-import { CSSProperties } from "react"
-import { MotionValue } from "../value"
-import { AnimationControls } from "../animation/types"
+import { CSSProperties } from "react";
+import { MotionValue } from "../value";
+import { AnimationControls } from "../animation/types";
 import {
-    Variants,
-    Target,
-    Transition,
-    TargetAndTransition,
-    Omit,
-    MakeCustomValueType,
-} from "../types"
-import { DraggableProps } from "../gestures/drag/types"
-import { LayoutProps } from "./features/layout/types"
-import { EventProps } from "../render/types"
+  Variants,
+  Target,
+  Transition,
+  TargetAndTransition,
+  Omit,
+  MakeCustomValueType,
+} from "../types";
+import { DraggableProps } from "../gestures/drag/types";
+import { LayoutProps } from "./features/layout/types";
+import { EventProps } from "../render/types";
 import {
-    PanHandlers,
-    TapHandlers,
-    HoverHandlers,
-    FocusHandlers,
-} from "../gestures/types"
-import { ViewportProps } from "./features/viewport/types"
+  PanHandlers,
+  TapHandlers,
+  HoverHandlers,
+  FocusHandlers,
+} from "../gestures/types";
+import { ViewportProps } from "./features/viewport/types";
 
-export type MotionStyleProp = string | number | MotionValue
+export type MotionStyleProp = string | number | MotionValue;
 
 /**
  * Either a string, or array of strings, that reference variants defined via the `variants` prop.
  * @public
  */
-export type VariantLabels = string | string[]
+export type VariantLabels = string | string[];
 
 export interface TransformProperties {
-    x?: string | number
-    y?: string | number
-    z?: string | number
-    translateX?: string | number
-    translateY?: string | number
-    translateZ?: string | number
-    rotate?: string | number
-    rotateX?: string | number
-    rotateY?: string | number
-    rotateZ?: string | number
-    scale?: string | number
-    scaleX?: string | number
-    scaleY?: string | number
-    scaleZ?: string | number
-    skew?: string | number
-    skewX?: string | number
-    skewY?: string | number
-    originX?: string | number
-    originY?: string | number
-    originZ?: string | number
-    perspective?: string | number
-    transformPerspective?: string | number
+  x?: string | number;
+  y?: string | number;
+  z?: string | number;
+  translateX?: string | number;
+  translateY?: string | number;
+  translateZ?: string | number;
+  rotate?: string | number;
+  rotateX?: string | number;
+  rotateY?: string | number;
+  rotateZ?: string | number;
+  scale?: string | number;
+  scaleX?: string | number;
+  scaleY?: string | number;
+  scaleZ?: string | number;
+  skew?: string | number;
+  skewX?: string | number;
+  skewY?: string | number;
+  originX?: string | number;
+  originY?: string | number;
+  originZ?: string | number;
+  perspective?: string | number;
+  transformPerspective?: string | number;
 }
 
 /**
  * @public
  */
 export interface SVGPathProperties {
-    pathLength?: number
-    pathOffset?: number
-    pathSpacing?: number
+  pathLength?: number;
+  pathOffset?: number;
+  pathSpacing?: number;
 }
 
 export interface CustomStyles {
-    /**
-     * Framer Library custom prop types. These are not actually supported in Motion - preferably
-     * we'd have a way of external consumers injecting supported styles into this library.
-     */
-    size?: string | number
-    radius?: string | number
-    shadow?: string
-    image?: string
+  /**
+   * Framer Library custom prop types. These are not actually supported in Motion - preferably
+   * we'd have a way of external consumers injecting supported styles into this library.
+   */
+  size?: string | number;
+  radius?: string | number;
+  shadow?: string;
+  image?: string;
 }
 
 export type MakeMotion<T> = MakeCustomValueType<{
-    [K in keyof T]:
-        | T[K]
-        | MotionValue<number>
-        | MotionValue<string>
-        | MotionValue<any> // A permissive type for Custom value types
-}>
+  [K in keyof T]:
+    | T[K]
+    | MotionValue<number>
+    | MotionValue<string>
+    | MotionValue<any>; // A permissive type for Custom value types
+}>;
 
 export type MotionCSS = MakeMotion<
-    Omit<CSSProperties, "rotate" | "scale" | "perspective">
->
+  Omit<CSSProperties, "rotate" | "scale" | "perspective">
+>;
 
 /**
  * @public
  */
-export type MotionTransform = MakeMotion<TransformProperties>
+export type MotionTransform = MakeMotion<TransformProperties>;
 
 /**
  * @public
  */
 export type MotionStyle = MotionCSS &
-    MotionTransform &
-    MakeMotion<SVGPathProperties> &
-    MakeCustomValueType<CustomStyles>
+  MotionTransform &
+  MakeMotion<SVGPathProperties> &
+  MakeCustomValueType<CustomStyles>;
 
-export type OnUpdate = (v: Target) => void
+export type OnUpdate = (v: Target) => void;
 
 /**
  * @public
  */
 export interface RelayoutInfo {
-    delta: {
-        x: number
-        y: number
-        width: number
-        height: number
-    }
+  delta: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
 }
 
 /**
  * @public
  */
 export type ResolveLayoutTransition = (
-    info: RelayoutInfo
-) => Transition | boolean
+  info: RelayoutInfo
+) => Transition | boolean;
 
 type CSSVariables = {
-  [key: `--${string}`]: string;
+  [key: `--${string}`]: string | number;
 };
 
 /**
  * @public
  */
 export interface AnimationProps {
-    /**
-     * Properties, variant label or array of variant labels to start in.
-     *
-     * Set to `false` to initialise with the values in `animate` (disabling the mount animation)
-     *
-     * ```jsx
-     * // As values
-     * <motion.div initial={{ opacity: 1 }} />
-     *
-     * // As variant
-     * <motion.div initial="visible" variants={variants} />
-     *
-     * // Multiple variants
-     * <motion.div initial={["visible", "active"]} variants={variants} />
-     *
-     * // As false (disable mount animation)
-     * <motion.div initial={false} animate={{ opacity: 0 }} />
-     * ```
-     */
-    initial?: boolean | Target | VariantLabels | CSSVariables
+  /**
+   * Properties, variant label or array of variant labels to start in.
+   *
+   * Set to `false` to initialise with the values in `animate` (disabling the mount animation)
+   *
+   * ```jsx
+   * // As values
+   * <motion.div initial={{ opacity: 1 }} />
+   *
+   * // As variant
+   * <motion.div initial="visible" variants={variants} />
+   *
+   * // Multiple variants
+   * <motion.div initial={["visible", "active"]} variants={variants} />
+   *
+   * // As false (disable mount animation)
+   * <motion.div initial={false} animate={{ opacity: 0 }} />
+   * ```
+   */
+  initial?: boolean | Target | VariantLabels | CSSVariables;
 
-    /**
-     * Values to animate to, variant label(s), or `AnimationControls`.
-     *
-     * ```jsx
-     * // As values
-     * <motion.div animate={{ opacity: 1 }} />
-     *
-     * // As variant
-     * <motion.div animate="visible" variants={variants} />
-     *
-     * // Multiple variants
-     * <motion.div animate={["visible", "active"]} variants={variants} />
-     *
-     * // AnimationControls
-     * <motion.div animate={animation} />
-     * ```
-     */
-    animate?: AnimationControls | TargetAndTransition | VariantLabels | boolean | CSSVariables  
+  /**
+   * Values to animate to, variant label(s), or `AnimationControls`.
+   *
+   * ```jsx
+   * // As values
+   * <motion.div animate={{ opacity: 1 }} />
+   *
+   * // As variant
+   * <motion.div animate="visible" variants={variants} />
+   *
+   * // Multiple variants
+   * <motion.div animate={["visible", "active"]} variants={variants} />
+   *
+   * // AnimationControls
+   * <motion.div animate={animation} />
+   * ```
+   */
+  animate?:
+    | AnimationControls
+    | TargetAndTransition
+    | VariantLabels
+    | boolean
+    | CSSVariables;
 
-    /**
-     * A target to animate to when this component is removed from the tree.
-     *
-     * This component **must** be the first animatable child of an `AnimatePresence` to enable this exit animation.
-     *
-     * This limitation exists because React doesn't allow components to defer unmounting until after
-     * an animation is complete. Once this limitation is fixed, the `AnimatePresence` component will be unnecessary.
-     *
-     * ```jsx
-     * import { AnimatePresence, motion } from 'framer-motion'
-     *
-     * export const MyComponent = ({ isVisible }) => {
-     *   return (
-     *     <AnimatePresence>
-     *        {isVisible && (
-     *          <motion.div
-     *            initial={{ opacity: 0 }}
-     *            animate={{ opacity: 1 }}
-     *            exit={{ opacity: 0 }}
-     *          />
-     *        )}
-     *     </AnimatePresence>
-     *   )
-     * }
-     * ```
-     */
-    exit?: TargetAndTransition | VariantLabels | CSSVariables
+  /**
+   * A target to animate to when this component is removed from the tree.
+   *
+   * This component **must** be the first animatable child of an `AnimatePresence` to enable this exit animation.
+   *
+   * This limitation exists because React doesn't allow components to defer unmounting until after
+   * an animation is complete. Once this limitation is fixed, the `AnimatePresence` component will be unnecessary.
+   *
+   * ```jsx
+   * import { AnimatePresence, motion } from 'framer-motion'
+   *
+   * export const MyComponent = ({ isVisible }) => {
+   *   return (
+   *     <AnimatePresence>
+   *        {isVisible && (
+   *          <motion.div
+   *            initial={{ opacity: 0 }}
+   *            animate={{ opacity: 1 }}
+   *            exit={{ opacity: 0 }}
+   *          />
+   *        )}
+   *     </AnimatePresence>
+   *   )
+   * }
+   * ```
+   */
+  exit?: TargetAndTransition | VariantLabels | CSSVariables;
 
-    /**
+  /**
      * Variants allow you to define animation states and organise them by name. They allow
      * you to control animations throughout a component tree by switching a single `animate` prop.
      *
@@ -220,63 +225,63 @@ export interface AnimationProps {
      * <motion.div variants={variants} animate="active" />
      * ```
      */
-    variants?: Variants
+  variants?: Variants;
 
-    /**
-     * Default transition. If no `transition` is defined in `animate`, it will use the transition defined here.
-     * ```jsx
-     * const spring = {
-     *   type: "spring",
-     *   damping: 10,
-     *   stiffness: 100
-     * }
-     *
-     * <motion.div transition={spring} animate={{ scale: 1.2 }} />
-     * ```
-     */
-    transition?: Transition
+  /**
+   * Default transition. If no `transition` is defined in `animate`, it will use the transition defined here.
+   * ```jsx
+   * const spring = {
+   *   type: "spring",
+   *   damping: 10,
+   *   stiffness: 100
+   * }
+   *
+   * <motion.div transition={spring} animate={{ scale: 1.2 }} />
+   * ```
+   */
+  transition?: Transition;
 }
 
 /**
  * @public
  */
 export interface MotionAdvancedProps {
-    /**
-     * Custom data to use to resolve dynamic variants differently for each animating component.
-     *
-     * ```jsx
-     * const variants = {
-     *   visible: (custom) => ({
-     *     opacity: 1,
-     *     transition: { delay: custom * 0.2 }
-     *   })
-     * }
-     *
-     * <motion.div custom={0} animate="visible" variants={variants} />
-     * <motion.div custom={1} animate="visible" variants={variants} />
-     * <motion.div custom={2} animate="visible" variants={variants} />
-     * ```
-     *
-     * @public
-     */
-    custom?: any
+  /**
+   * Custom data to use to resolve dynamic variants differently for each animating component.
+   *
+   * ```jsx
+   * const variants = {
+   *   visible: (custom) => ({
+   *     opacity: 1,
+   *     transition: { delay: custom * 0.2 }
+   *   })
+   * }
+   *
+   * <motion.div custom={0} animate="visible" variants={variants} />
+   * <motion.div custom={1} animate="visible" variants={variants} />
+   * <motion.div custom={2} animate="visible" variants={variants} />
+   * ```
+   *
+   * @public
+   */
+  custom?: any;
 
-    /**
-     * @public
-     * Set to `false` to prevent inheriting variant changes from its parent.
-     */
-    inherit?: boolean
+  /**
+   * @public
+   * Set to `false` to prevent inheriting variant changes from its parent.
+   */
+  inherit?: boolean;
 
-    /**
-     * @public
-     * Set to `false` to prevent throwing an error when a `motion` component is used within a `LazyMotion` set to strict.
-     */
-    ignoreStrict?: boolean
+  /**
+   * @public
+   * Set to `false` to prevent throwing an error when a `motion` component is used within a `LazyMotion` set to strict.
+   */
+  ignoreStrict?: boolean;
 }
 
 type ExternalMotionValues = {
-    [key: string]: MotionValue<number> | MotionValue<string>
-}
+  [key: string]: MotionValue<number> | MotionValue<string>;
+};
 
 /**
  * Props for `motion` components.
@@ -284,66 +289,66 @@ type ExternalMotionValues = {
  * @public
  */
 export interface MotionProps
-    extends AnimationProps,
-        EventProps,
-        PanHandlers,
-        TapHandlers,
-        HoverHandlers,
-        FocusHandlers,
-        ViewportProps,
-        DraggableProps,
-        LayoutProps,
-        MotionAdvancedProps {
-    /**
-     *
-     * The React DOM `style` prop, enhanced with support for `MotionValue`s and separate `transform` values.
-     *
-     * ```jsx
-     * export const MyComponent = () => {
-     *   const x = useMotionValue(0)
-     *
-     *   return <motion.div style={{ x, opacity: 1, scale: 0.5 }} />
-     * }
-     * ```
-     */
-    style?: MotionStyle
+  extends AnimationProps,
+    EventProps,
+    PanHandlers,
+    TapHandlers,
+    HoverHandlers,
+    FocusHandlers,
+    ViewportProps,
+    DraggableProps,
+    LayoutProps,
+    MotionAdvancedProps {
+  /**
+   *
+   * The React DOM `style` prop, enhanced with support for `MotionValue`s and separate `transform` values.
+   *
+   * ```jsx
+   * export const MyComponent = () => {
+   *   const x = useMotionValue(0)
+   *
+   *   return <motion.div style={{ x, opacity: 1, scale: 0.5 }} />
+   * }
+   * ```
+   */
+  style?: MotionStyle;
 
-    /**
-     * Provide a set of motion values to perform animations on.
-     *
-     * @internal
-     */
-    values?: ExternalMotionValues
+  /**
+   * Provide a set of motion values to perform animations on.
+   *
+   * @internal
+   */
+  values?: ExternalMotionValues;
 
-    /**
-     * By default, Framer Motion generates a `transform` property with a sensible transform order. `transformTemplate`
-     * can be used to create a different order, or to append/preprend the automatically generated `transform` property.
-     *
-     * ```jsx
-     * <motion.div
-     *   style={{ x: 0, rotate: 180 }}
-     *   transformTemplate={
-     *     ({ x, rotate }) => `rotate(${rotate}deg) translateX(${x}px)`
-     *   }
-     * />
-     * ```
-     *
-     * @param transform - The latest animated transform props.
-     * @param generatedTransform - The transform string as automatically generated by Framer Motion
-     *
-     * @public
-     */
-    transformTemplate?(
-        transform: TransformProperties,
-        generatedTransform: string
-    ): string
+  /**
+   * By default, Framer Motion generates a `transform` property with a sensible transform order. `transformTemplate`
+   * can be used to create a different order, or to append/preprend the automatically generated `transform` property.
+   *
+   * ```jsx
+   * <motion.div
+   *   style={{ x: 0, rotate: 180 }}
+   *   transformTemplate={
+   *     ({ x, rotate }) => `rotate(${rotate}deg) translateX(${x}px)`
+   *   }
+   * />
+   * ```
+   *
+   * @param transform - The latest animated transform props.
+   * @param generatedTransform - The transform string as automatically generated by Framer Motion
+   *
+   * @public
+   */
+  transformTemplate?(
+    transform: TransformProperties,
+    generatedTransform: string
+  ): string;
 
-    children?: React.ReactNode | MotionValue<number> | MotionValue<string>
+  children?: React.ReactNode | MotionValue<number> | MotionValue<string>;
 
-    "data-framer-appear-id"?: string
+  "data-framer-appear-id"?: string;
 }
 
 export type TransformTemplate = (
-    transform: TransformProperties,
-    generatedTransform: string
-) => string
+  transform: TransformProperties,
+  generatedTransform: string
+) => string;


### PR DESCRIPTION
In the [docs](https://www.framer.com/motion/component/#%23%23animating-css-variables) regarding css variables, it's recommended to cast it as `any`. 

This PR should allow you to add css variables, i.e "--${anthingGoesHere}". If the initial "--" is not there, an error is thrown !

Right now it only allows for strings & numbers as the properties.

Valid
```
{
  "--myColor": "#eeeeee"
}
```

Invalid
```
{
  "myColor": "#eeeeee"
}
```