### PR TITLE
fix: use JSX from the React namespace

### DIFF
--- a/packages/framer-motion/src/components/Reorder/Item.tsx
+++ b/packages/framer-motion/src/components/Reorder/Item.tsx
@@ -65,7 +65,7 @@ export function ReorderItemComponent<
         ...props
     }: ReorderItemProps<V, TagName>,
     externalRef?: React.ForwardedRef<any>
-): JSX.Element {
+): React.JSX.Element {
     const Component = useConstant(
         () => motion[as as keyof typeof motion]
     ) as FunctionComponent<


### PR DESCRIPTION
fixes #3397

PR #3389 fixed `framer-motion/src/components/Reorder/Group.tsx` this one addresses `framer-motion/src/components/Reorder/Item.tsx`