### PR TITLE
Adding support for custom animation types

### DIFF
--- a/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
@@ -8,6 +8,7 @@ import {
     secondsToMilliseconds,
 } from "../../utils/time-conversion"
 import { MotionValue } from "../../value"
+import { isGenerator } from "../generators/utils/is-generator"
 import { ValueAnimationOptions } from "../types"
 import {
     BaseAnimation,
@@ -44,7 +45,11 @@ const maxDuration = 20_000
 function requiresPregeneratedKeyframes<T extends string | number>(
     options: ValueAnimationOptions<T>
 ) {
-    return options.type === "spring" || !isWaapiSupportedEasing(options.ease)
+    return (
+        isGenerator(options.type) ||
+        options.type === "spring" ||
+        !isWaapiSupportedEasing(options.ease)
+    )
 }
 
 function pregenerateKeyframes<T extends string | number>(

--- a/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/AcceleratedAnimation.ts
@@ -9,7 +9,10 @@ import {
 } from "../../utils/time-conversion"
 import { MotionValue } from "../../value"
 import { isGenerator } from "../generators/utils/is-generator"
-import { ValueAnimationOptions } from "../types"
+import {
+    ValueAnimationOptions,
+    ValueAnimationOptionsWithRenderContext,
+} from "../types"
 import {
     BaseAnimation,
     ValueAnimationOptionsWithDefaults,
@@ -115,7 +118,7 @@ export class AcceleratedAnimation<
         motionValue: MotionValue<T>
     }
 
-    constructor(options: ValueAnimationOptions<T>) {
+    constructor(options: ValueAnimationOptionsWithRenderContext<T>) {
         super(options)
 
         const { name, motionValue, element, keyframes } = this.options
@@ -395,7 +398,7 @@ export class AcceleratedAnimation<
     }
 
     static supports(
-        options: ValueAnimationOptions
+        options: ValueAnimationOptionsWithRenderContext
     ): options is AcceleratedValueAnimationOptions {
         const { motionValue, name, repeatDelay, repeatType, damping, type } =
             options

--- a/packages/framer-motion/src/animation/animators/BaseAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/BaseAnimation.ts
@@ -9,6 +9,7 @@ import {
     AnimationPlaybackControls,
     RepeatType,
     ValueAnimationOptions,
+    ValueAnimationOptionsWithRenderContext,
 } from "../types"
 import { canAnimate } from "./utils/can-animate"
 import { getFinalKeyframe } from "./waapi/utils/get-final-keyframe"
@@ -24,7 +25,7 @@ import { getFinalKeyframe } from "./waapi/utils/get-final-keyframe"
 const MAX_RESOLVE_DELAY = 40
 
 export interface ValueAnimationOptionsWithDefaults<T extends string | number>
-    extends ValueAnimationOptions<T> {
+    extends ValueAnimationOptionsWithRenderContext<T> {
     autoplay: boolean
     delay: number
     repeat: number

--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -20,6 +20,7 @@ import { clamp } from "../../utils/clamp"
 import { invariant } from "../../utils/errors"
 import { frameloopDriver } from "./drivers/driver-frameloop"
 import { getFinalKeyframe } from "./waapi/utils/get-final-keyframe"
+import { isGenerator } from "../generators/utils/is-generator"
 
 type GeneratorFactory = (
     options: ValueAnimationOptions<any>
@@ -135,8 +136,9 @@ export class MainThreadAnimation<
             velocity = 0,
         } = this.options
 
-        const generatorFactory = generators[type] || keyframesGeneratorFactory
-
+        const generatorFactory = isGenerator(type)
+            ? type
+            : generators[type] || keyframesGeneratorFactory
         /**
          * If our generator doesn't support mixing numbers, we need to replace keyframes with
          * [0, 100] and then make a function that maps that to the actual keyframes.

--- a/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
+++ b/packages/framer-motion/src/animation/animators/MainThreadAnimation.ts
@@ -5,7 +5,10 @@ import {
 import { spring } from "../generators/spring/index"
 import { inertia } from "../generators/inertia"
 import { keyframes as keyframesGeneratorFactory } from "../generators/keyframes"
-import { ValueAnimationOptions } from "../types"
+import {
+    ValueAnimationOptions,
+    ValueAnimationOptionsWithRenderContext,
+} from "../types"
 import { BaseAnimation } from "./BaseAnimation"
 import { AnimationState, KeyframeGenerator } from "../generators/types"
 import { pipe } from "../../utils/pipe"
@@ -139,6 +142,7 @@ export class MainThreadAnimation<
         const generatorFactory = isGenerator(type)
             ? type
             : generators[type] || keyframesGeneratorFactory
+
         /**
          * If our generator doesn't support mixing numbers, we need to replace keyframes with
          * [0, 100] and then make a function that maps that to the actual keyframes.
@@ -537,7 +541,7 @@ export class MainThreadAnimation<
 
 // Legacy interface
 export function animateValue(
-    options: ValueAnimationOptions<any>
+    options: ValueAnimationOptionsWithRenderContext<any>
 ): MainThreadAnimation<any> {
     return new MainThreadAnimation(options)
 }

--- a/packages/framer-motion/src/animation/animators/utils/can-animate.ts
+++ b/packages/framer-motion/src/animation/animators/utils/can-animate.ts
@@ -1,5 +1,7 @@
 import { ResolvedKeyframes } from "../../../render/utils/KeyframesResolver"
 import { warning } from "../../../utils/errors"
+import { isGenerator } from "../../generators/utils/is-generator"
+import { AnimationGeneratorType } from "../../types"
 import { isAnimatable } from "../../utils/is-animatable"
 
 function hasKeyframesChanged(keyframes: ResolvedKeyframes<any>) {
@@ -13,7 +15,7 @@ function hasKeyframesChanged(keyframes: ResolvedKeyframes<any>) {
 export function canAnimate(
     keyframes: ResolvedKeyframes<any>,
     name?: string,
-    type?: string,
+    type?: AnimationGeneratorType,
     velocity?: number
 ) {
     /**
@@ -45,5 +47,8 @@ export function canAnimate(
         return false
     }
 
-    return hasKeyframesChanged(keyframes) || (type === "spring" && velocity)
+    return (
+        hasKeyframesChanged(keyframes) ||
+        ((type === "spring" || isGenerator(type)) && velocity)
+    )
 }

--- a/packages/framer-motion/src/animation/generators/utils/is-generator.ts
+++ b/packages/framer-motion/src/animation/generators/utils/is-generator.ts
@@ -3,5 +3,5 @@ import { AnimationGeneratorType, GeneratorFactory } from "../../types"
 export function isGenerator(
     type?: AnimationGeneratorType
 ): type is GeneratorFactory {
-    return typeof type !== "string"
+    return typeof type === "function"
 }

--- a/packages/framer-motion/src/animation/generators/utils/is-generator.ts
+++ b/packages/framer-motion/src/animation/generators/utils/is-generator.ts
@@ -1,0 +1,7 @@
+import { AnimationGeneratorType, GeneratorFactory } from "../../types"
+
+export function isGenerator(
+    type?: AnimationGeneratorType
+): type is GeneratorFactory {
+    return typeof type !== "string"
+}

--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -7,6 +7,7 @@ import { progress } from "../../utils/progress"
 import { secondsToMilliseconds } from "../../utils/time-conversion"
 import type { MotionValue } from "../../value"
 import { isMotionValue } from "../../value/utils/is-motion-value"
+import { isGenerator } from "../generators/utils/is-generator"
 import { DynamicAnimationOptions } from "../types"
 import {
     AnimationScope,
@@ -115,7 +116,7 @@ export function createAnimationsFromSequence(
              * If this animation should and can use a spring, generate a spring easing function.
              */
             const numKeyframes = valueKeyframesAsList.length
-            if (numKeyframes <= 2 && type === "spring") {
+            if ((numKeyframes <= 2 && type === "spring") || isGenerator(type)) {
                 /**
                  * As we're creating an easing function from a spring,
                  * ideally we want to generate it using the real distance

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -10,6 +10,7 @@ import {
     KeyframeResolver,
     OnKeyframesResolved,
 } from "../render/utils/KeyframesResolver"
+import { KeyframeGenerator } from "./generators/types"
 
 export interface AnimationPlaybackLifecycles<V> {
     onUpdate?: (latest: V) => void
@@ -19,6 +20,18 @@ export interface AnimationPlaybackLifecycles<V> {
     onStop?: () => void
 }
 
+export type GeneratorFactory = (
+    options: ValueAnimationOptions<any>
+) => KeyframeGenerator<any>
+
+export type AnimationGeneratorType =
+    | GeneratorFactory
+    | "decay"
+    | "spring"
+    | "keyframes"
+    | "tween"
+    | "inertia"
+
 export interface Transition
     extends AnimationPlaybackOptions,
         Omit<SpringOptions, "keyframes">,
@@ -27,7 +40,7 @@ export interface Transition
     delay?: number
     elapsed?: number
     driver?: Driver
-    type?: "decay" | "spring" | "keyframes" | "tween" | "inertia"
+    type?: AnimationGeneratorType
     duration?: number
     autoplay?: boolean
     startTime?: number

--- a/packages/framer-motion/src/animation/types.ts
+++ b/packages/framer-motion/src/animation/types.ts
@@ -60,12 +60,17 @@ export type ResolveKeyframes<V extends string | number> = (
 export interface ValueAnimationOptions<V extends string | number = number>
     extends ValueAnimationTransition {
     keyframes: V[]
-    KeyframeResolver?: typeof KeyframeResolver
     name?: string
-    motionValue?: MotionValue<V>
-    element?: VisualElement
     from?: V
     isGenerator?: boolean
+}
+
+export interface ValueAnimationOptionsWithRenderContext<
+    V extends string | number = number
+> extends ValueAnimationOptions<V> {
+    KeyframeResolver?: typeof KeyframeResolver
+    motionValue?: MotionValue<V>
+    element?: VisualElement
 }
 
 export interface AnimationScope<T = any> {

--- a/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
@@ -5,7 +5,7 @@ import {
     pointerUp,
     render,
 } from "../../../jest.setup"
-import { motion, useMotionValue } from "../../"
+import { motion, spring, useMotionValue } from "../../"
 import { act, useState, createRef } from "react"
 import { nextFrame } from "../../gestures/__tests__/utils"
 import "../../animation/animators/waapi/__tests__/setup"
@@ -648,6 +648,47 @@ describe("WAAPI animations", () => {
                 animate={{ opacity: 1 }}
                 transition={{
                     type: "spring",
+                    duration: 0.1,
+                    bounce: 0,
+                }}
+            />
+        )
+        const { rerender } = render(<Component />)
+        rerender(<Component />)
+
+        await nextFrame()
+
+        expect(ref.current!.animate).toBeCalled()
+        expect(ref.current!.animate).toBeCalledWith(
+            {
+                opacity: [
+                    0, 0.23606867982504365, 0.5509083741195555,
+                    0.7637684153125726, 0.8831910398786699, 0.9444771835619267,
+                    0.9743215604668359, 0.9883608373299467, 0.9948051108537942,
+                    0.9977094774280534, 1,
+                ],
+                offset: undefined,
+            },
+            {
+                delay: -0,
+                direction: "normal",
+                duration: 100,
+                easing: "linear",
+                fill: "both",
+                iterations: 1,
+            }
+        )
+    })
+
+    test("WAAPI is called with pre-generated generator keyframes", async () => {
+        const ref = createRef<HTMLDivElement>()
+        const Component = () => (
+            <motion.div
+                ref={ref}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{
+                    type: spring,
                     duration: 0.1,
                     bounce: 0,
                 }}

--- a/packages/framer-motion/src/types.ts
+++ b/packages/framer-motion/src/types.ts
@@ -897,36 +897,6 @@ export interface Keyframes {
 /**
  * @public
  */
-export interface Just {
-    /**
-     * @public
-     */
-    type: "just"
-
-    /**
-     * @internal
-     */
-    to?: number | string | ValueTarget
-
-    /**
-     * @internal
-     */
-    from?: number | string
-
-    /**
-     * @internal
-     */
-    delay?: number
-
-    /**
-     * @internal
-     */
-    velocity?: number
-}
-
-/**
- * @public
- */
 export interface None {
     /**
      * Set `type` to `false` for an instant transition.
@@ -954,12 +924,7 @@ export interface None {
 /**
  * @public
  */
-export type PopmotionTransitionProps =
-    | Tween
-    | Spring
-    | Keyframes
-    | Inertia
-    | Just
+export type PopmotionTransitionProps = Tween | Spring | Keyframes | Inertia
 
 /**
  * @public
@@ -976,7 +941,6 @@ export type TransitionDefinition =
     | Spring
     | Keyframes
     | Inertia
-    | Just
     | None
     | PermissiveTransitionDefinition
 


### PR DESCRIPTION
This PR adds support for custom animation generators.

```jsx
<motion.div
  transition={{ type: gravity }}
/>
```