### PR TITLE
fix: Ensure `isValidProp` is a function in filter-props.ts

### DIFF
--- a/packages/framer-motion/src/render/dom/utils/filter-props.ts
+++ b/packages/framer-motion/src/render/dom/utils/filter-props.ts
@@ -6,7 +6,7 @@ let shouldForward = (key: string) => !isValidMotionProp(key)
 export type IsValidProp = (key: string) => boolean
 
 export function loadExternalIsValidProp(isValidProp?: IsValidProp) {
-    if (!isValidProp) return
+    if (typeof isValidProp !== "function") return
 
     // Explicitly filter our events
     shouldForward = (key: string) =>


### PR DESCRIPTION
Implements a stricter check on `isValidProp` to ensure that it's not just truthy but also a function. 

#### Context:
There's [an issue](https://github.com/vitejs/rolldown-vite/issues/165) with Rolldown (upcoming Vite) in how it currently handles inline `require` OOTB. In relation to this library, it would replace `require("@emotion/is-prop-valid").default` with `{}` in [filter-props L35](https://github.com/motiondivision/motion/blob/d9d6ac186d07eabd02e926b60986f7978d48eac4/packages/framer-motion/src/render/dom/utils/filter-props.ts#L35). 

This bypasses the truthy check on L9 and causes the code to invoke the POJO, which explodes. There's definitely something to be said with how Rolldown is currently handling this issue but this PR can offer some relief to users attempting to switch over to Rolldown Vite while using `motion`.