### PR TITLE
Add skipAnimations config to MotionConfig for testing

### DIFF
--- a/packages/framer-motion/src/components/MotionConfig/__tests__/index.test.tsx
+++ b/packages/framer-motion/src/components/MotionConfig/__tests__/index.test.tsx
@@ -75,3 +75,107 @@ describe("reducedMotion", () => {
         expect(result[1]).not.toEqual(1)
     })
 })
+
+describe("skipAnimations", () => {
+    test("skipAnimations makes all animations complete instantly", async () => {
+        const result = await new Promise<[number, number]>(async (resolve) => {
+            const x = motionValue(0)
+            const opacity = motionValue(0)
+            const Component = () => {
+                return (
+                    <MotionConfig skipAnimations>
+                        <motion.div
+                            animate={{ opacity: 1, x: 100 }}
+                            transition={{ duration: 2 }}
+                            style={{ x, opacity }}
+                        />
+                    </MotionConfig>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+
+            await nextFrame()
+
+            resolve([x.get(), opacity.get()])
+        })
+
+        // Both transform and non-transform values should complete instantly
+        expect(result[0]).toEqual(100)
+        expect(result[1]).toEqual(1)
+    })
+
+    test("skipAnimations=false does not skip animations", async () => {
+        const result = await new Promise<[number, number]>(async (resolve) => {
+            const x = motionValue(0)
+            const opacity = motionValue(0)
+            const Component = () => {
+                return (
+                    <MotionConfig skipAnimations={false}>
+                        <motion.div
+                            animate={{ opacity: 1, x: 100 }}
+                            transition={{ duration: 2 }}
+                            style={{ x, opacity }}
+                        />
+                    </MotionConfig>
+                )
+            }
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+
+            await nextFrame()
+
+            resolve([x.get(), opacity.get()])
+        })
+
+        // Values should still be animating (not yet at final value)
+        expect(result[0]).not.toEqual(100)
+        expect(result[1]).not.toEqual(1)
+    })
+
+    test("skipAnimations is scoped to component tree", async () => {
+        const result = await new Promise<[number, number, number, number]>(
+            async (resolve) => {
+                const x1 = motionValue(0)
+                const opacity1 = motionValue(0)
+                const x2 = motionValue(0)
+                const opacity2 = motionValue(0)
+
+                const Component = () => {
+                    return (
+                        <>
+                            <MotionConfig skipAnimations>
+                                <motion.div
+                                    animate={{ opacity: 1, x: 100 }}
+                                    transition={{ duration: 2 }}
+                                    style={{ x: x1, opacity: opacity1 }}
+                                />
+                            </MotionConfig>
+                            <motion.div
+                                animate={{ opacity: 1, x: 100 }}
+                                transition={{ duration: 2 }}
+                                style={{ x: x2, opacity: opacity2 }}
+                            />
+                        </>
+                    )
+                }
+
+                const { rerender } = render(<Component />)
+                rerender(<Component />)
+
+                await nextFrame()
+
+                resolve([x1.get(), opacity1.get(), x2.get(), opacity2.get()])
+            }
+        )
+
+        // Inside MotionConfig with skipAnimations - should be instant
+        expect(result[0]).toEqual(100)
+        expect(result[1]).toEqual(1)
+        // Outside MotionConfig - should still be animating
+        expect(result[2]).not.toEqual(100)
+        expect(result[3]).not.toEqual(1)
+    })
+})

--- a/packages/framer-motion/src/components/MotionConfig/index.tsx
+++ b/packages/framer-motion/src/components/MotionConfig/index.tsx
@@ -59,6 +59,7 @@ export function MotionConfig({
             JSON.stringify(config.transition),
             config.transformPagePoint,
             config.reducedMotion,
+            config.skipAnimations,
         ]
     )
 

--- a/packages/framer-motion/src/context/MotionConfigContext.tsx
+++ b/packages/framer-motion/src/context/MotionConfigContext.tsx
@@ -44,6 +44,14 @@ export interface MotionConfigContext {
      * @public
      */
     nonce?: string
+
+    /**
+     * If true, all animations will be skipped and values will be set instantly.
+     * Useful for E2E tests and visual regression testing.
+     *
+     * @public
+     */
+    skipAnimations?: boolean
 }
 
 /**

--- a/packages/framer-motion/src/motion/utils/use-visual-element.ts
+++ b/packages/framer-motion/src/motion/utils/use-visual-element.ts
@@ -40,7 +40,9 @@ export function useVisualElement<
     const { visualElement: parent } = useContext(MotionContext)
     const lazyContext = useContext(LazyContext)
     const presenceContext = useContext(PresenceContext)
-    const reducedMotionConfig = useContext(MotionConfigContext).reducedMotion
+    const motionConfig = useContext(MotionConfigContext)
+    const reducedMotionConfig = motionConfig.reducedMotion
+    const skipAnimations = motionConfig.skipAnimations
 
     const visualElementRef = useRef<VisualElement<
         HTMLElement | SVGElement
@@ -69,6 +71,7 @@ export function useVisualElement<
                 ? presenceContext.initial === false
                 : false,
             reducedMotionConfig,
+            skipAnimations,
             isSVG,
         })
 

--- a/packages/framer-motion/src/render/types.ts
+++ b/packages/framer-motion/src/render/types.ts
@@ -32,6 +32,11 @@ export interface VisualElementOptions<Instance, RenderState = any> {
     blockInitialAnimation?: boolean
     reducedMotionConfig?: ReducedMotionConfig
     /**
+     * If true, all animations will be skipped and values will be set instantly.
+     * Useful for E2E tests and visual regression testing.
+     */
+    skipAnimations?: boolean
+    /**
      * Explicit override for SVG detection. When true, uses SVG rendering;
      * when false, uses HTML rendering. If undefined, auto-detects.
      */

--- a/packages/motion-dom/src/animation/interfaces/motion-value.ts
+++ b/packages/motion-dom/src/animation/interfaces/motion-value.ts
@@ -99,7 +99,8 @@ export const animateMotionValue =
 
         if (
             MotionGlobalConfig.instantAnimations ||
-            MotionGlobalConfig.skipAnimations
+            MotionGlobalConfig.skipAnimations ||
+            element?.shouldSkipAnimations
         ) {
             shouldSkip = true
             makeAnimationInstant(options)

--- a/packages/motion-dom/src/render/VisualElement.ts
+++ b/packages/motion-dom/src/render/VisualElement.ts
@@ -253,6 +253,12 @@ export abstract class VisualElement<
     shouldReduceMotion: boolean | null = null
 
     /**
+     * Decides whether animations should be skipped for this VisualElement.
+     * Useful for E2E tests and visual regression testing.
+     */
+    shouldSkipAnimations: boolean = false
+
+    /**
      * Normally, if a component is controlled by a parent's variants, it can
      * rely on that ancestor to trigger animations further down the tree.
      * However, if a component is created after its parent is mounted, the parent
@@ -321,6 +327,11 @@ export abstract class VisualElement<
     private reducedMotionConfig: ReducedMotionConfig | undefined
 
     /**
+     * A reference to the skipAnimations config passed to the VisualElement's host React component.
+     */
+    private skipAnimationsConfig: boolean | undefined
+
+    /**
      * On mount, this will be hydrated with a callback to disconnect
      * this visual element from its parent on unmount.
      */
@@ -366,6 +377,7 @@ export abstract class VisualElement<
             props,
             presenceContext,
             reducedMotionConfig,
+            skipAnimations,
             blockInitialAnimation,
             visualState,
         }: VisualElementOptions<Instance, RenderState>,
@@ -381,6 +393,7 @@ export abstract class VisualElement<
         this.presenceContext = presenceContext
         this.depth = parent ? parent.depth + 1 : 0
         this.reducedMotionConfig = reducedMotionConfig
+        this.skipAnimationsConfig = skipAnimations
         this.options = options
         this.blockInitialAnimation = Boolean(blockInitialAnimation)
 
@@ -452,6 +465,11 @@ export abstract class VisualElement<
                 "reduced-motion-disabled"
             )
         }
+
+        /**
+         * Set whether animations should be skipped based on the config.
+         */
+        this.shouldSkipAnimations = this.skipAnimationsConfig ?? false
 
         this.parent?.addChild(this)
 

--- a/packages/motion-dom/src/render/types.ts
+++ b/packages/motion-dom/src/render/types.ts
@@ -66,6 +66,14 @@ export interface MotionConfigContextProps {
      * @public
      */
     nonce?: string
+
+    /**
+     * If true, all animations will be skipped and values will be set instantly.
+     * Useful for E2E tests and visual regression testing.
+     *
+     * @public
+     */
+    skipAnimations?: boolean
 }
 
 export interface VisualState<_Instance, RenderState> {
@@ -81,6 +89,11 @@ export interface VisualElementOptions<Instance, RenderState = any> {
     props: MotionNodeOptions
     blockInitialAnimation?: boolean
     reducedMotionConfig?: ReducedMotionConfig
+    /**
+     * If true, all animations will be skipped and values will be set instantly.
+     * Useful for E2E tests and visual regression testing.
+     */
+    skipAnimations?: boolean
     /**
      * Explicit override for SVG detection. When true, uses SVG rendering;
      * when false, uses HTML rendering. If undefined, auto-detects.


### PR DESCRIPTION
## Summary
This PR adds a new `skipAnimations` configuration option to `MotionConfig` that allows all animations within a component tree to complete instantly. This is useful for E2E tests and visual regression testing where animation delays are undesirable.

## Key Changes
- **MotionConfig Context**: Added `skipAnimations?: boolean` property to `MotionConfigContext` interface
- **MotionConfig Component**: Updated dependency array to include `skipAnimations` config for proper memoization
- **VisualElement**: 
  - Added `shouldSkipAnimations` property to track whether animations should be skipped
  - Added `skipAnimationsConfig` private property to store the config value
  - Updated constructor to accept and initialize `skipAnimations` option
- **Animation Logic**: Modified animation check in `motion-dom` to respect `skipAnimations` flag alongside existing instant animation conditions
- **Type Definitions**: Updated `VisualElementOptions` and `MotionConfigContextProps` interfaces across both `framer-motion` and `motion-dom` packages
- **Tests**: Added comprehensive test suite covering:
  - Animations complete instantly when `skipAnimations` is enabled
  - Animations proceed normally when `skipAnimations={false}`
  - `skipAnimations` is properly scoped to the component tree (doesn't affect siblings outside MotionConfig)

## Implementation Details
The `skipAnimations` flag is passed through the React context and stored on each `VisualElement` instance. During animation initialization, the flag is checked alongside global animation skip conditions to determine whether to skip the animation and set values instantly. This approach ensures the setting is properly scoped to the component tree where `MotionConfig` is applied.

https://claude.ai/code/session_01A87hrNZPSrAajiuoEkGu86