### PR TITLE
Adding CSS variables to types

### DIFF
--- a/packages/framer-motion/src/animation/__tests__/css-variables.test.tsx
+++ b/packages/framer-motion/src/animation/__tests__/css-variables.test.tsx
@@ -1,6 +1,5 @@
 import { render } from "../../../jest.setup"
-import { motion } from "../.."
-import * as React from "react"
+import { motion, animate, animateMini } from "../.."
 import { parseCSSVariable } from "../../render/dom/utils/css-variables-conversion"
 
 const fromName = "--from"
@@ -13,7 +12,7 @@ const toVariable = `var(${toName})`
 const style = {
     [fromName]: fromValue,
     [toName]: toValue,
-} as React.CSSProperties
+}
 
 // Stub getPropertyValue because CSS variables aren't supported by JSDom
 
@@ -53,6 +52,23 @@ describe("css variables", () => {
     beforeAll(stubGetComputedStyles)
     afterAll(resetComputedStyles)
 
+    test("types work", () => {
+        ;() => (
+            <motion.div
+                initial={{ x: 0, "--from": "#f00", "--to": 0 }}
+                transition={{ "--from": { duration: 1 } }}
+                whileHover={{ x: 100, "--from": "#f00", "--to": 0 }}
+                style={{ "--from": "#f00", "--to": 0, x: 100 }}
+            />
+        )
+
+        animate(document.createElement("div"), { x: 0, "--color": "#f00" })
+        animateMini(document.createElement("div"), {
+            transform: "none",
+            "--color": "#f00",
+        })
+    })
+
     test("should animate css color variables", async () => {
         const promise = new Promise((resolve) => {
             let frameCount = 0
@@ -89,8 +105,8 @@ describe("css variables", () => {
             const output: string[] = []
             const Component = () => (
                 <motion.div
-                    style={{ "--color": " #fff " } as any}
-                    animate={{ "--a": "20px", "--color": "#000" } as any}
+                    style={{ "--color": " #fff " }}
+                    animate={{ "--a": "20px", "--color": "#000" }}
                     transition={{ duration: 0.001 }}
                     onUpdate={(latest: any) => output.push(latest)}
                     onAnimationComplete={() => resolve(output)}

--- a/packages/framer-motion/src/animation/sequence/create.ts
+++ b/packages/framer-motion/src/animation/sequence/create.ts
@@ -344,7 +344,7 @@ export function getValueTransition(
     transition: DynamicAnimationOptions & At,
     key: string
 ): DynamicAnimationOptions {
-    return transition[key as keyof typeof transition]
+    return transition && transition[key as keyof typeof transition]
         ? {
               ...transition,
               ...(transition[key as keyof typeof transition] as Transition),

--- a/packages/framer-motion/src/animation/utils/get-value-transition.ts
+++ b/packages/framer-motion/src/animation/utils/get-value-transition.ts
@@ -1,9 +1,9 @@
 import { Transition } from "../../types"
 
 export function getValueTransition(transition: Transition, key: string) {
-    return (
-        transition[key as keyof typeof transition] ||
-        (transition as any)["default"] ||
-        transition
-    )
+    return transition
+        ? transition[key as keyof typeof transition] ||
+              (transition as any)["default"] ||
+              transition
+        : undefined
 }

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -128,8 +128,6 @@ export {
     MotionStyle,
     MotionTransform,
     VariantLabels,
-    RelayoutInfo,
-    ResolveLayoutTransition,
 } from "./motion/types"
 export {
     Orchestration,

--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -20,8 +20,6 @@ import {
 } from "../gestures/types"
 import { ViewportProps } from "./features/viewport/types"
 
-export type MotionStyleProp = string | number | MotionValue
-
 /**
  * Either a string, or array of strings, that reference variants defined via the `variants` prop.
  * @public
@@ -90,34 +88,24 @@ export type MotionCSS = MakeMotion<
  */
 export type MotionTransform = MakeMotion<TransformProperties>
 
-/**
- * @public
- */
-export type MotionStyle = MotionCSS &
-    MotionTransform &
-    MakeMotion<SVGPathProperties> &
-    MakeCustomValueType<CustomStyles>
-
-export type OnUpdate = (v: Target) => void
-
-/**
- * @public
- */
-export interface RelayoutInfo {
-    delta: {
-        x: number
-        y: number
-        width: number
-        height: number
-    }
+export type MotionCSSVariables = {
+    [key: `--${string}`]:
+        | MotionValue<number>
+        | MotionValue<string>
+        | string
+        | number
 }
 
 /**
  * @public
  */
-export type ResolveLayoutTransition = (
-    info: RelayoutInfo
-) => Transition | boolean
+export type MotionStyle = MotionCSSVariables &
+    MotionCSS &
+    MotionTransform &
+    MakeMotion<SVGPathProperties> &
+    MakeCustomValueType<CustomStyles>
+
+export type OnUpdate = (v: Target) => void
 
 /**
  * @public

--- a/packages/framer-motion/src/types.ts
+++ b/packages/framer-motion/src/types.ts
@@ -5,6 +5,7 @@ import {
     CustomStyles,
     SVGPathProperties,
 } from "./motion/types"
+import { VariableKeyframesDefinition } from "./animation/types"
 
 export type GenericKeyframesTarget<V> = V[] | Array<null | V>
 
@@ -975,7 +976,8 @@ type TargetProperties = CSSPropertiesWithoutTransitionOrSingleTransforms &
     SVGTransformAttributes &
     TransformProperties &
     CustomStyles &
-    SVGPathProperties
+    SVGPathProperties &
+    VariableKeyframesDefinition
 
 /**
  * @public


### PR DESCRIPTION
This PR does away with the need to cast styles containing CSS variables to `as any`.