### PR TITLE
fix: fire onComplete when animate sequence finishes

### DIFF
--- a/packages/framer-motion/src/animation/animate/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/animate/__tests__/animate.test.tsx
@@ -491,6 +491,48 @@ describe("Sequence callbacks", () => {
         expect(doCount).toBe(2)
         expect(undoCount).toBe(1)
     })
+
+    test("onComplete fires when sequence finishes", async () => {
+        const element = document.createElement("div")
+        let completed = false
+
+        const animation = animate(
+            [
+                [element, { opacity: 0 }, { duration: 0.01 }],
+                [element, { opacity: 1 }, { duration: 0.01 }],
+            ],
+            {
+                onComplete: () => {
+                    completed = true
+                },
+            }
+        )
+
+        await animation.finished
+
+        expect(completed).toBe(true)
+    })
+
+    test("onComplete fires once when sequence finishes", async () => {
+        const element = document.createElement("div")
+        let completedCount = 0
+
+        const animation = animate(
+            [
+                [element, { opacity: 0 }, { duration: 0.01 }],
+                [element, { opacity: 1 }, { duration: 0.01 }],
+            ],
+            {
+                onComplete: () => {
+                    completedCount++
+                },
+            }
+        )
+
+        await animation.finished
+
+        expect(completedCount).toBe(1)
+    })
 })
 
 describe("animate: Objects", () => {

--- a/packages/framer-motion/src/animation/animate/index.ts
+++ b/packages/framer-motion/src/animation/animate/index.ts
@@ -110,11 +110,16 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
         let animationOnComplete: VoidFunction | undefined
 
         if (isSequence(subjectOrSequence)) {
+            const { onComplete, ...sequenceOptions } =
+                (optionsOrKeyframes as SequenceOptions) || {}
+            if (typeof onComplete === "function") {
+                animationOnComplete = onComplete as VoidFunction
+            }
             animations = animateSequence(
                 subjectOrSequence,
                 reduceMotion !== undefined
-                    ? { reduceMotion, ...(optionsOrKeyframes as SequenceOptions) }
-                    : (optionsOrKeyframes as SequenceOptions),
+                    ? { reduceMotion, ...sequenceOptions }
+                    : (sequenceOptions as SequenceOptions),
                 scope
             )
         } else {

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -87,6 +87,7 @@ export interface SequenceOptions extends AnimationPlaybackOptions {
     duration?: number
     defaultTransition?: Transition
     reduceMotion?: boolean
+    onComplete?: () => void
 }
 
 export interface AbsoluteKeyframe {


### PR DESCRIPTION
## Bug

When using `animate()` with a sequence (an array of animation segments), the `onComplete` callback passed in the options was silently ignored and never called.

## Root Cause

In `packages/framer-motion/src/animation/animate/index.ts`, the `onComplete` extraction and attachment to `animation.finished.then()` only happened in the non-sequence `else` branch. The sequence branch passed `optionsOrKeyframes` directly to `animateSequence()` without extracting `onComplete`, so it was never wired up.

Additionally, `SequenceOptions` didn't include `onComplete` in its type definition, so TypeScript would reject attempts to pass it.

## Fix

- Added `onComplete?: () => void` to `SequenceOptions` in `packages/framer-motion/src/animation/sequence/types.ts`
- In the sequence branch of `index.ts`, destructure `onComplete` from the options and assign it to `animationOnComplete` (the same variable used by the non-sequence path), so it gets attached to `animation.finished.then()` after the if/else

## Tests

Added two new tests to the "Sequence callbacks" describe block:
- `onComplete fires when sequence finishes` — verifies the callback is called
- `onComplete fires once when sequence finishes` — verifies it fires exactly once (not once per segment)

Fixes #3563