### PR TITLE
Animate values when child variant definitions change

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -63,7 +63,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 variant.test.tsx",
         "test-server": "jest --config jest.config.ssr.json",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-e2e": "yarn test-e2e-next && yarn test-e2e-html && yarn test-e2e-react",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -63,7 +63,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 variant.test.tsx",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-e2e": "yarn test-e2e-next && yarn test-e2e-html && yarn test-e2e-react",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -98,15 +98,15 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "34.05 kB"
+            "maxSize": "33.95 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
-            "maxSize": "6 kB"
+            "maxSize": "5.9 kB"
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "17 kB"
+            "maxSize": "16.9 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
@@ -114,7 +114,7 @@
         },
         {
             "path": "./dist/size-rollup-animate.js",
-            "maxSize": "18 kB"
+            "maxSize": "17.9 kB"
         }
     ],
     "gitHead": "dcf88c8f6c178d1af7a8f7dec81326db5fd68cea"

--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -1295,4 +1295,32 @@ describe("animate prop as variant", () => {
 
         return expect(promise).resolves.toBe("visible")
     })
+
+    test.only("changing values within an inherited variant triggers an animation", async () => {
+        const Component = ({ x }: { x: number }) => {
+            return (
+                <motion.div initial="variant">
+                    <motion.div
+                        data-testid="element"
+                        variants={{ variant: { x } }}
+                        transition={{ type: false }}
+                    />
+                </motion.div>
+            )
+        }
+
+        const { rerender, getByTestId } = render(<Component x={0} />)
+
+        await nextFrame()
+
+        const element = getByTestId("element")
+
+        expect(element).toHaveStyle("transform: none")
+
+        rerender(<Component x={100} />)
+
+        await nextFrame()
+
+        expect(element).toHaveStyle("transform: translateX(100px)")
+    })
 })

--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -1296,10 +1296,10 @@ describe("animate prop as variant", () => {
         return expect(promise).resolves.toBe("visible")
     })
 
-    test.only("changing values within an inherited variant triggers an animation", async () => {
+    test("changing values within an inherited variant triggers an animation", async () => {
         const Component = ({ x }: { x: number }) => {
             return (
-                <motion.div initial="variant">
+                <motion.div initial={false} animate="variant">
                     <motion.div
                         data-testid="element"
                         variants={{ variant: { x } }}

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -18,7 +18,6 @@ import { isMotionValue } from "../value/utils/is-motion-value"
 import { transformProps } from "./html/utils/transform"
 import {
     ResolvedValues,
-    VariantStateContext,
     VisualElementEventCallbacks,
     VisualElementOptions,
 } from "./types"
@@ -27,14 +26,12 @@ import {
     isControllingVariants as checkIsControllingVariants,
     isVariantNode as checkIsVariantNode,
 } from "./utils/is-controlling-variants"
-import { isVariantLabel } from "./utils/is-variant-label"
 import { updateMotionValuesFromProps } from "./utils/motion-values"
 import { resolveVariantFromProps } from "./utils/resolve-variants"
 import { warnOnce } from "../utils/warn-once"
 import { featureDefinitions } from "../motion/features/definitions"
 import { Feature } from "../motion/features/Feature"
 import type { PresenceContextProps } from "../context/PresenceContext"
-import { variantProps } from "./utils/variant-props"
 import { visualElementStore } from "./store"
 import { KeyframeResolver } from "./utils/KeyframesResolver"
 import { isNumericalString } from "../utils/is-numerical-string"
@@ -53,8 +50,6 @@ const propEventHandlers = [
     "LayoutAnimationStart",
     "LayoutAnimationComplete",
 ] as const
-
-const numVariantProps = variantProps.length
 
 /**
  * A VisualElement is an imperative abstraction around UI elements such as
@@ -653,34 +648,6 @@ export abstract class VisualElement<
             : this.parent
             ? this.parent.getClosestVariantNode()
             : undefined
-    }
-
-    getVariantContext(startAtParent = false): undefined | VariantStateContext {
-        if (startAtParent) {
-            return this.parent ? this.parent.getVariantContext() : undefined
-        }
-
-        if (!this.isControllingVariants) {
-            const context = this.parent
-                ? this.parent.getVariantContext() || {}
-                : {}
-            if (this.props.initial !== undefined) {
-                context.initial = this.props.initial as any
-            }
-            return context
-        }
-
-        const context = {}
-        for (let i = 0; i < numVariantProps; i++) {
-            const name = variantProps[i] as keyof typeof context
-            const prop = this.props[name]
-
-            if (isVariantLabel(prop) || prop === false) {
-                context[name] = prop
-            }
-        }
-
-        return context
     }
 
     /**

--- a/packages/framer-motion/src/render/types.ts
+++ b/packages/framer-motion/src/render/types.ts
@@ -16,16 +16,6 @@ export interface MotionPoint {
     y: MotionValue<number>
 }
 
-export type VariantStateContext = {
-    initial?: string | string[]
-    animate?: string | string[]
-    exit?: string | string[]
-    whileHover?: string | string[]
-    whileDrag?: string | string[]
-    whileFocus?: string | string[]
-    whileTap?: string | string[]
-}
-
 export type ScrapeMotionValuesFromProps = (
     props: MotionProps,
     prevProps: MotionProps,

--- a/packages/framer-motion/src/render/utils/get-variant-context.ts
+++ b/packages/framer-motion/src/render/utils/get-variant-context.ts
@@ -1,0 +1,43 @@
+import { VisualElement } from "../VisualElement"
+import { isVariantLabel } from "./is-variant-label"
+import { variantProps } from "./variant-props"
+
+const numVariantProps = variantProps.length
+
+type VariantStateContext = {
+    initial?: string | string[]
+    animate?: string | string[]
+    exit?: string | string[]
+    whileHover?: string | string[]
+    whileDrag?: string | string[]
+    whileFocus?: string | string[]
+    whileTap?: string | string[]
+}
+
+export function getVariantContext(
+    visualElement?: VisualElement
+): undefined | VariantStateContext {
+    if (!visualElement) return undefined
+
+    if (!visualElement.isControllingVariants) {
+        const context = visualElement.parent
+            ? getVariantContext(visualElement.parent) || {}
+            : {}
+        if (visualElement.props.initial !== undefined) {
+            context.initial = visualElement.props.initial as any
+        }
+        return context
+    }
+
+    const context = {}
+    for (let i = 0; i < numVariantProps; i++) {
+        const name = variantProps[i] as keyof typeof context
+        const prop = visualElement.props[name]
+
+        if (isVariantLabel(prop) || prop === false) {
+            context[name] = prop
+        }
+    }
+
+    return context
+}


### PR DESCRIPTION
Ensure that when the **value** of a variant changes, we animate to the latest value.

```jsx
<motion.div initial="a">
  <motion.div variants={{ a: { x }}} />
</motion.div>
```