### PR TITLE
Add type option to motion.create() for SVG support

### DIFF
--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -32,7 +32,8 @@ export function useVisualElement<
         | VisualState<HTMLElement, HTMLRenderState>,
     props: MotionProps & Partial<MotionConfigContext>,
     createVisualElement?: CreateVisualElement<Props, TagName>,
-    ProjectionNodeConstructor?: any
+    ProjectionNodeConstructor?: any,
+    isSVG?: boolean
 ): VisualElement<HTMLElement | SVGElement> | undefined {
     const { visualElement: parent } = useContext(MotionContext)
     const lazyContext = useContext(LazyContext)
@@ -60,6 +61,7 @@ export function useVisualElement<
                 ? presenceContext.initial === false
                 : false,
             reducedMotionConfig,
+            isSVG,
         })
     }
 

--- a/packages/framer-motion/src/render/dom/create-visual-element.ts
+++ b/packages/framer-motion/src/render/dom/create-visual-element.ts
@@ -8,7 +8,12 @@ export const createDomVisualElement: CreateVisualElement = (
     Component: string | ComponentType<React.PropsWithChildren<unknown>>,
     options: VisualElementOptions<HTMLElement | SVGElement>
 ) => {
-    return isSVGComponent(Component)
+    /**
+     * Use explicit isSVG override if provided, otherwise auto-detect
+     */
+    const isSVG = options.isSVG ?? isSVGComponent(Component)
+
+    return isSVG
         ? new SVGVisualElement(options)
         : new HTMLVisualElement(options, {
               allowProjection: Component !== Fragment,

--- a/packages/framer-motion/src/render/dom/use-render.ts
+++ b/packages/framer-motion/src/render/dom/use-render.ts
@@ -23,11 +23,11 @@ export function useRender<
         latestValues,
     }: VisualState<HTMLElement | SVGElement, HTMLRenderState | SVGRenderState>,
     isStatic: boolean,
-    forwardMotionProps: boolean = false
+    forwardMotionProps: boolean = false,
+    isSVG?: boolean
 ) {
-    const useVisualProps = isSVGComponent(Component)
-        ? useSVGProps
-        : useHTMLProps
+    const useVisualProps =
+        (isSVG ?? isSVGComponent(Component)) ? useSVGProps : useHTMLProps
 
     const visualProps = useVisualProps(
         props as any,

--- a/packages/framer-motion/src/render/types.ts
+++ b/packages/framer-motion/src/render/types.ts
@@ -26,6 +26,11 @@ export interface VisualElementOptions<Instance, RenderState = any> {
     props: MotionProps
     blockInitialAnimation?: boolean
     reducedMotionConfig?: ReducedMotionConfig
+    /**
+     * Explicit override for SVG detection. When true, uses SVG rendering;
+     * when false, uses HTML rendering. If undefined, auto-detects.
+     */
+    isSVG?: boolean
 }
 
 /**


### PR DESCRIPTION
Fixes #1177 - viewBox animations now work when wrapping custom SVG components using motion.create(CustomSVGComponent, { type: "svg" })

Changes:
- Add `type?: "html" | "svg"` option to MotionComponentOptions
- Update createMotionComponent to use explicit type over auto-detection
- Pass isSVG through useVisualElement and useRender
- Update createDomVisualElement to respect isSVG option in VisualElementOptions