### PR TITLE
Support for `linear()` easing function

### DIFF
--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -63,7 +63,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2 waapi",
+        "test-client": "jest --config jest.config.json --max-workers=2",
         "test-server": "jest --config jest.config.ssr.json",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-e2e": "yarn test-e2e-next && yarn test-e2e-html && yarn test-e2e-react",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -98,7 +98,7 @@
     "bundlesize": [
         {
             "path": "./dist/size-rollup-motion.js",
-            "maxSize": "33.85 kB"
+            "maxSize": "34.02 kB"
         },
         {
             "path": "./dist/size-rollup-m.js",
@@ -106,15 +106,15 @@
         },
         {
             "path": "./dist/size-rollup-dom-animation.js",
-            "maxSize": "16.9 kB"
+            "maxSize": "17 kB"
         },
         {
             "path": "./dist/size-rollup-dom-max.js",
-            "maxSize": "29 kB"
+            "maxSize": "29.1 kB"
         },
         {
             "path": "./dist/size-rollup-animate.js",
-            "maxSize": "17.7 kB"
+            "maxSize": "17.9 kB"
         },
         {
             "path": "./dist/size-rollup-scroll.js",

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -63,7 +63,7 @@
         "clean": "rm -rf types dist lib",
         "test": "yarn test-server && yarn test-client",
         "test-ci": "yarn test",
-        "test-client": "jest --config jest.config.json --max-workers=2",
+        "test-client": "jest --config jest.config.json --max-workers=2 waapi",
         "test-server": "jest --config jest.config.ssr.json",
         "test-watch": "jest --watch --coverage --coverageReporters=lcov --config jest.config.json",
         "test-e2e": "yarn test-e2e-next && yarn test-e2e-html && yarn test-e2e-react",

--- a/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
@@ -1,3 +1,6 @@
+import { anticipate } from "../../easing/anticipate"
+import { backInOut } from "../../easing/back"
+import { circInOut } from "../../easing/circ"
 import { EasingDefinition } from "../../easing/types"
 import { DOMKeyframesResolver } from "../../render/dom/DOMKeyframesResolver"
 import { ResolvedKeyframes } from "../../render/utils/KeyframesResolver"
@@ -20,7 +23,7 @@ import {
 import { MainThreadAnimation } from "./MainThreadAnimation"
 import { acceleratedValues } from "./utils/accelerated-values"
 import { animateStyle } from "./waapi"
-import { isWaapiSupportedEasing } from "./waapi/easing"
+import { isWaapiSupportedEasing, supportsLinearEasing } from "./waapi/easing"
 import { getFinalKeyframe } from "./waapi/utils/get-final-keyframe"
 
 const supportsWaapi = /*@__PURE__*/ memo(() =>
@@ -110,6 +113,12 @@ interface ResolvedAcceleratedAnimation {
     keyframes: string[] | number[]
 }
 
+const unsupportedEasingFunctions = {
+    anticipate,
+    backInOut,
+    circInOut,
+}
+
 export class AcceleratedAnimation<
     T extends string | number
 > extends BaseAnimation<T, ResolvedAcceleratedAnimation> {
@@ -157,6 +166,22 @@ export class AcceleratedAnimation<
          */
         if (!motionValue.owner?.current) {
             return false
+        }
+
+        /**
+         * If the user has provided an easing function name that isn't supported
+         * by WAAPI (like "anticipate"), we need to provide the corressponding
+         * function. This will later get converted to a linear() easing function.
+         */
+        if (
+            typeof ease === "string" &&
+            supportsLinearEasing() &&
+            ease in unsupportedEasingFunctions
+        ) {
+            ease =
+                unsupportedEasingFunctions[
+                    ease as keyof typeof unsupportedEasingFunctions
+                ]
         }
 
         /**

--- a/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
@@ -119,6 +119,12 @@ const unsupportedEasingFunctions = {
     circInOut,
 }
 
+function isUnsupportedEase(
+    key: string
+): key is keyof typeof unsupportedEasingFunctions {
+    return key in unsupportedEasingFunctions
+}
+
 export class AcceleratedAnimation<
     T extends string | number
 > extends BaseAnimation<T, ResolvedAcceleratedAnimation> {
@@ -176,12 +182,9 @@ export class AcceleratedAnimation<
         if (
             typeof ease === "string" &&
             supportsLinearEasing() &&
-            ease in unsupportedEasingFunctions
+            isUnsupportedEase(ease)
         ) {
-            ease =
-                unsupportedEasingFunctions[
-                    ease as keyof typeof unsupportedEasingFunctions
-                ]
+            ease = unsupportedEasingFunctions[ease]
         }
 
         /**

--- a/packages/framer-motion/src/animation/animators/waapi/__tests__/easing.test.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/__tests__/easing.test.ts
@@ -1,4 +1,5 @@
 import { isWaapiSupportedEasing } from "../easing"
+import { supportsFlags } from "../utils/supports-flags"
 
 test("isWaapiSupportedEasing", () => {
     expect(isWaapiSupportedEasing()).toEqual(true)
@@ -7,6 +8,9 @@ test("isWaapiSupportedEasing", () => {
     expect(isWaapiSupportedEasing("anticipate")).toEqual(false)
     expect(isWaapiSupportedEasing("backInOut")).toEqual(false)
     expect(isWaapiSupportedEasing([0, 1, 2, 3])).toEqual(true)
+    supportsFlags.linearEasing = true
+    expect(isWaapiSupportedEasing((v) => v)).toEqual(true)
+    supportsFlags.linearEasing = false
     expect(isWaapiSupportedEasing((v) => v)).toEqual(false)
     expect(isWaapiSupportedEasing(["linear", "easeIn"])).toEqual(true)
     expect(isWaapiSupportedEasing(["linear", "easeIn", [0, 1, 2, 3]])).toEqual(
@@ -15,6 +19,9 @@ test("isWaapiSupportedEasing", () => {
     expect(isWaapiSupportedEasing(["linear", "easeIn", "anticipate"])).toEqual(
         false
     )
+    supportsFlags.linearEasing = true
+    expect(isWaapiSupportedEasing(["linear", "easeIn", (v) => v])).toEqual(true)
+    supportsFlags.linearEasing = false
     expect(isWaapiSupportedEasing(["linear", "easeIn", (v) => v])).toEqual(
         false
     )

--- a/packages/framer-motion/src/animation/animators/waapi/index.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/index.ts
@@ -17,7 +17,7 @@ export function animateStyle(
     const keyframeOptions: PropertyIndexedKeyframes = { [valueName]: keyframes }
     if (times) keyframeOptions.offset = times
 
-    const easing = mapEasingToNativeEasing(ease)
+    const easing = mapEasingToNativeEasing(ease, duration)
 
     /**
      * If this is an easing array, apply to keyframes, not animation as a whole

--- a/packages/framer-motion/src/animation/animators/waapi/utils/__tests__/linear.test.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/__tests__/linear.test.ts
@@ -1,0 +1,13 @@
+import { noop } from "../../../../../utils/noop"
+import { generateLinearEasing } from "../linear"
+
+describe("generateLinearEasing", () => {
+    test("Converts easing function into string of points", () => {
+        expect(generateLinearEasing(noop, 110)).toEqual(
+            "linear(0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1)"
+        )
+        expect(generateLinearEasing(() => 0.5, 200)).toEqual(
+            "linear(0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5)"
+        )
+    })
+})

--- a/packages/framer-motion/src/animation/animators/waapi/utils/__tests__/linear.test.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/__tests__/linear.test.ts
@@ -9,5 +9,6 @@ describe("generateLinearEasing", () => {
         expect(generateLinearEasing(() => 0.5, 200)).toEqual(
             "linear(0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5)"
         )
+        expect(generateLinearEasing(() => 0.5, 0)).toEqual("linear(0.5, 0.5)")
     })
 })

--- a/packages/framer-motion/src/animation/animators/waapi/utils/linear.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/linear.ts
@@ -11,8 +11,8 @@ export const generateLinearEasing = (
     let points = ""
     const numPoints = Math.round(duration / resolution)
 
-    for (let i = 0; i <= numPoints; i++) {
-        points += easing(progress(0, numPoints, i)) + ", "
+    for (let i = 0; i < numPoints; i++) {
+        points += easing(progress(0, numPoints - 1, i)) + ", "
     }
 
     return `linear(${points.substring(0, points.length - 2)})`

--- a/packages/framer-motion/src/animation/animators/waapi/utils/linear.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/linear.ts
@@ -1,0 +1,19 @@
+import { EasingFunction } from "../../../../easing/types"
+import { progress } from "../../../../utils/progress"
+
+// Create a linear easing point for every 10 ms
+const resolution = 10
+
+export const generateLinearEasing = (
+    easing: EasingFunction,
+    duration: number // as milliseconds
+): string => {
+    let points = ""
+    const numPoints = Math.round(duration / resolution)
+
+    for (let i = 0; i <= numPoints; i++) {
+        points += easing(progress(0, numPoints, i)) + ", "
+    }
+
+    return `linear(${points.substring(0, points.length - 2)})`
+}

--- a/packages/framer-motion/src/animation/animators/waapi/utils/linear.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/linear.ts
@@ -9,7 +9,7 @@ export const generateLinearEasing = (
     duration: number // as milliseconds
 ): string => {
     let points = ""
-    const numPoints = Math.round(duration / resolution)
+    const numPoints = Math.max(Math.round(duration / resolution), 2)
 
     for (let i = 0; i < numPoints; i++) {
         points += easing(progress(0, numPoints - 1, i)) + ", "

--- a/packages/framer-motion/src/animation/animators/waapi/utils/memo-supports.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/memo-supports.ts
@@ -1,0 +1,10 @@
+import { memo } from "../../../../utils/memo"
+import { supportsFlags } from "./supports-flags"
+
+export function memoSupports<T extends any>(
+    callback: () => T,
+    supportsFlag: keyof typeof supportsFlags
+) {
+    const memoized = memo(callback)
+    return () => supportsFlags[supportsFlag] ?? memoized()
+}

--- a/packages/framer-motion/src/animation/animators/waapi/utils/supports-flags.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/supports-flags.ts
@@ -1,0 +1,3 @@
+export const supportsFlags: Record<string, boolean | undefined> = {
+    linearEasing: undefined,
+}

--- a/packages/framer-motion/src/animation/animators/waapi/utils/supports-flags.ts
+++ b/packages/framer-motion/src/animation/animators/waapi/utils/supports-flags.ts
@@ -1,3 +1,7 @@
+/**
+ * Add the ability for test suites to manually set support flags
+ * to better test more environments.
+ */
 export const supportsFlags: Record<string, boolean | undefined> = {
     linearEasing: undefined,
 }

--- a/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
@@ -9,6 +9,7 @@ import { motion, spring, useMotionValue } from "../../"
 import { act, useState, createRef } from "react"
 import { nextFrame } from "../../gestures/__tests__/utils"
 import "../../animation/animators/waapi/__tests__/setup"
+import { supportsFlags } from "../../animation/animators/waapi/utils/supports-flags"
 
 describe("WAAPI animations", () => {
     test("opacity animates with WAAPI at default settings", async () => {
@@ -389,7 +390,8 @@ describe("WAAPI animations", () => {
         )
     })
 
-    test("WAAPI is called with expected arguments with pre-generated keyframes", async () => {
+    test("WAAPI is called with pre-generated keyframes when linear() is unsupported ", async () => {
+        supportsFlags.linearEasing = false
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -399,7 +401,7 @@ describe("WAAPI animations", () => {
                 transition={{
                     duration: 0.05,
                     delay: 2,
-                    ease: () => 0.5,
+                    ease: (p) => p,
                     times: [0, 1],
                 }}
             />
@@ -411,7 +413,10 @@ describe("WAAPI animations", () => {
 
         expect(ref.current!.animate).toBeCalled()
         expect(ref.current!.animate).toBeCalledWith(
-            { opacity: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5], offset: undefined },
+            {
+                opacity: [0, 0.2, 0.4, 0.6, 0.8, 1],
+                offset: undefined,
+            },
             {
                 delay: 2000,
                 duration: 50,
@@ -421,6 +426,42 @@ describe("WAAPI animations", () => {
                 iterations: 1,
             }
         )
+        supportsFlags.linearEasing = undefined
+    })
+
+    test("WAAPI is called with generated linear() easing function when supported", async () => {
+        supportsFlags.linearEasing = true
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                    duration: 0.05,
+                    delay: 2,
+                    ease: (p) => p,
+                }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        await nextFrame()
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            { opacity: [0, 1], offset: undefined },
+            {
+                delay: 2000,
+                duration: 50,
+                direction: "normal",
+                easing: "linear(0, 0.2, 0.4, 0.6, 0.8, 1)",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+        supportsFlags.linearEasing = undefined
     })
 
     test("Maps 'easeIn' to 'ease-in'", async () => {
@@ -742,39 +783,8 @@ describe("WAAPI animations", () => {
         expect(ref.current!.animate).not.toBeCalled()
     })
 
-    test("Pregenerates keyframes if ease is function", async () => {
-        const ref = createRef<HTMLDivElement>()
-        const Component = () => (
-            <motion.div
-                ref={ref}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 0.9 }}
-                transition={{ ease: () => 0.5, duration: 0.05 }}
-            />
-        )
-        const { rerender } = render(<Component />)
-        rerender(<Component />)
-
-        await nextFrame()
-
-        expect(ref.current!.animate).toBeCalled()
-        expect(ref.current!.animate).toBeCalledWith(
-            {
-                opacity: [0.45, 0.45, 0.45, 0.45, 0.45, 0.45],
-                offset: undefined,
-            },
-            {
-                delay: -0,
-                direction: "normal",
-                duration: 50,
-                easing: "linear",
-                fill: "both",
-                iterations: 1,
-            }
-        )
-    })
-
-    test("Pregenerates keyframes if ease is anticipate", async () => {
+    test("Pregenerates keyframes if ease is anticipate and linear() is not supported", async () => {
+        supportsFlags.linearEasing = false
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -807,9 +817,47 @@ describe("WAAPI animations", () => {
                 iterations: 1,
             }
         )
+
+        supportsFlags.linearEasing = undefined
     })
 
-    test("Pregenerates keyframes if ease is backInOut", async () => {
+    test("Generates linear() easing if ease is anticipate", async () => {
+        supportsFlags.linearEasing = true
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.9 }}
+                transition={{ ease: "anticipate", duration: 0.05 }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        await nextFrame()
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            {
+                opacity: [0, 0.9],
+                offset: undefined,
+            },
+            {
+                delay: -0,
+                direction: "normal",
+                duration: 50,
+                easing: "linear(0, -0.04224417777368217, 0.15596336740345584, 0.875, 0.9921875, 0.99951171875)",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+        supportsFlags.linearEasing = undefined
+    })
+
+    test("Pregenerates keyframes if ease is backInOut and linear() is not supported", async () => {
+        supportsFlags.linearEasing = false
+
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -842,9 +890,46 @@ describe("WAAPI animations", () => {
                 iterations: 1,
             }
         )
+        supportsFlags.linearEasing = undefined
     })
 
-    test("Pregenerates keyframes if ease is circInOut", async () => {
+    test("Generates linear() if ease is backInOut", async () => {
+        supportsFlags.linearEasing = true
+
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.7 }}
+                transition={{ ease: "backInOut", duration: 0.05 }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        await nextFrame()
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            {
+                opacity: [0, 0.7],
+                offset: undefined,
+            },
+            {
+                delay: -0,
+                direction: "normal",
+                duration: 50,
+                easing: "linear(0, -0.04224417777368217, 0.15596336740345584, 0.8440366325965442, 1.0422441777736822, 1)",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+        supportsFlags.linearEasing = undefined
+    })
+
+    test("Pregenerates keyframes if ease is circInOut and linear() is not supported", async () => {
+        supportsFlags.linearEasing = false
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -877,6 +962,41 @@ describe("WAAPI animations", () => {
                 iterations: 1,
             }
         )
+        supportsFlags.linearEasing = undefined
+    })
+
+    test("Generates linear() if ease is circInOut", async () => {
+        supportsFlags.linearEasing = true
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.9 }}
+                transition={{ ease: "circInOut", duration: 0.05 }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        await nextFrame()
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            {
+                opacity: [0, 0.9],
+                offset: undefined,
+            },
+            {
+                delay: -0,
+                direction: "normal",
+                duration: 50,
+                easing: "linear(0, 0.041742430504416006, 0.20000000000000007, 0.7999999999999999, 0.958257569495584, 1)",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+        supportsFlags.linearEasing = undefined
     })
 
     test("Doesn't animate with WAAPI if repeatType is defined as mirror", async () => {
@@ -933,6 +1053,7 @@ describe("WAAPI animations", () => {
     })
 
     test("Animates with WAAPI if repeat is defined and we need to generate keyframes", async () => {
+        supportsFlags.linearEasing = false
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -969,9 +1090,11 @@ describe("WAAPI animations", () => {
                 iterations: 3,
             }
         )
+        supportsFlags.linearEasing = undefined
     })
 
     test("Animates with WAAPI if repeat is Infinity and we need to generate keyframes", async () => {
+        supportsFlags.linearEasing = false
         const ref = createRef<HTMLDivElement>()
         const Component = () => (
             <motion.div
@@ -1008,6 +1131,7 @@ describe("WAAPI animations", () => {
                 iterations: Infinity,
             }
         )
+        supportsFlags.linearEasing = undefined
     })
 })
 

--- a/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
@@ -456,7 +456,7 @@ describe("WAAPI animations", () => {
                 delay: 2000,
                 duration: 50,
                 direction: "normal",
-                easing: "linear(0, 0.2, 0.4, 0.6, 0.8, 1)",
+                easing: "linear(0, 0.25, 0.5, 0.75, 1)",
                 fill: "both",
                 iterations: 1,
             }
@@ -847,7 +847,7 @@ describe("WAAPI animations", () => {
                 delay: -0,
                 direction: "normal",
                 duration: 50,
-                easing: "linear(0, -0.04224417777368217, 0.15596336740345584, 0.875, 0.9921875, 0.99951171875)",
+                easing: "linear(0, -0.033628590829175686, 0.5, 0.984375, 0.99951171875)",
                 fill: "both",
                 iterations: 1,
             }
@@ -920,7 +920,7 @@ describe("WAAPI animations", () => {
                 delay: -0,
                 direction: "normal",
                 duration: 50,
-                easing: "linear(0, -0.04224417777368217, 0.15596336740345584, 0.8440366325965442, 1.0422441777736822, 1)",
+                easing: "linear(0, -0.033628590829175686, 0.5, 1.0336285908291756, 1)",
                 fill: "both",
                 iterations: 1,
             }
@@ -991,7 +991,7 @@ describe("WAAPI animations", () => {
                 delay: -0,
                 direction: "normal",
                 duration: 50,
-                easing: "linear(0, 0.041742430504416006, 0.20000000000000007, 0.7999999999999999, 0.958257569495584, 1)",
+                easing: "linear(0, 0.06698729810778065, 0.5, 0.9330127018922194, 1)",
                 fill: "both",
                 iterations: 1,
             }


### PR DESCRIPTION
Currently, when a WAAPI animation is defined with an easing function:

```javascript
animate(
  element,
  { opacity: 0 },
  { ease: (p) => p ** p }
) 
```

Or an easing name not supported by WAAPI:

```javascript
animate(
  element,
  { opacity: 0 },
  { ease: "anticipate" }
) 
```

Then Motion will pre-generate keyframes for this animation and run it with `linear` easing.

This can have poor performance characteristics: https://issues.chromium.org/issues/41491098

Likewise for complex values like `clip-path` and `filter` this can have the overhead of number -> string conversion.

This PR adds support for the `linear()` easing function. So when an easing isn't supported by WAAPI, we generate a `linear()` easing function instead of pre-generating keyframes.