### PR TITLE
Fix MotionStyle type conflict with React 19 CSSProperties

### DIFF
--- a/packages/framer-motion/src/motion/types.ts
+++ b/packages/framer-motion/src/motion/types.ts
@@ -31,7 +31,7 @@ type MakeCustomValueTypeHelper<T> = MakeMotionHelper<T>
 export type MakeMotion<T> = MakeCustomValueTypeHelper<T>
 
 export type MotionCSS = MakeMotion<
-    Omit<CSSProperties, "rotate" | "scale" | "perspective">
+    Omit<CSSProperties, "rotate" | "scale" | "perspective" | "x" | "y" | "z">
 >
 
 /**


### PR DESCRIPTION
Exclude x, y, z from CSSProperties when creating MotionCSS type to prevent TypeScript error "Interface 'MotionStyle' cannot simultaneously extend types" when using Motion with React 19 and skipLibCheck: false.

React 19's CSSProperties now includes x, y, z properties which conflict with Motion's TransformProperties. This follows the same pattern already used in CSSStyleDeclarationWithTransform.

Fixes #3422