### PR TITLE
fork: fix memory leak in prefers-reduced-motion listener and one othe…

### DIFF
--- a/packages/framer-motion/src/frameloop/render-step.ts
+++ b/packages/framer-motion/src/frameloop/render-step.ts
@@ -91,8 +91,8 @@ export function createRenderStep(runNextFrame: () => void): Step {
 
             isProcessing = true
 
-            // Swap this frame and the next to avoid GC
-            ;[thisFrame, nextFrame] = [nextFrame, thisFrame]
+                // Swap this frame and the next to avoid GC
+                ;[thisFrame, nextFrame] = [nextFrame, thisFrame]
 
             // Clear the next frame queue
             nextFrame.clear()
@@ -111,6 +111,7 @@ export function createRenderStep(runNextFrame: () => void): Step {
 
                     callback(frameData)
                 }
+                thisFrame.clear()
             }
 
             isProcessing = false

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -441,7 +441,9 @@ export abstract class VisualElement<
 
         this.values.forEach((value, key) => this.bindToMotionValue(key, value))
 
-        if (!hasReducedMotionListener.current) {
+        const isAutoConfig = this.reducedMotionConfig !== "never" && this.reducedMotionConfig !== "always";
+
+        if (isAutoConfig && !hasReducedMotionListener.current) {
             initPrefersReducedMotion()
         }
 
@@ -449,8 +451,8 @@ export abstract class VisualElement<
             this.reducedMotionConfig === "never"
                 ? false
                 : this.reducedMotionConfig === "always"
-                ? true
-                : prefersReducedMotion.current
+                    ? true
+                    : prefersReducedMotion.current
 
         if (process.env.NODE_ENV !== "production") {
             warnOnce(
@@ -745,8 +747,8 @@ export abstract class VisualElement<
         return this.isVariantNode
             ? this
             : this.parent
-            ? this.parent.getClosestVariantNode()
-            : undefined
+                ? this.parent.getClosestVariantNode()
+                : undefined
     }
 
     getVariantContext(startAtParent = false): undefined | VariantStateContext {
@@ -862,7 +864,7 @@ export abstract class VisualElement<
             this.latestValues[key] !== undefined || !this.current
                 ? this.latestValues[key]
                 : this.getBaseTargetFromProps(this.props, key) ??
-                  this.readValueFromInstance(this.current, key, this.options)
+                this.readValueFromInstance(this.current, key, this.options)
 
         if (value !== undefined && value !== null) {
             if (


### PR DESCRIPTION
Fix: Potential Memory Leaks with Framer Motion + React Portal (Dialog)
We've observed memory leaks when using Framer Motion inside React Portals — specifically with modal dialogs.

On the first few renders, detached DOM nodes from the dialog content appear in memory snapshots. These leaks are more concerning when DOM nodes have event listeners that close over large data objects (e.g., closures referencing refs or component state).

Investigation
Using memory profiling tools, I traced two potential sources of retained memory:

window.matchMedia listeners – particularly for the "prefers-reduced-motion" query

The render queue in render-step

These seem to hold references beyond their intended lifecycle, contributing to retention of DOM nodes and React refs (e.g., VisualElement instances).

 Note
These fixes may not be optimal or complete — the goal of this PR is to start a discussion and validate the approach with the Framer team. If more appropriate internal handling is possible, I’m happy to revise accordingly.

Related Issue
See discussion and example in: [motiondivision/motion#2444](https://github.com/motiondivision/motion/issues/2444)