### PR TITLE
fix: commit final style before cancelling WAAPI animation to prevent Firefox opacity flash

### DIFF
--- a/packages/motion-dom/src/animation/NativeAnimation.ts
+++ b/packages/motion-dom/src/animation/NativeAnimation.ts
@@ -104,13 +104,16 @@ export class NativeAnimation<T extends AnyResolvedKeyframe>
                 )
                 if (this.updateMotionValue) {
                     this.updateMotionValue(keyframe)
-                } else {
-                    /**
-                     * If we can, we want to commit the final style as set by the user,
-                     * rather than the computed keyframe value supplied by the animation.
-                     */
-                    setStyle(element, name, keyframe)
                 }
+
+                /**
+                 * If we can, we want to commit the final style as set by the user,
+                 * rather than the computed keyframe value supplied by the animation.
+                 * We always do this, even when a motion value is present, to prevent
+                 * a visual flash in Firefox where the WAAPI animation's fill is removed
+                 * during cancel() before the scheduled render can apply the correct value.
+                 */
+                setStyle(element, name, keyframe)
 
                 this.animation.cancel()
             }

--- a/packages/motion-dom/src/animation/__tests__/NativeAnimation.test.ts
+++ b/packages/motion-dom/src/animation/__tests__/NativeAnimation.test.ts
@@ -1,0 +1,66 @@
+import { motionValue } from "../../value"
+import { NativeAnimationExtended } from "../NativeAnimationExtended"
+
+/**
+ * Tests for the Firefox opacity bug (issue #3552) where the WAAPI animation's
+ * onfinish handler needed to commit the final style to the element's inline
+ * styles before cancelling the animation. Without this, there was a timing
+ * window in Firefox where the WAAPI fill was removed (via cancel()) before
+ * the scheduled render could apply the correct value, causing a visual flash
+ * back to the initial value.
+ */
+describe("NativeAnimation - onfinish style commit", () => {
+    let mockAnimation: any
+
+    beforeEach(() => {
+        mockAnimation = {
+            cancel: jest.fn(),
+            onfinish: null,
+            playbackRate: 1,
+            currentTime: 300,
+            playState: "running",
+            effect: {
+                getComputedTiming: () => ({ duration: 300 }),
+                updateTiming: jest.fn(),
+            },
+        }
+
+        Element.prototype.animate = jest
+            .fn()
+            .mockImplementation(() => mockAnimation)
+    })
+
+    afterEach(() => {
+        ;(Element.prototype as any).animate = undefined
+        jest.restoreAllMocks()
+    })
+
+    test("sets element inline style to final value synchronously in onfinish when motionValue is present", () => {
+        const element = document.createElement("div")
+        const mv = motionValue(0)
+
+        new NativeAnimationExtended({
+            element,
+            name: "opacity",
+            keyframes: [0, 1],
+            motionValue: mv,
+            finalKeyframe: 1,
+            onComplete: jest.fn(),
+            duration: 300,
+            ease: "easeOut",
+        } as any)
+
+        // Simulate the WAAPI onfinish event firing (as Firefox does)
+        mockAnimation.onfinish?.()
+
+        /**
+         * The element's inline style opacity should be "1" synchronously
+         * after onfinish fires, BEFORE any scheduled render runs.
+         *
+         * This prevents a visual flash in Firefox where animation.cancel()
+         * removes the WAAPI fill before the scheduled render can apply
+         * the correct value back to the element.
+         */
+        expect(element.style.opacity).toBe("1")
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #3552 — In Firefox, opacity animations powered by WAAPI could intermittently revert to the `initial` value at the end of the animation.

**Root cause:** When a WAAPI animation finishes, `NativeAnimation.onfinish` calls:
1. `updateMotionValue(keyframe)` — updates the motion value and schedules a DOM render for the next frame
2. `animation.cancel()` — removes the WAAPI animation (and its `fill: "both"` effect), causing the element to revert to its base inline style (e.g. `opacity: 0` from `initial`)

In Firefox, `onfinish` can fire in a timing window where the current frame's render step has already run. When this happens, `scheduleRender()` will not queue a new render because `renderScheduledAt` equals the current frame timestamp. After `animation.cancel()` removes the fill, no render is scheduled to correct the element's style, leaving it stuck at the initial value.

**Fix:** Always call `setStyle(element, name, keyframe)` before `animation.cancel()`, even when a motion value is present. This commits the final user-specified value directly to the element's inline style so there's no visual flash when the WAAPI animation is cancelled. The subsequent render (if it runs) simply writes the same value again.

Note: the `else` branch (no motion value) already did this — the fix makes both branches consistent.

## Test plan

- [x] Added a unit test in `motion-dom` that verifies `element.style.opacity` is set to the final keyframe value synchronously in `onfinish` (before any async render), regardless of whether a motion value is present
- [x] All existing `motion-dom` and `framer-motion` unit tests pass
- [x] `yarn build` succeeds
- Manual verification in Firefox requires: animate `opacity` from 0 to 1, confirm it stays at 1 after completion and doesn't flash back to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)