### PR TITLE
Fix staggerChildren not working when children have gesture props

### DIFF
--- a/packages/framer-motion/src/context/MotionContext/utils.ts
+++ b/packages/framer-motion/src/context/MotionContext/utils.ts
@@ -1,13 +1,13 @@
 import type { MotionContextProps } from "."
 import { MotionProps } from "../../motion/types"
-import { isControllingVariants } from "../../render/utils/is-controlling-variants"
+import { isControllingPrimaryVariants } from "../../render/utils/is-controlling-variants"
 import { isVariantLabel } from "../../render/utils/is-variant-label"
 
 export function getCurrentTreeVariants(
     props: MotionProps,
     context: MotionContextProps
 ): MotionContextProps {
-    if (isControllingVariants(props)) {
+    if (isControllingPrimaryVariants(props)) {
         const { initial, animate } = props
         return {
             initial:

--- a/packages/framer-motion/src/motion/__tests__/variant.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/variant.test.tsx
@@ -747,6 +747,165 @@ describe("animate prop as variant", () => {
         expect(isCorrectlyStaggered).toBe(true)
     })
 
+    test("staggerChildren works correctly when children have whileHover", async () => {
+        const isCorrectlyStaggered = await new Promise((resolve) => {
+            const childVariants = {
+                hidden: { opacity: 0 },
+                visible: { opacity: 1, transition: { duration: 0.1 } },
+                hover: { scale: 1.1 },
+            }
+
+            function Component() {
+                const a = useMotionValue(0)
+                const b = useMotionValue(0)
+
+                useEffect(
+                    () =>
+                        a.on("change", (latest) => {
+                            if (latest >= 1 && b.get() === 0) resolve(true)
+                        }),
+                    [a, b]
+                )
+
+                return (
+                    <motion.div
+                        variants={{
+                            hidden: {},
+                            visible: {
+                                x: 100,
+                                transition: { staggerChildren: 0.15 },
+                            },
+                        }}
+                        initial="hidden"
+                        animate="visible"
+                    >
+                        <motion.div
+                            variants={childVariants}
+                            whileHover="hover"
+                            style={{ opacity: a }}
+                        />
+                        <motion.div
+                            variants={childVariants}
+                            whileHover="hover"
+                            style={{ opacity: b }}
+                        />
+                    </motion.div>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(isCorrectlyStaggered).toBe(true)
+    })
+
+    test("staggerChildren works correctly when children have whileTap", async () => {
+        const isCorrectlyStaggered = await new Promise((resolve) => {
+            const childVariants = {
+                hidden: { opacity: 0 },
+                visible: { opacity: 1, transition: { duration: 0.1 } },
+                tap: { scale: 0.9 },
+            }
+
+            function Component() {
+                const a = useMotionValue(0)
+                const b = useMotionValue(0)
+
+                useEffect(
+                    () =>
+                        a.on("change", (latest) => {
+                            if (latest >= 1 && b.get() === 0) resolve(true)
+                        }),
+                    [a, b]
+                )
+
+                return (
+                    <motion.div
+                        variants={{
+                            hidden: {},
+                            visible: {
+                                x: 100,
+                                transition: { staggerChildren: 0.15 },
+                            },
+                        }}
+                        initial="hidden"
+                        animate="visible"
+                    >
+                        <motion.div
+                            variants={childVariants}
+                            whileTap="tap"
+                            style={{ opacity: a }}
+                        />
+                        <motion.div
+                            variants={childVariants}
+                            whileTap="tap"
+                            style={{ opacity: b }}
+                        />
+                    </motion.div>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(isCorrectlyStaggered).toBe(true)
+    })
+
+    test("staggerChildren works correctly when children have whileFocus", async () => {
+        const isCorrectlyStaggered = await new Promise((resolve) => {
+            const childVariants = {
+                hidden: { opacity: 0 },
+                visible: { opacity: 1, transition: { duration: 0.1 } },
+                focus: { scale: 1.05 },
+            }
+
+            function Component() {
+                const a = useMotionValue(0)
+                const b = useMotionValue(0)
+
+                useEffect(
+                    () =>
+                        a.on("change", (latest) => {
+                            if (latest >= 1 && b.get() === 0) resolve(true)
+                        }),
+                    [a, b]
+                )
+
+                return (
+                    <motion.div
+                        variants={{
+                            hidden: {},
+                            visible: {
+                                x: 100,
+                                transition: { staggerChildren: 0.15 },
+                            },
+                        }}
+                        initial="hidden"
+                        animate="visible"
+                    >
+                        <motion.button
+                            variants={childVariants}
+                            whileFocus="focus"
+                            style={{ opacity: a }}
+                        />
+                        <motion.button
+                            variants={childVariants}
+                            whileFocus="focus"
+                            style={{ opacity: b }}
+                        />
+                    </motion.div>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+        })
+
+        expect(isCorrectlyStaggered).toBe(true)
+    })
+
     test("Child variants with value-specific transitions correctly calculate delay based on staggerChildren (deprecated)", async () => {
         const isCorrectlyStaggered = await new Promise((resolve) => {
             const childVariants = {

--- a/packages/framer-motion/src/motion/utils/use-visual-state.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-state.ts
@@ -10,7 +10,7 @@ import {
 } from "../../context/PresenceContext"
 import { ResolvedValues, ScrapeMotionValuesFromProps } from "../../render/types"
 import {
-    isControllingVariants as checkIsControllingVariants,
+    isControllingPrimaryVariants as checkIsControllingPrimaryVariants,
     isVariantNode as checkIsVariantNode,
 } from "../../render/utils/is-controlling-variants"
 import { resolveVariantFromProps } from "../../render/utils/resolve-variants"
@@ -70,13 +70,13 @@ function makeLatestValues(
     }
 
     let { initial, animate } = props
-    const isControllingVariants = checkIsControllingVariants(props)
+    const isControllingPrimaryVariants = checkIsControllingPrimaryVariants(props)
     const isVariantNode = checkIsVariantNode(props)
 
     if (
         context &&
         isVariantNode &&
-        !isControllingVariants &&
+        !isControllingPrimaryVariants &&
         props.inherit !== false
     ) {
         if (initial === undefined) initial = context.initial

--- a/packages/framer-motion/src/render/VisualElement.ts
+++ b/packages/framer-motion/src/render/VisualElement.ts
@@ -45,6 +45,7 @@ import {
 import { AnimationState } from "./utils/animation-state"
 import {
     isControllingVariants as checkIsControllingVariants,
+    isControllingPrimaryVariants as checkIsControllingPrimaryVariants,
     isVariantNode as checkIsVariantNode,
 } from "./utils/is-controlling-variants"
 import { updateMotionValuesFromProps } from "./utils/motion-values"
@@ -216,6 +217,7 @@ export abstract class VisualElement<
      */
     isVariantNode: boolean = false
     isControllingVariants: boolean = false
+    isControllingPrimaryVariants: boolean = false
 
     /**
      * If this component is part of the variant tree, it should track
@@ -366,6 +368,7 @@ export abstract class VisualElement<
         this.blockInitialAnimation = Boolean(blockInitialAnimation)
 
         this.isControllingVariants = checkIsControllingVariants(props)
+        this.isControllingPrimaryVariants = checkIsControllingPrimaryVariants(props)
         this.isVariantNode = checkIsVariantNode(props)
         if (this.isVariantNode) {
             this.variantChildren = new Set()
@@ -404,7 +407,7 @@ export abstract class VisualElement<
             this.projection.mount(instance)
         }
 
-        if (this.parent && this.isVariantNode && !this.isControllingVariants) {
+        if (this.parent && this.isVariantNode && !this.isControllingPrimaryVariants) {
             this.removeFromVariantTree = this.parent.addVariantChild(this)
         }
 

--- a/packages/framer-motion/src/render/utils/is-controlling-variants.ts
+++ b/packages/framer-motion/src/render/utils/is-controlling-variants.ts
@@ -3,6 +3,10 @@ import { MotionProps } from "../../motion/types"
 import { isVariantLabel } from "./is-variant-label"
 import { variantProps } from "./variant-props"
 
+/**
+ * Check if a component has any variant props that make it participate in the variant system.
+ * This is used to determine if a component should build variant context for children.
+ */
 export function isControllingVariants(props: MotionProps) {
     return (
         isAnimationControls(props.animate) ||
@@ -12,6 +16,23 @@ export function isControllingVariants(props: MotionProps) {
     )
 }
 
+/**
+ * Check if a component participates in the variant system at all.
+ */
 export function isVariantNode(props: MotionProps) {
     return Boolean(isControllingVariants(props) || props.variants)
+}
+
+/**
+ * Check if a component is controlling the primary variant animation flow.
+ * This only includes animate/initial - gesture props like whileHover, whileTap etc.
+ * are NOT included because they are independent animations that should not
+ * prevent a child from inheriting parent variants for staggerChildren.
+ */
+export function isControllingPrimaryVariants(props: MotionProps): boolean {
+    return (
+        isAnimationControls(props.animate) ||
+        isVariantLabel(props.initial) ||
+        isVariantLabel(props.animate)
+    )
 }


### PR DESCRIPTION
## Summary

- Fixed an issue where `staggerChildren` didn't work when child components had gesture props like `whileHover`, `whileTap`, `whileFocus`, or `whileDrag`
- Introduced `isControllingPrimaryVariants()` to distinguish between primary variant control (`animate`/`initial`) and gesture-based variants
- Added tests for `staggerChildren` with `whileHover`, `whileTap`, and `whileFocus`

## Problem

When a child component had any gesture prop (e.g., `whileHover="hover"`), it was incorrectly excluded from the parent's `variantChildren` set. This broke `staggerChildren` animations because the parent couldn't coordinate timing with its children.

The root cause was that `isControllingVariants()` checked ALL variant props including gesture-based ones. A component with `whileHover` was treated as "controlling variants" even though gesture props are independent animations that shouldn't prevent variant inheritance.

## Solution

Introduced `isControllingPrimaryVariants()` which only checks for `animate` and `initial` props. This is used in three places:
1. `VisualElement.ts` - Whether to add a component to parent's `variantChildren`
2. `use-visual-state.ts` - Whether to inherit `initial`/`animate` from parent context
3. `MotionContext/utils.ts` - Whether to inherit context from parent

The original `isControllingVariants()` is unchanged and still used for building variant context that propagates to children.

## Test plan

- [x] Added test: `staggerChildren works correctly when children have whileHover`
- [x] Added test: `staggerChildren works correctly when children have whileTap`
- [x] Added test: `staggerChildren works correctly when children have whileFocus`
- [x] All existing variant tests pass
- [x] All press gesture tests pass (including parent-to-child variant propagation)

Fixes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)