### PR TITLE
Fix double `.update()` call on mount

### DIFF
--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -72,9 +72,14 @@ export function useVisualElement<Instance, RenderState>(
         )
     }
 
+    const isMounted = useRef(false)
     useInsertionEffect(() => {
-        if (visualElement && visualElement.current) {
-            visualElement && visualElement.update(props, presenceContext)
+        /**
+         * Check the component has already mounted before calling
+         * `update` unnecessarily. This ensures we skip the initial update.
+         */
+        if (visualElement && isMounted.current) {
+            visualElement.update(props, presenceContext)
         }
     })
 
@@ -93,6 +98,7 @@ export function useVisualElement<Instance, RenderState>(
     useIsomorphicLayoutEffect(() => {
         if (!visualElement) return
 
+        isMounted.current = true
         window.MotionIsMounted = true
 
         visualElement.updateFeatures()

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -73,7 +73,9 @@ export function useVisualElement<Instance, RenderState>(
     }
 
     useInsertionEffect(() => {
-        visualElement && visualElement.update(props, presenceContext)
+        if (visualElement && visualElement.current) {
+            visualElement && visualElement.update(props, presenceContext)
+        }
     })
 
     /**


### PR DESCRIPTION
This PR ensures that the insertion effect responsible for updating props from a `motion` commit to its `VisualElement` only runs when the `VisualElement` is hydrated with an element reference. This cuts an unnecessary `.update()` call on mount.