### PR TITLE
docs: fix README contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A one-time payment, lifetime-updates membership:
 
 ## 💎 Contribute
 
--   Want to contribute to Motion? Our [contributing guide](https://github.com/motiondivision/motion/blob/master/CONTRIBUTING.md) has you covered.
+-   Want to contribute to Motion? Our [contributing guide](CONTRIBUTING.md) has you covered.
 
 ## ✨ Sponsors
 


### PR DESCRIPTION
The README contribution link still referenced the old motiondivision/motion repo and master branch.
This updates it to a relative CONTRIBUTING.md link so it stays correct regardless of default branch/org changes.