### PR TITLE
Fix `radius` in `feMorphology` tag

### DIFF
--- a/packages/motion-dom/src/animation/waapi/utils/px-values.ts
+++ b/packages/motion-dom/src/animation/waapi/utils/px-values.ts
@@ -6,7 +6,6 @@ export const pxValues = new Set([
     "borderBottomWidth",
     "borderLeftWidth",
     "borderRadius",
-    "radius",
     "borderTopLeftRadius",
     "borderTopRightRadius",
     "borderBottomRightRadius",

--- a/packages/motion-dom/src/effects/__tests__/svg-effect.test.ts
+++ b/packages/motion-dom/src/effects/__tests__/svg-effect.test.ts
@@ -9,6 +9,27 @@ async function nextFrame() {
 }
 
 describe("svgEffect", () => {
+    it("sets feMorphology radius as unitless number (issue #2779)", async () => {
+        const element = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "feMorphology"
+        )
+
+        // Create motion value for radius
+        const radius = motionValue(4)
+
+        // Apply svg effect
+        svgEffect(element, {
+            radius,
+        })
+
+        await nextFrame()
+
+        // Verify radius is set as unitless number, not with "px" suffix
+        // This was the bug - radius was being set as "4px" instead of "4"
+        expect(element.getAttribute("radius")).toBe("4")
+    })
+
     it("sets SVG attributes and styles after svgEffect is applied", async () => {
         const element = document.createElementNS(
             "http://www.w3.org/2000/svg",

--- a/packages/motion-dom/src/value/types/maps/number.ts
+++ b/packages/motion-dom/src/value/types/maps/number.ts
@@ -12,7 +12,6 @@ export const numberValueTypes: ValueTypeMap = {
     borderBottomWidth: px,
     borderLeftWidth: px,
     borderRadius: px,
-    radius: px,
     borderTopLeftRadius: px,
     borderTopRightRadius: px,
     borderBottomRightRadius: px,


### PR DESCRIPTION
The SVG feMorphology filter primitive requires radius to be a unitless number. The radius property was incorrectly mapped to px units, which caused animated radius values to become invalid (e.g., "4px" instead of "4").

Fixes #2779