### PR TITLE
refactor(types): Make BezierDefinition readonly for improved usability

### DIFF
--- a/packages/framer-motion/src/easing/types.ts
+++ b/packages/framer-motion/src/easing/types.ts
@@ -2,7 +2,7 @@ export type EasingFunction = (v: number) => number
 
 export type EasingModifier = (easing: EasingFunction) => EasingFunction
 
-export type BezierDefinition = [number, number, number, number]
+export type BezierDefinition = readonly [number, number, number, number]
 
 export type EasingDefinition =
     | BezierDefinition

--- a/packages/framer-motion/src/easing/utils/__tests__/is-bezier-definition.test.ts
+++ b/packages/framer-motion/src/easing/utils/__tests__/is-bezier-definition.test.ts
@@ -5,4 +5,5 @@ test("isBezierDefinition", () => {
     expect(isBezierDefinition((v) => v)).toEqual(false)
     expect(isBezierDefinition(["linear"])).toEqual(false)
     expect(isBezierDefinition([0, 1, 2, 3])).toEqual(true)
+    expect(isBezierDefinition([0, 1, 2, 3] as const)).toEqual(true)
 })

--- a/packages/framer-motion/src/easing/utils/map.ts
+++ b/packages/framer-motion/src/easing/utils/map.ts
@@ -6,6 +6,7 @@ import { circIn, circInOut, circOut } from "../../easing/circ"
 import { backIn, backInOut, backOut } from "../../easing/back"
 import { anticipate } from "../../easing/anticipate"
 import { Easing } from "../../easing/types"
+import { isBezierDefinition } from "./is-bezier-definition";
 
 const easingLookup = {
     linear: noop,
@@ -22,7 +23,7 @@ const easingLookup = {
 }
 
 export const easingDefinitionToFunction = (definition: Easing) => {
-    if (Array.isArray(definition)) {
+    if (isBezierDefinition(definition)) {
         // If cubic bezier definition, create bezier curve
         invariant(
             definition.length === 4,


### PR DESCRIPTION
fixed #2653

Hello. It seems that changing the currently written `tuple` type to a `readonly` type would make it more convenient to use. 

If any modifications are needed, please let me know.

## AS-IS

``` ts
import { animate } from 'framer-motion'

// this works
animate(someElement, { rotateY: '180deg' }, { ease: [0.3, 1, 0, 1] })

// this throws type error
const e = [0.3, 1, 0, 1] as const
animate(someElement, { rotateY: '180deg' }, { ease: e })
```

## TO-BE
``` ts
import { animate } from 'framer-motion'

// this works
animate(someElement, { rotateY: '180deg' }, { ease: [0.3, 1, 0, 1] })

// this also works
const e = [0.3, 1, 0, 1] as const
animate(someElement, { rotateY: '180deg' }, { ease: e })
```