### PR TITLE
fix: replace banned TypeScript type {} with React.PropsWithChildren

### DIFF
--- a/dev/react/src/tests/layout-group-unmount-list.tsx
+++ b/dev/react/src/tests/layout-group-unmount-list.tsx
@@ -54,7 +54,7 @@ const stackStyle: React.CSSProperties = {
     backgroundColor: "blue",
 }
 
-const List: React.FunctionComponent<{}> = (props) => {
+const List: React.FunctionComponent<React.PropsWithChildren> = (props) => {
     return (
         <LayoutGroup id="list">
             <motion.div style={{ display: "contents" }}>


### PR DESCRIPTION
Fixes TypeScript lint error by replacing the banned type {} with React.PropsWithChildren.

## Summary

TypeScript's @typescript-eslint/ban-types rule flags {} as a banned type. This PR replaces it with the more specific React.PropsWithChildren<unknown> type.

## Changes

- Changed type from {} to React.PropsWithChildren<unknown>
- Maintains same functionality with better type safety

## Test Plan

- TypeScript compilation passes
- No runtime changes
- Lint errors resolved