### PR TITLE
Fix AnimatePresence keeping exiting children during rapid updates with dynamic variants

### DIFF
--- a/packages/motion-dom/src/render/utils/animation-state.ts
+++ b/packages/motion-dom/src/render/utils/animation-state.ts
@@ -198,6 +198,23 @@ export function createAnimationState(visualElement: any): AnimationState {
             }
 
             /**
+             * If exit is already active and wasn't just activated, skip
+             * re-processing to prevent interrupting running exit animations.
+             * Re-resolving exit with a changed custom value can start new
+             * value animations that stop the originals, leaving the exit
+             * animation promise unresolved and the component stuck in the DOM.
+             */
+            if (type === "exit" && typeState.isActive && activeDelta !== true) {
+                if (typeState.prevResolvedValues) {
+                    encounteredKeys = {
+                        ...encounteredKeys,
+                        ...typeState.prevResolvedValues,
+                    }
+                }
+                continue
+            }
+
+            /**
              * As we go look through the values defined on this type, if we detect
              * a changed value or a value that was removed in a higher priority, we set
              * this to true and add this prop to the animation list.


### PR DESCRIPTION
## Summary
- Fixes exiting children getting stuck in the DOM when rapidly switching `AnimatePresence` children with dynamic custom variants (where animated properties differ between items)
- Root cause: `animateChanges()` re-resolved exit variants on every re-render with the latest `custom` value, starting new value animations that interrupted the originals. Since `JSAnimation.stop()` doesn't resolve its `finished` promise, the exit completion chain hung forever.
- Fix: skip re-processing the exit animation type in `animateChanges()` when it's already active and wasn't just explicitly toggled, preserving the running exit animation's promise chain

Fixes #3541

## Test plan
- [x] Added test: exiting children are removed from DOM during rapid key switches with dynamic custom variants
- [x] Added test: `onExitComplete` fires reliably during rapid key switches with dynamic custom variants
- [x] All 42 AnimatePresence tests pass
- [x] All 25 animation-state tests pass
- [x] Full framer-motion test suite passes (739 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)