### PR TITLE
Fix AnimatePresence exit animations with Radix UI asChild

### DIFF
--- a/dev/react-19/package.json
+++ b/dev/react-19/package.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.0.0"
     },
     "devDependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/dev/react/package.json
+++ b/dev/react/package.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.3.1"
     },
     "devDependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/dev/react/src/tests/animate-presence-radix-dialog.tsx
+++ b/dev/react/src/tests/animate-presence-radix-dialog.tsx
@@ -1,0 +1,120 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { AnimatePresence, motion } from "framer-motion"
+import { useId, useState } from "react"
+
+/**
+ * Test for AnimatePresence with Radix UI Dialog
+ * This reproduces issue #3455 where exit animations break
+ * when using asChild with motion components inside AnimatePresence.
+ *
+ * The issue occurs because Radix UI's asChild prop creates new callback refs
+ * on each render, and when externalRef is in the useMotionRef dependency array,
+ * this causes the callback to be recreated, triggering remounts that break
+ * exit animations.
+ */
+export const App = () => {
+    const id = useId()
+    const [isOpen, setIsOpen] = useState(false)
+    const [exitComplete, setExitComplete] = useState(false)
+    const [exitStarted, setExitStarted] = useState(false)
+
+    return (
+        <div className="App" style={{ padding: 20 }}>
+            <style>{`
+                .overlay {
+                    position: fixed;
+                    inset: 0;
+                    background: rgba(0, 0, 0, 0.5);
+                }
+                .dialog {
+                    position: fixed;
+                    background: white;
+                    padding: 20px;
+                    border-radius: 8px;
+                    width: 300px;
+                }
+            `}</style>
+
+            <DialogPrimitive.Root onOpenChange={setIsOpen} open={isOpen}>
+                <DialogPrimitive.Trigger id="trigger">
+                    {isOpen ? "Close" : "Open"}
+                </DialogPrimitive.Trigger>
+                <AnimatePresence
+                    onExitComplete={() => setExitComplete(true)}
+                >
+                    {isOpen ? (
+                        <DialogPrimitive.Portal key={id} forceMount>
+                            <DialogPrimitive.Overlay asChild>
+                                <motion.div
+                                    id="overlay"
+                                    className="overlay"
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    initial={{ opacity: 0 }}
+                                    transition={{ duration: 0.3 }}
+                                    onAnimationStart={(definition) => {
+                                        if (
+                                            definition === "exit" ||
+                                            (typeof definition === "object" &&
+                                                "opacity" in definition &&
+                                                definition.opacity === 0)
+                                        ) {
+                                            setExitStarted(true)
+                                        }
+                                    }}
+                                />
+                            </DialogPrimitive.Overlay>
+
+                            <DialogPrimitive.Content asChild>
+                                <motion.div
+                                    id="dialog"
+                                    className="dialog"
+                                    animate={{
+                                        left: "50%",
+                                        bottom: "50%",
+                                        y: "50%",
+                                        x: "-50%",
+                                    }}
+                                    exit={{
+                                        left: "50%",
+                                        bottom: 0,
+                                        y: "100%",
+                                        x: "-50%",
+                                    }}
+                                    initial={{
+                                        left: "50%",
+                                        bottom: 0,
+                                        y: "100%",
+                                        x: "-50%",
+                                    }}
+                                    transition={{ duration: 0.3 }}
+                                >
+                                    <DialogPrimitive.Title>
+                                        Dialog Title
+                                    </DialogPrimitive.Title>
+
+                                    <DialogPrimitive.Description>
+                                        Dialog content here
+                                    </DialogPrimitive.Description>
+
+                                    <DialogPrimitive.Close id="close">
+                                        Close
+                                    </DialogPrimitive.Close>
+                                </motion.div>
+                            </DialogPrimitive.Content>
+                        </DialogPrimitive.Portal>
+                    ) : null}
+                </AnimatePresence>
+            </DialogPrimitive.Root>
+
+            <div id="status" style={{ marginTop: 20 }}>
+                <div id="exit-started" data-value={exitStarted.toString()}>
+                    Exit started: {exitStarted.toString()}
+                </div>
+                <div id="exit-complete" data-value={exitComplete.toString()}>
+                    Exit complete: {exitComplete.toString()}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/dev/react/src/tests/motion-ref-forwarding.tsx
+++ b/dev/react/src/tests/motion-ref-forwarding.tsx
@@ -1,0 +1,139 @@
+import { motion } from "framer-motion"
+import { useRef, useState, useCallback } from "react"
+
+/**
+ * Test for ref forwarding behavior in motion components.
+ * Tests:
+ * 1. RefObject forwarding - ref.current should be set to the DOM element
+ * 2. Callback ref forwarding - callback should be called with DOM element on mount, null on unmount
+ * 3. Callback ref cleanup (React 19) - cleanup function should be called on unmount
+ */
+export const App = () => {
+    const [mounted, setMounted] = useState(true)
+    const [results, setResults] = useState({
+        refObjectMounted: false,
+        refObjectValue: "none",
+        callbackRefMountCalled: false,
+        callbackRefMountValue: "none",
+        callbackRefUnmountCalled: false,
+        callbackRefUnmountValue: "none",
+        cleanupCalled: false,
+    })
+
+    // Test 1: RefObject
+    const refObject = useRef<HTMLDivElement>(null)
+
+    // Test 2: Callback ref
+    const callbackRef = useCallback((instance: HTMLDivElement | null) => {
+        if (instance) {
+            setResults((prev) => ({
+                ...prev,
+                callbackRefMountCalled: true,
+                callbackRefMountValue: instance.tagName,
+            }))
+            // Return cleanup function (React 19 feature)
+            return () => {
+                setResults((prev) => ({
+                    ...prev,
+                    cleanupCalled: true,
+                }))
+            }
+        } else {
+            setResults((prev) => ({
+                ...prev,
+                callbackRefUnmountCalled: true,
+                callbackRefUnmountValue: "null",
+            }))
+        }
+    }, [])
+
+    // Check refObject after mount
+    const checkRefObject = () => {
+        setResults((prev) => ({
+            ...prev,
+            refObjectMounted: true,
+            refObjectValue: refObject.current?.tagName || "null",
+        }))
+    }
+
+    return (
+        <div style={{ padding: 20 }}>
+            <h2>Motion Ref Forwarding Test</h2>
+
+            <button id="toggle" onClick={() => setMounted(!mounted)}>
+                {mounted ? "Unmount" : "Mount"}
+            </button>
+            <button id="check-ref" onClick={checkRefObject}>
+                Check RefObject
+            </button>
+
+            {mounted && (
+                <>
+                    <motion.div
+                        id="ref-object-target"
+                        ref={refObject}
+                        style={{
+                            width: 100,
+                            height: 100,
+                            background: "blue",
+                            margin: 10,
+                        }}
+                    >
+                        RefObject Target
+                    </motion.div>
+
+                    <motion.div
+                        id="callback-ref-target"
+                        ref={callbackRef}
+                        style={{
+                            width: 100,
+                            height: 100,
+                            background: "green",
+                            margin: 10,
+                        }}
+                    >
+                        Callback Ref Target
+                    </motion.div>
+                </>
+            )}
+
+            <div id="results" style={{ marginTop: 20, fontFamily: "monospace" }}>
+                <div
+                    id="ref-object-mounted"
+                    data-value={results.refObjectMounted.toString()}
+                >
+                    refObject checked: {results.refObjectMounted.toString()}
+                </div>
+                <div id="ref-object-value" data-value={results.refObjectValue}>
+                    refObject.current?.tagName: {results.refObjectValue}
+                </div>
+                <div
+                    id="callback-mount-called"
+                    data-value={results.callbackRefMountCalled.toString()}
+                >
+                    callback ref mount called:{" "}
+                    {results.callbackRefMountCalled.toString()}
+                </div>
+                <div
+                    id="callback-mount-value"
+                    data-value={results.callbackRefMountValue}
+                >
+                    callback ref mount value: {results.callbackRefMountValue}
+                </div>
+                <div
+                    id="callback-unmount-called"
+                    data-value={results.callbackRefUnmountCalled.toString()}
+                >
+                    callback ref unmount called:{" "}
+                    {results.callbackRefUnmountCalled.toString()}
+                </div>
+                <div
+                    id="cleanup-called"
+                    data-value={results.cleanupCalled.toString()}
+                >
+                    cleanup function called: {results.cleanupCalled.toString()}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-radix-dialog.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-radix-dialog.ts
@@ -1,0 +1,56 @@
+describe("AnimatePresence with Radix UI Dialog", () => {
+    it("Exit animations work correctly with Radix Dialog asChild", () => {
+        cy.visit("?test=animate-presence-radix-dialog")
+            .wait(100)
+            // Open the dialog
+            .get("#trigger")
+            .click()
+            .wait(500)
+            // Verify dialog is open
+            .get("#dialog")
+            .should("exist")
+            .get("#overlay")
+            .should("exist")
+            // Close the dialog
+            .get("#close")
+            .click()
+            // Wait for exit animation to complete
+            .wait(600)
+            // Verify exit animation completed (onExitComplete was called)
+            .get("#exit-complete")
+            .should("have.attr", "data-value", "true")
+            // Verify the dialog elements are removed from DOM after exit
+            .get("#dialog")
+            .should("not.exist")
+            .get("#overlay")
+            .should("not.exist")
+    })
+
+    it("Exit animation actually runs (not immediately removed)", () => {
+        cy.visit("?test=animate-presence-radix-dialog")
+            .wait(100)
+            // Open the dialog
+            .get("#trigger")
+            .click()
+            .wait(500)
+            // Verify dialog is open
+            .get("#overlay")
+            .should("exist")
+            // Close the dialog
+            .get("#close")
+            .click()
+            // Check immediately - overlay should still exist during exit animation
+            .get("#overlay")
+            .should("exist")
+            // Wait a small amount for animation to start but not complete
+            .wait(100)
+            // Overlay should still be animating out
+            .get("#overlay")
+            .should("exist")
+            // Now wait for full animation
+            .wait(400)
+            // Now it should be gone
+            .get("#overlay")
+            .should("not.exist")
+    })
+})

--- a/packages/framer-motion/cypress/integration/motion-ref-forwarding.ts
+++ b/packages/framer-motion/cypress/integration/motion-ref-forwarding.ts
@@ -1,0 +1,47 @@
+describe("Motion ref forwarding", () => {
+    it("RefObject receives the DOM element", () => {
+        cy.visit("?test=motion-ref-forwarding")
+            .wait(100)
+            .get("#ref-object-target")
+            .should("exist")
+            .get("#check-ref")
+            .click()
+            .wait(50)
+            .get("#ref-object-value")
+            .should("have.attr", "data-value", "DIV")
+    })
+
+    it("Callback ref is called with element on mount", () => {
+        cy.visit("?test=motion-ref-forwarding")
+            .wait(100)
+            .get("#callback-mount-called")
+            .should("have.attr", "data-value", "true")
+            .get("#callback-mount-value")
+            .should("have.attr", "data-value", "DIV")
+    })
+
+    it("Callback ref cleanup is handled on unmount", () => {
+        cy.visit("?test=motion-ref-forwarding")
+            .wait(100)
+            // Unmount the components
+            .get("#toggle")
+            .click()
+            .wait(100)
+            // Either cleanup function is called (React 19 pattern)
+            // OR callback ref is called with null (React 18 pattern)
+            .then(() => {
+                cy.get("#callback-unmount-called").then(($unmount) => {
+                    cy.get("#cleanup-called").then(($cleanup) => {
+                        const unmountCalled =
+                            $unmount.attr("data-value") === "true"
+                        const cleanupCalled =
+                            $cleanup.attr("data-value") === "true"
+                        expect(
+                            unmountCalled || cleanupCalled,
+                            "Either unmount or cleanup should be called"
+                        ).to.be.true
+                    })
+                })
+            })
+    })
+})

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -93,6 +93,7 @@
         "tslib": "^2.4.0"
     },
     "devDependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@thednp/dommatrix": "^2.0.11",
         "@types/three": "0.137.0",
         "three": "0.137.0"

--- a/packages/framer-motion/src/motion/utils/__tests__/use-motion-ref.test.tsx
+++ b/packages/framer-motion/src/motion/utils/__tests__/use-motion-ref.test.tsx
@@ -17,7 +17,7 @@ describe("useMotionRef", () => {
         expect(refCallback).toHaveBeenCalledWith(expect.any(HTMLElement))
     })
 
-    it("should call external ref callback with null on unmount (React 18 behavior)", () => {
+    it("should call external ref callback with null on unmount", () => {
         const refCallback = jest.fn()
 
         const Component = () => {
@@ -35,10 +35,7 @@ describe("useMotionRef", () => {
         expect(refCallback).toHaveBeenCalledWith(null)
     })
 
-    it("should support React 19 cleanup function pattern (forward compatibility)", () => {
-        // This test verifies that when a ref callback returns a cleanup function,
-        // our code properly stores it and calls it on unmount instead of calling ref(null).
-        // This works in both React 18 and React 19 without warnings.
+    it("should call cleanup function on unmount when ref returns one (React 19)", () => {
         const cleanup = jest.fn()
         const refCallback = jest.fn(() => cleanup)
 
@@ -48,18 +45,14 @@ describe("useMotionRef", () => {
 
         const { unmount } = render(<Component />)
 
-        // Verify mount called correctly
         expect(refCallback).toHaveBeenCalledTimes(1)
         expect(refCallback).toHaveBeenCalledWith(expect.any(HTMLElement))
 
-        // Clear previous calls to focus on unmount behavior
         refCallback.mockClear()
-        cleanup.mockClear()
 
         unmount()
 
-        // With our new approach: cleanup function should be called
-        // and ref should NOT be called with null
+        // Cleanup should be called, ref should NOT be called with null
         expect(cleanup).toHaveBeenCalledTimes(1)
         expect(refCallback).not.toHaveBeenCalledWith(null)
     })
@@ -92,34 +85,7 @@ describe("useMotionRef", () => {
         expect(() => rerender(<Component useCallback={false} />)).not.toThrow()
     })
 
-    it("should handle visual element cleanup correctly with React 19 pattern", () => {
-        const cleanup = jest.fn()
-        const refCallback = jest.fn(() => cleanup)
-
-        const Component = () => {
-            return (
-                <motion.div
-                    ref={refCallback}
-                    // Add motion props to ensure visual element is created
-                    animate={{ x: 100 }}
-                />
-            )
-        }
-
-        const { unmount } = render(<Component />)
-
-        // Clear previous calls
-        refCallback.mockClear()
-        cleanup.mockClear()
-
-        unmount()
-
-        // Both external ref cleanup and visual element unmount should happen
-        expect(cleanup).toHaveBeenCalledTimes(1)
-        expect(refCallback).not.toHaveBeenCalledWith(null)
-    })
-
-    it("should work with forwardRef components and React 19 cleanup pattern", () => {
+    it("should work with forwardRef components", () => {
         const cleanup = jest.fn()
         const refCallback = jest.fn(() => cleanup)
 
@@ -137,9 +103,7 @@ describe("useMotionRef", () => {
 
         expect(refCallback).toHaveBeenCalledWith(expect.any(HTMLElement))
 
-        // Clear previous calls
         refCallback.mockClear()
-        cleanup.mockClear()
 
         unmount()
 

--- a/packages/framer-motion/src/motion/utils/use-motion-ref.ts
+++ b/packages/framer-motion/src/motion/utils/use-motion-ref.ts
@@ -1,23 +1,9 @@
 "use client"
 
 import * as React from "react"
-import { useCallback, useRef } from "react"
+import { useCallback, useInsertionEffect, useRef } from "react"
 import type { VisualElement } from "../../render/VisualElement"
-import { isRefObject } from "../../utils/is-ref-object"
 import { VisualState } from "./use-visual-state"
-
-/**
- * Set a given ref to a given value
- * This utility takes care of different types of refs: callback refs and RefObject(s)
- * Returns a cleanup function if the ref callback returns one (React 19 feature)
- */
-function setRef<T>(ref: React.Ref<T>, value: T): void | (() => void) {
-    if (typeof ref === "function") {
-        return ref(value)
-    } else if (isRefObject(ref)) {
-        ;(ref as any).current = value
-    }
-}
 
 /**
  * Creates a ref function that, when called, hydrates the provided
@@ -28,45 +14,48 @@ export function useMotionRef<Instance, RenderState>(
     visualElement?: VisualElement<Instance> | null,
     externalRef?: React.Ref<Instance>
 ): React.Ref<Instance> {
-    // Store the cleanup function from external ref if it returns one
-    const externalRefCleanupRef = useRef<(() => void) | null>(null)
+    /**
+     * Store externalRef in a ref to avoid including it in the useCallback
+     * dependency array. Including externalRef in dependencies causes issues
+     * with libraries like Radix UI that create new callback refs on each render
+     * when using asChild - this would cause the callback to be recreated,
+     * triggering element remounts and breaking AnimatePresence exit animations.
+     */
+    const externalRefContainer = useRef(externalRef)
+    useInsertionEffect(() => {
+        externalRefContainer.current = externalRef
+    })
+
+    // Store cleanup function returned by callback refs (React 19 feature)
+    const refCleanup = useRef<(() => void) | null>(null)
 
     return useCallback(
         (instance: Instance) => {
             if (instance) {
-                visualState.onMount && visualState.onMount(instance)
+                visualState.onMount?.(instance)
             }
 
             if (visualElement) {
-                if (instance) {
-                    visualElement.mount(instance)
-                } else {
-                    visualElement.unmount()
-                }
+                instance ? visualElement.mount(instance) : visualElement.unmount()
             }
 
-            if (externalRef) {
+            const ref = externalRefContainer.current
+            if (typeof ref === "function") {
                 if (instance) {
-                    // Mount: call the external ref and store any cleanup function
-                    const cleanup = setRef(externalRef, instance)
+                    const cleanup = ref(instance)
                     if (typeof cleanup === "function") {
-                        externalRefCleanupRef.current = cleanup
+                        refCleanup.current = cleanup
                     }
+                } else if (refCleanup.current) {
+                    refCleanup.current()
+                    refCleanup.current = null
                 } else {
-                    // Unmount: call stored cleanup function if available, otherwise call ref with null
-                    if (externalRefCleanupRef.current) {
-                        externalRefCleanupRef.current()
-                        externalRefCleanupRef.current = null
-                    } else {
-                        // Fallback to React <19 behavior for refs that don't return cleanup
-                        setRef(externalRef, instance)
-                    }
+                    ref(instance)
                 }
+            } else if (ref) {
+                ;(ref as React.MutableRefObject<Instance>).current = instance
             }
         },
-        /**
-         * Include all dependencies to ensure the callback updates correctly
-         */
-        [visualElement, visualState, externalRef]
+        [visualElement]
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,6 +2486,289 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/primitive@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/primitive@npm:1.1.3"
+  checksum: ee27abbff0d6d305816e9314655eb35e72478ba47416bc9d5cb0581728be35e3408cfc0748313837561d635f0cb7dfaae26e61831f0e16c0fd7d669a612f2cb0
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 9a91f0213014ffa40c5b8aae4debb993be5654217e504e35aa7422887eb2d114486d37e53c482d0fffb00cd44f51b5269fcdf397b280c71666fa11b7f32f165d
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-context@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6d08437f23df362672259e535ae463e70bf7a0069f09bfa06c983a5a90e15250bde19da1d63ef8e3da06df1e1b4f92afa9d28ca6aa0297bb1c8aaf6ca83d28c5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dialog@npm:^1.1.15":
+  version: 1.1.15
+  resolution: "@radix-ui/react-dialog@npm:1.1.15"
+  dependencies:
+    "@radix-ui/primitive": 1.1.3
+    "@radix-ui/react-compose-refs": 1.1.2
+    "@radix-ui/react-context": 1.1.2
+    "@radix-ui/react-dismissable-layer": 1.1.11
+    "@radix-ui/react-focus-guards": 1.1.3
+    "@radix-ui/react-focus-scope": 1.1.7
+    "@radix-ui/react-id": 1.1.1
+    "@radix-ui/react-portal": 1.1.9
+    "@radix-ui/react-presence": 1.1.5
+    "@radix-ui/react-primitive": 2.1.3
+    "@radix-ui/react-slot": 1.2.3
+    "@radix-ui/react-use-controllable-state": 1.2.2
+    aria-hidden: ^1.2.4
+    react-remove-scroll: ^2.6.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: a0834338ec66866ce301ef46e0dad9d99accf496f03b5021eceec7e2b79d7286b4f2c5e35f2387891e2bf33ef9a11d381dde2c8fe936a2f30cd50ca4e9bf4cb5
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dismissable-layer@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.11"
+  dependencies:
+    "@radix-ui/primitive": 1.1.3
+    "@radix-ui/react-compose-refs": 1.1.2
+    "@radix-ui/react-primitive": 2.1.3
+    "@radix-ui/react-use-callback-ref": 1.1.1
+    "@radix-ui/react-use-escape-keydown": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 8fc9f027c9f68940c69c9cc117c43e1313d1a78ae4109cf809868b82837e5e2a7d410adf78e97328d9d5a080a63e399918414985658ab029a8df7d775af23b68
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-guards@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: b57878f6cf0ebc3e8d7c5c6bbaad44598daac19c921551ca541c104201048a9a902f3d69196e7a09995fd46e998c309aab64dc30fa184b3609d67d187a6a9c24
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-scope@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-focus-scope@npm:1.1.7"
+  dependencies:
+    "@radix-ui/react-compose-refs": 1.1.2
+    "@radix-ui/react-primitive": 2.1.3
+    "@radix-ui/react-use-callback-ref": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: bb642d192d3da8431f8b39f64959b493a7ba743af8501b76699ef93357c96507c11fb76d468824b52b0e024eaee130a641f3a213268ac7c9af34883b45610c9b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-id@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-id@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8d68e200778eb3038906870fc869b3d881f4a46715fb20cddd9c76cba42fdaaa4810a3365b6ec2daf0f185b9201fc99d009167f59c7921bc3a139722c2e976db
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:1.1.9":
+  version: 1.1.9
+  resolution: "@radix-ui/react-portal@npm:1.1.9"
+  dependencies:
+    "@radix-ui/react-primitive": 2.1.3
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: bd6be39bf021d5c917e2474ecba411e2625171f7ef96862b9af04bbd68833bb3662a7f1fbdeb5a7a237111b10e811e76d2cd03e957dadd6e668ef16541bfbd68
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-presence@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/react-presence@npm:1.1.5"
+  dependencies:
+    "@radix-ui/react-compose-refs": 1.1.2
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 05f1b8e80d3d878efab44304ce55d0b9e6c7050e8345f9da95d0597a716121fb2467c3247c847c51a6cb27edd00e86ac36b2635e4c00ea79d91cfc26c930da81
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": 1.2.3
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 01f82e4bad76b57767198762c905e5bcea04f4f52129749791e31adfcb1b36f6fdc89c73c40017d812b6e25e4ac925d837214bb280cfeaa5dc383457ce6940b0
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": 1.1.2
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 2731089e15477dd5eef98a5757c36113dd932d0c52ff05123cd89f05f0412e95e5b205229185d1cd705cda4a674a838479cce2b3b46ed903f82f5d23d9e3f3c2
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: cde8c40f1d4e79e6e71470218163a746858304bad03758ac84dc1f94247a046478e8e397518350c8d6609c84b7e78565441d7505bb3ed573afce82cfdcd19faf
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
+  dependencies:
+    "@radix-ui/react-use-effect-event": 0.0.2
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: b438ee199d0630bf95eaafe8bf4bce219e73b371cfc8465f47548bfa4ee231f1134b5c6696b242890a01a0fd25fa34a7b172346bbfc5ee25cfb28b3881b1dc92
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 5a1950a30a399ea7e4b98154da9f536737a610de80189b7aacd4f064a89a3cd0d2a48571d527435227252e72e872bdb544ff6ffcfbdd02de2efd011be4aaa902
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-escape-keydown@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-use-callback-ref": 1.1.1
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0eb0756c2c55ddcde9ff01446ab01c085ab2bf799173e97db7ef5f85126f9e8600225570801a1f64740e6d14c39ffe8eed7c14d29737345a5797f4622ac96f6f
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: bad2ba4f206e6255263582bedfb7868773c400836f9a1b423c0b464ffe4a17e13d3f306d1ce19cf7a19a492e9d0e49747464f2656451bb7c6a99f5a57bd34de2
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0-beta.11":
   version: 1.0.0-beta.11
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.11"
@@ -3873,6 +4156,15 @@ __metadata:
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
   checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
+  languageName: node
+  linkType: hard
+
+"aria-hidden@npm:^1.2.4":
+  version: 1.2.6
+  resolution: "aria-hidden@npm:1.2.6"
+  dependencies:
+    tslib: ^2.0.0
+  checksum: 56409c55c43ad917607f3f3aa67748dcf30a27e8bb5cb3c5d86b43e38babadd63cd77731a27bc8a8c4332c2291741ed92333bf7ca45f8b99ebc87b94a8070a6e
   languageName: node
   linkType: hard
 
@@ -5770,6 +6062,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-node-es@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "detect-node-es@npm:1.1.0"
+  checksum: e46307d7264644975b71c104b9f028ed1d3d34b83a15b8a22373640ce5ea630e5640b1078b8ea15f202b54641da71e4aa7597093bd4b91f113db520a26a37449
+  languageName: node
+  linkType: hard
+
 "detect-port-alt@npm:^1.1.6":
   version: 1.1.6
   resolution: "detect-port-alt@npm:1.1.6"
@@ -7125,6 +7424,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "framer-motion@workspace:packages/framer-motion"
   dependencies:
+    "@radix-ui/react-dialog": ^1.1.15
     "@thednp/dommatrix": ^2.0.11
     "@types/three": 0.137.0
     motion-dom: ^12.24.8
@@ -7338,6 +7638,13 @@ __metadata:
     hasown: ^2.0.2
     math-intrinsics: ^1.1.0
   checksum: 301008e4482bb9a9cb49e132b88fee093bff373b4e6def8ba219b1e96b60158a6084f273ef5cafe832e42cd93462f4accb46a618d35fe59a2b507f2388c5b79d
+  languageName: node
+  linkType: hard
+
+"get-nonce@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "get-nonce@npm:1.0.1"
+  checksum: e2614e43b4694c78277bb61b0f04583d45786881289285c73770b07ded246a98be7e1f78b940c80cbe6f2b07f55f0b724e6db6fd6f1bcbd1e8bdac16521074ed
   languageName: node
   linkType: hard
 
@@ -12285,6 +12592,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-19-env@workspace:dev/react-19"
   dependencies:
+    "@radix-ui/react-dialog": ^1.1.15
     "@types/react": ^19.0.0
     "@types/react-dom": ^19.0.0
     "@typescript-eslint/eslint-plugin": ^7.2.0
@@ -12368,6 +12676,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-env@workspace:dev/react"
   dependencies:
+    "@radix-ui/react-dialog": ^1.1.15
     "@types/react": ^18.2.66
     "@types/react-dom": ^18.2.22
     "@typescript-eslint/eslint-plugin": ^7.2.0
@@ -12406,6 +12715,57 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
+  languageName: node
+  linkType: hard
+
+"react-remove-scroll-bar@npm:^2.3.7":
+  version: 2.3.8
+  resolution: "react-remove-scroll-bar@npm:2.3.8"
+  dependencies:
+    react-style-singleton: ^2.2.2
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c4663247f689dbe51c370836edf735487f6d8796acb7f15b09e8a1c14e84c7997360e8e3d54de2bc9c0e782fed2b2c4127d15b4053e4d2cf26839e809e57605f
+  languageName: node
+  linkType: hard
+
+"react-remove-scroll@npm:^2.6.3":
+  version: 2.7.2
+  resolution: "react-remove-scroll@npm:2.7.2"
+  dependencies:
+    react-remove-scroll-bar: ^2.3.7
+    react-style-singleton: ^2.2.3
+    tslib: ^2.1.0
+    use-callback-ref: ^1.3.3
+    use-sidecar: ^1.1.3
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 70179d794b3172afea8f1df7aedab0df2849f8f9662e20814a3ef6268564f19f077e1153e80c4ab3b379543e7ac1492bec921db130018ca74f2eaedeea841f4d
+  languageName: node
+  linkType: hard
+
+"react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "react-style-singleton@npm:2.2.3"
+  dependencies:
+    get-nonce: ^1.0.0
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a7b0bf493c9231065ebafa84c4237aed997c746c561196121b7de82fe155a5355b372db5070a3ac9fe980cf7f60dc0f1e8cf6402a2aa5b2957392932ccf76e76
   languageName: node
   linkType: hard
 
@@ -14735,7 +15095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
@@ -15186,6 +15546,37 @@ __metadata:
     punycode: ^1.4.1
     qs: ^6.12.3
   checksum: c25e587723d343d5d4248892393bfa5039ded9c2c07095a9d005bc64b7cb8956d623c0d8da8d1a28f71986a7a8d80fc2e9f9cf84235e48fa435a5cb4451062c6
+  languageName: node
+  linkType: hard
+
+"use-callback-ref@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "use-callback-ref@npm:1.3.3"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 4da1c82d7a2409cee6c882748a40f4a083decf238308bf12c3d0166f0e338f8d512f37b8d11987eb5a421f14b9b5b991edf3e11ed25c3bb7a6559081f8359b44
+  languageName: node
+  linkType: hard
+
+"use-sidecar@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "use-sidecar@npm:1.1.3"
+  dependencies:
+    detect-node-es: ^1.1.0
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 88664c6b2c5b6e53e4d5d987694c9053cea806da43130248c74ca058945c8caa6ccb7b1787205a9eb5b9d124633e42153848904002828acabccdc48cda026622
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Fixes AnimatePresence exit animations not running when using Radix UI's `asChild` prop with motion components
- Stores `externalRef` in a ref (updated via `useInsertionEffect` for concurrent mode safety) instead of including it in `useCallback` dependency array
- Preserves React 19 cleanup function support

## Problem

When using Radix UI Dialog (or similar libraries) with `asChild` and motion components inside `AnimatePresence`, exit animations were not running. The elements were immediately removed from the DOM instead of animating out.

```jsx
<AnimatePresence>
  {isOpen ? (
    <DialogPrimitive.Portal forceMount>
      <DialogPrimitive.Overlay asChild>
        <motion.div exit={{ opacity: 0 }} />  {/* Exit animation not working */}
      </DialogPrimitive.Overlay>
    </DialogPrimitive.Portal>
  ) : null}
</AnimatePresence>
```

## Root Cause

In `use-motion-ref.ts`, `externalRef` was in the `useCallback` dependency array. Radix UI's `asChild` creates a new composed callback ref on each render. This caused:
1. `useCallback` to return a new function each render
2. React to call the ref with `null` (unmount) then the new instance (remount)
3. AnimatePresence exit animations to be bypassed

## Solution

Store `externalRef` in a ref (`externalRefContainer`) and update it via `useInsertionEffect` (for concurrent mode safety). Access the current value inside the callback rather than including it in dependencies. This maintains:
- React 19 cleanup function support
- Proper ref forwarding
- AnimatePresence exit animations working correctly

## Test plan

- [x] Added E2E test with `@radix-ui/react-dialog` reproducing the exact issue from #3455
- [x] Added E2E tests for ref forwarding (RefObject, callback ref, cleanup)
- [x] All unit tests pass (701 tests)
- [x] React 18 E2E tests pass
- [x] React 19 E2E tests pass

Fixes #3455

🤖 Generated with [Claude Code](https://claude.com/claude-code)