### PR TITLE
fix(types): Change hover event type from MouseEvent to PointerEvent

### DIFF
--- a/packages/motion-dom/src/node/types.ts
+++ b/packages/motion-dom/src/node/types.ts
@@ -424,7 +424,7 @@ export interface MotionNodeHoverHandlers {
      * <motion.div onHoverStart={() => console.log('Hover starts')} />
      * ```
      */
-    onHoverStart?(event: MouseEvent, info: EventInfo): void
+    onHoverStart?(event: PointerEvent, info: EventInfo): void
 
     /**
      * Callback function that fires when pointer stops hovering over the component.
@@ -433,7 +433,7 @@ export interface MotionNodeHoverHandlers {
      * <motion.div onHoverEnd={() => console.log("Hover ends")} />
      * ```
      */
-    onHoverEnd?(event: MouseEvent, info: EventInfo): void
+    onHoverEnd?(event: PointerEvent, info: EventInfo): void
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix `onHoverStart` and `onHoverEnd` callback event parameter type from `MouseEvent` to `PointerEvent`
- The hover gesture uses `pointerenter`/`pointerleave` DOM events, which produce `PointerEvent` objects at runtime, so the type definitions should match

Fixes #2286

## Test plan
- [x] Verify build passes with the type change
- [ ] Confirm `onHoverStart` and `onHoverEnd` callbacks receive `PointerEvent` at runtime
- [ ] Verify no downstream type errors in consumer code

🤖 Generated with [Claude Code](https://claude.com/claude-code)