### PR TITLE
Fix ReferenceError when importing motion-utils as native browser ESM

### DIFF
--- a/packages/motion-utils/src/errors.ts
+++ b/packages/motion-utils/src/errors.ts
@@ -1,15 +1,7 @@
-import { formatErrorMessage } from "./format-error-message"
-
-export type DevMessage = (
-    check: boolean,
-    message: string,
-    errorCode?: string
-) => void
-
 let warning: DevMessage = () => {}
 let invariant: DevMessage = () => {}
 
-if (process.env.NODE_ENV !== "production") {
+if (import.meta.env?.DEV ?? false) {
     warning = (check, message, errorCode) => {
         if (!check && typeof console !== "undefined") {
             console.warn(formatErrorMessage(message, errorCode))


### PR DESCRIPTION
### Problem
Importing `motion-utils` directly in the browser as a native ES module
throws `ReferenceError: process is not defined`.

This happens because `process.env.NODE_ENV` is accessed in ESM code
without guarding for non-Node environments.

### Solution
Guard `process` access so the code runs safely in browsers while
preserving existing behavior for Node and bundlers.

### Result
-  Works in native browser ESM
-  No behavior change in production
-  No reliance on bundler polyfills
