### PR TITLE
fix: transitionEnd stuck with stale values after rapid variant switching

### DIFF
--- a/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
+++ b/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
@@ -132,11 +132,16 @@ export function animateTarget(
     }
 
     if (transitionEnd) {
-        Promise.all(animations).then(() => {
+        const applyTransitionEnd = () =>
             frame.update(() => {
                 transitionEnd && setTarget(visualElement, transitionEnd)
             })
-        })
+
+        if (animations.length) {
+            Promise.all(animations).then(applyTransitionEnd)
+        } else {
+            applyTransitionEnd()
+        }
     }
 
     return animations


### PR DESCRIPTION
## Summary

- Fixes [#1668](https://github.com/motiondivision/motion/issues/1668): `transitionEnd` values override the new variant's values when rapidly switching variants with instant transitions (`type: false` or `duration: 0`)
- Root cause: when all animations are instant (shouldSkip), `Promise.all([])` resolves as a microtask, deferring the `transitionEnd` `frame.update` callback until after the new variant's callbacks — so the stale `transitionEnd` fires last and wins
- Fix: when `animations` array is empty, queue `transitionEnd` synchronously via `frame.update` instead of through `Promise.all`, keeping it ordered correctly in the same frame batch

## Test plan

- [x] Added regression test: "transitionEnd from instant animation does not override subsequent variant"
- [x] Full variant test suite passes (37/37)
- [x] All motion tests pass (229/229)
- [x] Build succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)