### PR TITLE
Fix TypeScript error in GroupPlaybackControls.ts

### DIFF
--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -31,7 +31,7 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
 
     attachTimeline(
         timeline: any,
-        fallback: (animation: AnimationPlaybackControls) => VoidFunction | undefined
+        fallback?: (animation: AnimationPlaybackControls) => VoidFunction
     ) {
         const subscriptions = this.animations.map((animation) => {
             if (supportsScrollTimeline() && animation.attachTimeline) {

--- a/packages/framer-motion/src/animation/GroupPlaybackControls.ts
+++ b/packages/framer-motion/src/animation/GroupPlaybackControls.ts
@@ -31,12 +31,12 @@ export class GroupPlaybackControls implements AnimationPlaybackControls {
 
     attachTimeline(
         timeline: any,
-        fallback: (animation: AnimationPlaybackControls) => VoidFunction
+        fallback: (animation: AnimationPlaybackControls) => VoidFunction | undefined
     ) {
         const subscriptions = this.animations.map((animation) => {
             if (supportsScrollTimeline() && animation.attachTimeline) {
                 return animation.attachTimeline(timeline)
-            } else {
+            } else if (fallback) {
                 return fallback(animation)
             }
         })


### PR DESCRIPTION
Makes the `fallback` argument optional to satisfy the AnimationPlaybackControls interface and resolve typescript errors for consumers of Framer Motion:

<img width="1033" alt="image" src="https://github.com/user-attachments/assets/c0dbdb03-33a2-44f4-a498-7cc0e4fdc52c">


### Context

I'm consuming `framer-motion@v11.11.9` in a project running `typescript@v5.6.3`, and receiving the above TypeScript error from `node_modules/framer-motion/dist/index.d.ts`. There seems to be a mismatch in the types between GroupPlaybackControls and AnimationPlaybackControls