### PR TITLE
Ignore velocity for time-defined springs

### DIFF
--- a/dev/react/src/tests/layout-appear-spring-bounce.tsx
+++ b/dev/react/src/tests/layout-appear-spring-bounce.tsx
@@ -1,0 +1,109 @@
+import { animate, motion, useMotionValue } from "framer-motion"
+import { useEffect, useRef } from "react"
+
+/**
+ * Reproduces the bug where a time-defined spring receives velocity from
+ * an interrupted animation, causing wild oscillation.
+ *
+ * The Framer scenario:
+ * - Appear effect animates opacity 0.001 → 1 with time-defined spring
+ * - On hover, opacity → 0.49 with same spring
+ * - WAAPI appear animation sets velocity on motionValue when stopped
+ * - Hover animation reads velocity, passes it to findSpring()
+ * - findSpring() computes wrong spring parameters → wild oscillation
+ *
+ * This test uses external motionValues (no WAAPI owner → JS animation)
+ * with explicit velocity injection to simulate the WAAPI handoff.
+ */
+
+const springTransition = {
+    type: "spring" as const,
+    duration: 0.4,
+    bounce: 0.2,
+}
+
+export const App = () => <ExternalMotionValueMode />
+
+function ExternalMotionValueMode() {
+    // Start at 0.5 (simulating appear animation mid-flight)
+    const opacity = useMotionValue(0.5)
+    const scale = useMotionValue(1)
+    const trackerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        // Simulate WAAPI handoff: inject velocity as if appear animation
+        // was stopped mid-flight (NativeAnimationExtended.updateMotionValue
+        // calls setWithVelocity on the motionValue)
+        const sampleDelta = 10 // ms, same as NativeAnimationExtended
+        opacity.setWithVelocity(
+            0.45, // prev sample (velocity ~5/s upward)
+            0.5, // current
+            sampleDelta
+        )
+
+        // Start hover animation — reads velocity from motionValue
+        animate(opacity, 0.49, springTransition)
+        animate(scale, 1.1, springTransition)
+
+        // Track min/max values during hover animation
+        let minOpacity = 0.5
+        let maxOpacity = 0.5
+        let minScale = 1
+        let maxScale = 1
+
+        const unsubOpacity = opacity.on("change", (v) => {
+            if (v < minOpacity) minOpacity = v
+            if (v > maxOpacity) maxOpacity = v
+            if (trackerRef.current) {
+                trackerRef.current.dataset.minOpacity = minOpacity.toFixed(4)
+                trackerRef.current.dataset.maxOpacity = maxOpacity.toFixed(4)
+            }
+        })
+
+        const unsubScale = scale.on("change", (v) => {
+            if (v < minScale) minScale = v
+            if (v > maxScale) maxScale = v
+            if (trackerRef.current) {
+                trackerRef.current.dataset.minScale = minScale.toFixed(4)
+                trackerRef.current.dataset.maxScale = maxScale.toFixed(4)
+            }
+        })
+
+        return () => {
+            unsubOpacity()
+            unsubScale()
+        }
+    }, [])
+
+    return (
+        <>
+            <div id="tracker" ref={trackerRef} />
+            <motion.div
+                style={{
+                    position: "absolute",
+                    top: 50,
+                    left: 50,
+                    width: 231,
+                    height: 231,
+                    backgroundColor: "rgb(153, 238, 255)",
+                }}
+            >
+                <motion.div
+                    id="box"
+                    style={{
+                        width: 115,
+                        height: 106,
+                        backgroundColor: "rgb(68, 204, 255)",
+                        position: "absolute",
+                        top: "50%",
+                        left: "50%",
+                        x: "-50%",
+                        y: "-50%",
+                        opacity,
+                        scale,
+                    }}
+                />
+            </motion.div>
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/layout-appear-spring-bounce.ts
+++ b/packages/framer-motion/cypress/integration/layout-appear-spring-bounce.ts
@@ -1,0 +1,30 @@
+describe("Time-defined spring with inherited velocity", () => {
+    it("Doesn't wildly oscillate when velocity is inherited from interrupted animation", () => {
+        /**
+         * Reproduces the Framer bug:
+         * 1. Appear animation sets velocity on motionValue when stopped
+         * 2. Hover animation reads velocity and passes to time-defined spring
+         * 3. findSpring() computes wrong parameters → wild oscillation
+         *
+         * Opacity starts at 0.5 with +5/s velocity (simulating interrupted
+         * appear). Hover targets 0.49. Without fix, opacity shoots up to
+         * ~0.58+ before settling. With fix, it stays near 0.5.
+         */
+        cy.visit("?test=layout-appear-spring-bounce")
+            .wait(1500)
+            .get("#tracker")
+            .should(([$tracker]: any) => {
+                const maxOpacity = Number($tracker.dataset.maxOpacity)
+
+                // Opacity starts at 0.5, targets 0.49 (tiny delta of 0.01)
+                // A well-behaved spring should barely overshoot above 0.5
+                // Bug: velocity causes overshoot to ~0.58+
+                // Fixed: maxOpacity stays near 0.5
+                expect(maxOpacity).to.be.lessThan(
+                    0.55,
+                    `Opacity overshot to ${maxOpacity} (start: 0.5, target: 0.49). ` +
+                        `Time-defined spring should ignore inherited velocity.`
+                )
+            })
+    })
+})

--- a/packages/motion-dom/src/animation/generators/spring/index.ts
+++ b/packages/motion-dom/src/animation/generators/spring/index.ts
@@ -41,6 +41,12 @@ function getSpringOptions(options: SpringOptions) {
         !isSpringType(options, physicsKeys) &&
         isSpringType(options, durationKeys)
     ) {
+        // Time-defined springs should ignore inherited velocity.
+        // Velocity from interrupted animations can cause findSpring()
+        // to compute wildly different spring parameters, leading to
+        // massive oscillation on small-range animations.
+        springOptions.velocity = 0
+
         if (options.visualDuration) {
             const visualDuration = options.visualDuration
             const root = (2 * Math.PI) / (visualDuration * 1.2)
@@ -57,7 +63,7 @@ function getSpringOptions(options: SpringOptions) {
                 damping,
             }
         } else {
-            const derived = findSpring(options)
+            const derived = findSpring({ ...options, velocity: 0 })
 
             springOptions = {
                 ...springOptions,


### PR DESCRIPTION
## Summary
- Time-defined springs (duration/bounce) now ignore inherited velocity from interrupted animations
- Previously, velocity leaked into `findSpring()` which used it to compute stiffness/damping, fundamentally changing the spring's character and causing wild oscillation on small-range animations (e.g. opacity 0.5→0.49)
- Physics-defined springs (stiffness/damping/mass) are unaffected — velocity correctly acts as an initial condition on fixed parameters

## Test plan
- [x] Unit test: `Time-defined spring ignores velocity` — confirms velocity has no effect on time-defined spring output
- [x] Unit test: `Time-defined spring with velocity does not wildly oscillate` — confirms no overshoot with velocity=5000
- [x] E2E test: Simulates interrupted appear → hover with external motionValues and injected velocity; asserts opacity stays within bounds
- [x] All existing spring tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)