### PR TITLE
Add shared layout Fragment animation test

### DIFF
--- a/dev/react/src/tests/layout-shared-fragment.tsx
+++ b/dev/react/src/tests/layout-shared-fragment.tsx
@@ -1,0 +1,62 @@
+import { motion } from "framer-motion"
+import { Fragment, useState } from "react"
+
+const box: React.CSSProperties = {
+    position: "absolute",
+    left: 0,
+    background: "red",
+}
+
+const a: React.CSSProperties = {
+    ...box,
+    top: 100,
+    width: 100,
+    height: 100,
+}
+
+const b: React.CSSProperties = {
+    ...box,
+    top: 300,
+    width: 100,
+    height: 100,
+}
+
+function A({ onClick }: { onClick: () => void }) {
+    return (
+        <Fragment>
+            <motion.div
+                id="box"
+                data-testid="box"
+                layoutId="box"
+                style={a}
+                onClick={onClick}
+                transition={{ duration: 1, ease: () => 0.5 }}
+            />
+        </Fragment>
+    )
+}
+
+function B({ onClick }: { onClick: () => void }) {
+    return (
+        <Fragment>
+            <motion.div
+                id="box"
+                data-testid="box"
+                layoutId="box"
+                style={b}
+                onClick={onClick}
+                transition={{ duration: 1, ease: () => 0.5 }}
+            />
+        </Fragment>
+    )
+}
+
+export const App = () => {
+    const [state, setState] = useState(true)
+
+    return state ? (
+        <A onClick={() => setState(false)} />
+    ) : (
+        <B onClick={() => setState(true)} />
+    )
+}

--- a/packages/framer-motion/cypress/integration/layout-shared-fragment.ts
+++ b/packages/framer-motion/cypress/integration/layout-shared-fragment.ts
@@ -1,0 +1,41 @@
+interface BoundingBox {
+    top: number
+    left: number
+    width: number
+    height: number
+}
+
+function expectBbox(element: HTMLElement, expectedBbox: BoundingBox) {
+    const bbox = element.getBoundingClientRect()
+    expect(bbox.left).to.equal(expectedBbox.left)
+    expect(bbox.top).to.equal(expectedBbox.top)
+    expect(bbox.width).to.equal(expectedBbox.width)
+    expect(bbox.height).to.equal(expectedBbox.height)
+}
+
+describe("Shared layout: Fragment", () => {
+    it("Elements with layoutId inside a Fragment should animate from the correct starting position", () => {
+        cy.visit("?test=layout-shared-fragment")
+            .wait(50)
+            .get("#box")
+            .should(([$box]: any) => {
+                expectBbox($box, {
+                    top: 100,
+                    left: 0,
+                    width: 100,
+                    height: 100,
+                })
+            })
+            .trigger("click")
+            .wait(200)
+            .get("#box")
+            .should(([$box]: any) => {
+                // At ease: () => 0.5, the element should be halfway
+                // between top: 100 and top: 300, i.e. top: 200.
+                // If the bug is present, it will start from top: 0
+                // and be at top: 150 instead.
+                const bbox = $box.getBoundingClientRect()
+                expect(bbox.top).to.equal(200)
+            })
+    })
+})


### PR DESCRIPTION
## Summary
- Adds a Cypress E2E test verifying that elements with `layoutId` inside a React `Fragment` animate from the correct starting position
- Test confirms the element animates from its actual position (top: 100 → 300) rather than incorrectly starting from top: 0

## Test plan
- [x] Cypress test passes: `cypress/integration/layout-shared-fragment.ts`
- [x] Test component renders correctly at `?test=layout-shared-fragment`

Closes #1681

🤖 Generated with [Claude Code](https://claude.com/claude-code)