### PR TITLE
Fix `motion.create()` types

### DIFF
--- a/packages/framer-motion/src/render/components/create-proxy.ts
+++ b/packages/framer-motion/src/render/components/create-proxy.ts
@@ -33,7 +33,10 @@ export function createMotionProxy(
      */
     const componentCache = new Map<string, any>()
 
-    const factory = (Component: string, options?: MotionComponentOptions) => {
+    const factory = <Props>(
+        Component: string | React.ComponentType<Props>,
+        options?: MotionComponentOptions
+    ) => {
         return createMotionComponent(
             Component,
             options,
@@ -45,8 +48,8 @@ export function createMotionProxy(
     /**
      * Support for deprecated`motion(Component)` pattern
      */
-    const deprecatedFactoryFunction = (
-        Component: string,
+    const deprecatedFactoryFunction = <Props>(
+        Component: string | React.ComponentType<Props>,
         options?: MotionComponentOptions
     ) => {
         if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
The factory and deprecatedFactoryFunction in createMotionProxy were incorrectly typed to only accept string as the Component parameter, but createMotionComponent (which they call internally) accepts string | React.ComponentType<Props>.

This caused TypeScript errors when users tried to use motion.create() with custom React components, as reported in issue #2792.

Fixes #2792