### PR TITLE
Fix TypeScript error in create-proxy component

### DIFF
--- a/packages/framer-motion/src/render/components/create-proxy.ts
+++ b/packages/framer-motion/src/render/components/create-proxy.ts
@@ -21,7 +21,7 @@ type MotionProxy = typeof createMotionComponent &
 
 export function createMotionProxy(
     preloadedFeatures?: FeaturePackages,
-    createVisualElement?: CreateVisualElement
+    createVisualElement?: CreateVisualElement<any, any>
 ): MotionProxy {
     if (typeof Proxy === "undefined") {
         return createMotionComponent as MotionProxy


### PR DESCRIPTION
The CreateVisualElement parameter type was too narrow (defaulting to CreateVisualElement<{}, "div">), causing type errors when passed to the generic createMotionComponent function. Changed to use explicit <any, any> type parameters to allow the proxy to work with any props and tag names.