### PR TITLE
Fix spring animation velocity loss on Chrome (vsync-aligned mousemove)

### DIFF
--- a/packages/motion-dom/src/animation/JSAnimation.ts
+++ b/packages/motion-dom/src/animation/JSAnimation.ts
@@ -493,6 +493,34 @@ export class JSAnimation<T extends number | string>
         return this.tick(sampleTime, true)
     }
 
+    /**
+     * Returns whether this animation can provide accurate velocity sampling.
+     * Used to get precise spring velocity before interrupting an animation.
+     */
+    get canSampleVelocity(): boolean {
+        return (
+            this.state === "running" &&
+            !this.isStopped &&
+            !this.mixKeyframes &&
+            !!this.generator
+        )
+    }
+
+    /**
+     * Sample the animation's value at a specific time in milliseconds,
+     * without advancing the animation's own state.
+     */
+    sampleAt(t: number): number {
+        return this.generator.next(t).value as number
+    }
+
+    /**
+     * The current elapsed time of the animation in milliseconds.
+     */
+    get elapsed(): number {
+        return this.currentTime
+    }
+
     attachTimeline(timeline: TimelineWithFallback): VoidFunction {
         if (this.options.allowFlatten) {
             this.options.type = "keyframes"

--- a/packages/motion-dom/src/animation/__tests__/JSAnimation.test.ts
+++ b/packages/motion-dom/src/animation/__tests__/JSAnimation.test.ts
@@ -1,6 +1,8 @@
 import { noop, reverseEasing } from "motion-utils"
 import { frame } from "../../frameloop"
 import { JSAnimation, animateValue } from "../JSAnimation"
+import { spring } from "../generators/spring"
+import { calcGeneratorVelocity } from "../generators/utils/velocity"
 import { AnyResolvedKeyframe, ValueAnimationOptions } from "../types"
 import { syncDriver } from "./utils"
 
@@ -1406,5 +1408,89 @@ describe("JSAnimation", () => {
                 type: "spring",
             }).duration
         ).toEqual(1.2)
+    })
+})
+
+describe("JSAnimation velocity sampling (for spring interruption fix)", () => {
+    test("canSampleVelocity is true for a running spring animation", () => {
+        const anim = new JSAnimation<number>({
+            keyframes: [0, 100],
+            type: spring,
+            stiffness: 100,
+            damping: 10,
+        })
+
+        expect(anim.canSampleVelocity).toBe(true)
+        anim.stop()
+    })
+
+    test("canSampleVelocity is false after stopping", () => {
+        const anim = new JSAnimation<number>({
+            keyframes: [0, 100],
+            type: spring,
+            stiffness: 100,
+            damping: 10,
+        })
+
+        anim.stop()
+        expect(anim.canSampleVelocity).toBe(false)
+    })
+
+    test("sampleAt returns origin at t=0", () => {
+        const anim = new JSAnimation<number>({
+            keyframes: [0, 100],
+            type: spring,
+            stiffness: 100,
+            damping: 10,
+        })
+
+        expect(anim.sampleAt(0)).toBe(0)
+        anim.stop()
+    })
+
+    test("sampleAt returns non-zero position at t > 0", () => {
+        const anim = new JSAnimation<number>({
+            keyframes: [0, 100],
+            type: spring,
+            stiffness: 100,
+            damping: 10,
+        })
+
+        const pos = anim.sampleAt(50)
+        expect(pos).toBeGreaterThan(0)
+        anim.stop()
+    })
+
+    test("elapsed is 0 for a new animation before ticking", () => {
+        const anim = new JSAnimation<number>({
+            keyframes: [0, 100],
+            type: spring,
+            stiffness: 100,
+            damping: 10,
+            autoplay: false,
+        })
+
+        expect(anim.elapsed).toBe(0)
+        anim.stop()
+    })
+
+    test("calcGeneratorVelocity with sampleAt returns non-zero spring velocity at t > 0", () => {
+        const anim = new JSAnimation<number>({
+            keyframes: [0, 100],
+            type: spring,
+            stiffness: 100,
+            damping: 10,
+        })
+
+        const t = 16
+        const velocity = calcGeneratorVelocity(
+            (ms) => anim.sampleAt(ms),
+            t,
+            anim.sampleAt(t)
+        )
+
+        // Spring generator velocity should be positive (moving toward target)
+        expect(velocity).toBeGreaterThan(0)
+        anim.stop()
     })
 })

--- a/packages/motion-dom/src/value/follow-value.ts
+++ b/packages/motion-dom/src/value/follow-value.ts
@@ -1,6 +1,7 @@
 import { MotionValue, motionValue } from "."
 import { JSAnimation } from "../animation/JSAnimation"
 import { AnyResolvedKeyframe, ValueAnimationTransition } from "../animation/types"
+import { calcGeneratorVelocity } from "../animation/generators/utils/velocity"
 import { frame } from "../frameloop"
 import { isMotionValue } from "./utils/is-motion-value"
 
@@ -77,19 +78,35 @@ export function attachFollow<T extends AnyResolvedKeyframe>(
     }
 
     const startAnimation = () => {
-        stopAnimation()
-
         const currentValue = asNumber(value.get())
         const targetValue = asNumber(latestValue)
 
         // Don't animate if we're already at the target
         if (currentValue === targetValue) {
+            stopAnimation()
             return
         }
 
+        // Get velocity from the running animation before stopping it.
+        // Reading directly from the spring generator (5ms window) is more
+        // accurate than the motion value's cross-frame finite difference,
+        // especially when the animation is interrupted after only one frame
+        // (which Chrome does consistently due to vsync-aligned mousemove).
+        let velocity = value.getVelocity()
+        if (activeAnimation?.canSampleVelocity) {
+            const elapsed = activeAnimation.elapsed
+            velocity = calcGeneratorVelocity(
+                (t) => activeAnimation!.sampleAt(t),
+                elapsed,
+                activeAnimation.sampleAt(elapsed)
+            )
+        }
+
+        stopAnimation()
+
         activeAnimation = new JSAnimation({
             keyframes: [currentValue, targetValue],
-            velocity: value.getVelocity(),
+            velocity,
             // Default to spring if no type specified (matches useSpring behavior)
             type: "spring",
             restDelta: 0.001,


### PR DESCRIPTION
## Bug

Spring animations using `followValue`/`springValue`/`useSpring` behave incorrectly in Chrome when following a pointer. The ball feels "stuck" and resists orbiting the cursor, while Firefox and Safari work correctly.

Fixes #3407

## Root Cause

Chrome fires `mousemove` events at vsync rate (aligned with `requestAnimationFrame`), which means a spring animation is consistently interrupted after exactly **1 frame** whenever the target changes.

In `attachFollow`'s `startAnimation()`, the old code called `stopAnimation()` before reading `value.getVelocity()`. After only 1 frame, `getVelocity()` computes a finite difference between the previous animation's last rendered position and the new animation's first keyframe — values from different animations, possibly with different targets. This cross-animation delta is often near zero or directionally wrong, causing the spring to restart with near-zero velocity every time.

## Fix

Read velocity from the active animation's spring generator **before** stopping it, using a 5ms finite difference against the generator's formula directly (`calcGeneratorVelocity` + `sampleAt`). This gives accurate instantaneous spring velocity even when the animation has only run for a single frame.

Three new members were added to `JSAnimation`:

- `canSampleVelocity` — guards that the animation is running and the generator is accessible
- `sampleAt(t)` — samples the generator's position at time `t` (milliseconds)
- `elapsed` — exposes `currentTime` for use as the sampling reference point

The `startAnimation()` function in `follow-value.ts` now uses these to read velocity before calling `stopAnimation()`.

## Tests

Added 6 unit tests in `JSAnimation.test.ts` under "JSAnimation velocity sampling (for spring interruption fix)" covering the new API members and the velocity calculation.