### PR TITLE
Add test for useInView margin option

### DIFF
--- a/packages/framer-motion/src/utils/__tests__/mock-intersection-observer.ts
+++ b/packages/framer-motion/src/utils/__tests__/mock-intersection-observer.ts
@@ -8,14 +8,20 @@ export type MockIntersectionObserverCallback = (
 ) => void
 
 let activeIntersectionObserver: MockIntersectionObserverCallback | undefined
+let lastObserverOptions: IntersectionObserverInit | undefined
 
 export const getActiveObserver = () => activeIntersectionObserver
+export const getLastObserverOptions = () => lastObserverOptions
 
 window.IntersectionObserver = class MockIntersectionObserver {
     callback: MockIntersectionObserverCallback
 
-    constructor(callback: MockIntersectionObserverCallback) {
+    constructor(
+        callback: MockIntersectionObserverCallback,
+        options?: IntersectionObserverInit
+    ) {
         this.callback = callback
+        lastObserverOptions = options
     }
 
     observe(_element: Element) {

--- a/packages/framer-motion/src/utils/__tests__/use-in-view.test.tsx
+++ b/packages/framer-motion/src/utils/__tests__/use-in-view.test.tsx
@@ -1,7 +1,10 @@
 import { act, useEffect, useRef } from "react"
 import { render } from "../../jest.setup"
 import { useInView } from "../use-in-view"
-import { getActiveObserver } from "./mock-intersection-observer"
+import {
+    getActiveObserver,
+    getLastObserverOptions,
+} from "./mock-intersection-observer"
 
 const target = document.createElement("div")
 
@@ -107,6 +110,19 @@ describe("useInView", () => {
         act(leave)
 
         expect(results).toEqual([false, true, false, true, false])
+    })
+
+    test("Passes margin to IntersectionObserver as rootMargin", () => {
+        const Component = () => {
+            const ref = useRef(null)
+            useInView(ref, { margin: "100px 0px" })
+
+            return <div ref={ref} />
+        }
+
+        render(<Component />)
+
+        expect(getLastObserverOptions()?.rootMargin).toBe("100px 0px")
     })
 
     test("Only triggers true once, if once is set", async () => {


### PR DESCRIPTION
The margin option already exists and is passed through to IntersectionObserver
as rootMargin. This adds test coverage to verify that behavior, updating the
mock IntersectionObserver to capture constructor options.

https://claude.ai/code/session_019i3qtdF5MpeqreVHWWvbBj