### PR TITLE
Add fontSize to default px types list

### DIFF
--- a/packages/framer-motion/src/render/html/utils/__tests__/build-styles.test.ts
+++ b/packages/framer-motion/src/render/html/utils/__tests__/build-styles.test.ts
@@ -12,6 +12,14 @@ describe("buildHTMLStyles", () => {
         expect(style).toEqual({ width: "100px" })
     })
 
+    test("Builds fontSize with px unit", () => {
+        const latest = { fontSize: 16 }
+        const style = {}
+        build(latest, { style })
+
+        expect(style).toEqual({ fontSize: "16px" })
+    })
+
     test("Builds vars", () => {
         const latest = { "--width": 100 }
         const vars = {}

--- a/packages/motion-dom/src/animation/waapi/utils/px-values.ts
+++ b/packages/motion-dom/src/animation/waapi/utils/px-values.ts
@@ -50,6 +50,8 @@ export const pxValues = new Set([
     "marginInline",
     "marginInlineStart",
     "marginInlineEnd",
+    // Typography
+    "fontSize",
     // Misc
     "backgroundPositionX",
     "backgroundPositionY",

--- a/packages/motion-dom/src/value/types/maps/number.ts
+++ b/packages/motion-dom/src/value/types/maps/number.ts
@@ -59,6 +59,9 @@ export const numberValueTypes: ValueTypeMap = {
     marginInlineStart: px,
     marginInlineEnd: px,
 
+    // Typography
+    fontSize: px,
+
     // Misc
     backgroundPositionX: px,
     backgroundPositionY: px,


### PR DESCRIPTION
This allows numeric fontSize values to automatically have "px" units appended, matching the behavior of width, height, and other dimension properties.

Fixes #2749