### PR TITLE
Fix duplicate exit animation processing in AnimatePresence

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -87,6 +87,11 @@ export const AnimatePresence = ({
     const exitComplete = useConstant(() => new Map<ComponentKey, boolean>())
 
     /**
+     * Track which components are currently processing exit to prevent duplicate processing.
+     */
+    const exitingComponents = useRef(new Set<ComponentKey>())
+
+    /**
      * Save children to render as React state. To ensure this component is concurrent-safe,
      * we check for exiting children via an effect.
      */
@@ -109,6 +114,7 @@ export const AnimatePresence = ({
                 }
             } else {
                 exitComplete.delete(key)
+                exitingComponents.current.delete(key)
             }
         }
     }, [renderedChildren, presentKeys.length, presentKeys.join("-")])
@@ -179,6 +185,11 @@ export const AnimatePresence = ({
                           presentKeys.includes(key)
 
                 const onExit = () => {
+                    if (exitingComponents.current.has(key)) {
+                        return
+                    }
+                    exitingComponents.current.add(key)
+
                     if (exitComplete.has(key)) {
                         exitComplete.set(key, true)
                     } else {


### PR DESCRIPTION
## Summary

- Fixes issue where AnimatePresence processes exit animations multiple times when receiving rapid sequential events (e.g., Radix UI dismissable layers firing multiple dismiss events)
- Adds a `Set` to track components currently processing exit and guards against duplicate `onExit` calls
- Adds tests using `usePresence` to verify the fix without relying on animation timing

## Test plan

- [x] Added test "Calling safeToRemove multiple times only triggers exit once" - verifies `onExitComplete` is called only once when `safeToRemove` is called multiple times
- [x] Added test "Rapid rerenders during exit only triggers exit once" - verifies rapid re-renders don't cause duplicate exit processing
- [x] All existing AnimatePresence tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)