### PR TITLE
Add `anchorY` prop to `AnimatePresence`

### DIFF
--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -13,12 +13,14 @@ interface Size {
     top: number
     left: number
     right: number
+    bottom: number
 }
 
 interface Props {
     children: React.ReactElement
     isPresent: boolean
     anchorX?: "left" | "right"
+    anchorY?: "top" | "bottom"
     root?: HTMLElement | ShadowRoot
 }
 
@@ -39,6 +41,9 @@ class PopChildMeasure extends React.Component<MeasureProps> {
             const parentWidth = isHTMLElement(parent)
                 ? parent.offsetWidth || 0
                 : 0
+            const parentHeight = isHTMLElement(parent)
+                ? parent.offsetHeight || 0
+                : 0
 
             const size = this.props.sizeRef.current!
             size.height = element.offsetHeight || 0
@@ -46,6 +51,7 @@ class PopChildMeasure extends React.Component<MeasureProps> {
             size.top = element.offsetTop
             size.left = element.offsetLeft
             size.right = parentWidth - size.width - size.left
+            size.bottom = parentHeight - size.height - size.top
         }
 
         return null
@@ -61,7 +67,7 @@ class PopChildMeasure extends React.Component<MeasureProps> {
     }
 }
 
-export function PopChild({ children, isPresent, anchorX, root }: Props) {
+export function PopChild({ children, isPresent, anchorX, anchorY, root }: Props) {
     const id = useId()
     const ref = useRef<HTMLElement>(null)
     const size = useRef<Size>({
@@ -70,6 +76,7 @@ export function PopChild({ children, isPresent, anchorX, root }: Props) {
         top: 0,
         left: 0,
         right: 0,
+        bottom: 0,
     })
     const { nonce } = useContext(MotionConfigContext)
     /**
@@ -91,10 +98,11 @@ export function PopChild({ children, isPresent, anchorX, root }: Props) {
      * styles set via the style prop.
      */
     useInsertionEffect(() => {
-        const { width, height, top, left, right } = size.current
+        const { width, height, top, left, right, bottom } = size.current
         if (isPresent || !ref.current || !width || !height) return
 
         const x = anchorX === "left" ? `left: ${left}` : `right: ${right}`
+        const y = anchorY === "bottom" ? `bottom: ${bottom}` : `top: ${top}`
 
         ref.current.dataset.motionPopId = id
 
@@ -111,7 +119,7 @@ export function PopChild({ children, isPresent, anchorX, root }: Props) {
             width: ${width}px !important;
             height: ${height}px !important;
             ${x}px !important;
-            top: ${top}px !important;
+            ${y}px !important;
           }
         `)
         }

--- a/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PresenceChild.tsx
@@ -19,6 +19,7 @@ interface PresenceChildProps {
     presenceAffectsLayout: boolean
     mode: "sync" | "popLayout" | "wait"
     anchorX?: "left" | "right"
+    anchorY?: "top" | "bottom"
     root?: HTMLElement | ShadowRoot
 }
 
@@ -31,6 +32,7 @@ export const PresenceChild = ({
     presenceAffectsLayout,
     mode,
     anchorX,
+    anchorY,
     root
 }: PresenceChildProps) => {
     const presenceChildren = useConstant(newChildrenMap)
@@ -86,7 +88,7 @@ export const PresenceChild = ({
 
     if (mode === "popLayout") {
         children = (
-            <PopChild isPresent={isPresent} anchorX={anchorX} root={root}>
+            <PopChild isPresent={isPresent} anchorX={anchorX} anchorY={anchorY} root={root}>
                 {children}
             </PopChild>
         )

--- a/packages/framer-motion/src/components/AnimatePresence/index.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/index.tsx
@@ -52,6 +52,7 @@ export const AnimatePresence = ({
     mode = "sync",
     propagate = false,
     anchorX = "left",
+    anchorY = "top",
     root
 }: React.PropsWithChildren<AnimatePresenceProps>) => {
     const [isParentPresent, safeToRemove] = usePresence(propagate)
@@ -226,6 +227,7 @@ export const AnimatePresence = ({
                         root={root}
                         onExitComplete={isPresent ? undefined : onExit}
                         anchorX={anchorX}
+                        anchorY={anchorY}
                     >
                         {child}
                     </PresenceChild>

--- a/packages/framer-motion/src/components/AnimatePresence/types.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/types.ts
@@ -75,4 +75,11 @@ export interface AnimatePresenceProps {
      * when using `mode="popLayout"`.
      */
     anchorX?: "left" | "right"
+
+    /**
+     * Internal. Set whether to anchor the y position of the exiting element to the top or bottom
+     * when using `mode="popLayout"`. Use `"bottom"` for elements originally positioned with
+     * `bottom: 0` to prevent them from shifting during exit animations.
+     */
+    anchorY?: "top" | "bottom"
 }


### PR DESCRIPTION
Add anchorY prop to AnimatePresence to control vertical anchor point during exit animations in popLayout mode. Similar to the existing anchorX prop for horizontal positioning, anchorY allows choosing between "top" (default) and "bottom" positioning.

When an element is originally positioned using `bottom: 0`, setting `anchorY="bottom"` ensures it maintains its position relative to the bottom of its container during exit animations, fixing the reported bug where elements would shift downward.

Changes:
- Add anchorY prop to AnimatePresenceProps type
- Add bottom measurement in PopChild's getSnapshotBeforeUpdate
- Use anchorY to determine whether to use top or bottom CSS positioning
- Pass anchorY through PresenceChild to PopChild
- Add test for bottom positioning preservation

Fixes #3324