### PR TITLE
Fix animateMini crash when element removed from DOM during scroll cancellation

### DIFF
--- a/dev/html/public/playwright/animate/mini.html
+++ b/dev/html/public/playwright/animate/mini.html
@@ -35,6 +35,7 @@
         <div class="box" id="autoplay">autoplay</div>
         <div class="box" id="time">time</div>
         <div class="box" id="custom-easing">custom easing</div>
+        <div class="box" id="stop-after-remove">stop after remove</div>
         <script type="module" src="/src/inc.js"></script>
         <script type="module">
             const { animateMini, spring } = window.Motion
@@ -161,6 +162,35 @@
             customEasingFunction.pause()
             customEasingFunction.time = 0.1
             customEasingFunction.stop()
+
+            // Test stop() doesn't crash when element is removed from DOM (issue #3509)
+            const stopAfterRemoveElement = document.getElementById("stop-after-remove")
+            const stopAfterRemoveAnimation = animateMini(
+                stopAfterRemoveElement,
+                { opacity: [0, 1] },
+                { duration: 1 }
+            )
+
+            try {
+                // Remove element from DOM
+                stopAfterRemoveElement.remove()
+                // Stop animation - this should not throw
+                stopAfterRemoveAnimation.stop()
+                // If we get here without throwing, the test passed
+                // Create a new element to show success
+                const successElement = document.createElement("div")
+                successElement.id = "stop-after-remove-result"
+                successElement.className = "box"
+                successElement.textContent = "complete"
+                document.body.appendChild(successElement)
+            } catch (e) {
+                // If we catch an error, the test failed
+                const errorElement = document.createElement("div")
+                errorElement.id = "stop-after-remove-result"
+                errorElement.className = "box"
+                errorElement.textContent = "error: " + e.message
+                document.body.appendChild(errorElement)
+            }
         </script>
     </body>
 </html>

--- a/packages/motion-dom/src/animation/NativeAnimation.ts
+++ b/packages/motion-dom/src/animation/NativeAnimation.ts
@@ -178,7 +178,8 @@ export class NativeAnimation<T extends AnyResolvedKeyframe>
      * while deferring the commit until the next animation frame.
      */
     protected commitStyles() {
-        if (!this.isPseudoElement) {
+        const element = this.options?.element
+        if (!this.isPseudoElement && element?.isConnected) {
             this.animation.commitStyles?.()
         }
     }

--- a/tests/animate/mini.spec.ts
+++ b/tests/animate/mini.spec.ts
@@ -62,4 +62,11 @@ test.describe("animateMini", () => {
         const element = page.locator("#custom-easing")
         await expect(element).toHaveCSS("opacity", "0.25")
     })
+
+    test("stop() does not crash when element is removed from DOM", async ({
+        page,
+    }) => {
+        const element = page.locator("#stop-after-remove-result")
+        await expect(element).toHaveText("complete")
+    })
 })


### PR DESCRIPTION
Check if element is still connected to the DOM before calling commitStyles()
in NativeAnimation. This prevents the WAAPI commitStyles() method from throwing
when the animation is stopped after the element has been removed from the DOM
(e.g., in disconnectedCallback).

Fixes #3509