### PR TITLE
fix: Refactor ref handling in PopChild component

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -72,10 +72,8 @@ export function PopChild({ children, isPresent, anchorX, root }: Props) {
         right: 0,
     })
     const { nonce } = useContext(MotionConfigContext)
-    const composedRef = useComposedRefs(
-    ref,
-    (children as any)?.props?.ref
-    )
+    const childRef = (children as any)?.ref ?? (children as any)?.props?.ref;
+    const composedRef = useComposedRefs(ref, childRef);
     
     /**
      * We create and inject a style block so we can apply this explicit


### PR DESCRIPTION
In React 19, ref is no longer a special property on the element, Its just a normal prop so we have to do  **children.props.ref** not  **children.ref**

fixes: #3428 