### PR TITLE
fix: fire onPlay when animate sequence starts

### DIFF
--- a/packages/framer-motion/src/animation/animate/__tests__/animate.test.tsx
+++ b/packages/framer-motion/src/animation/animate/__tests__/animate.test.tsx
@@ -492,6 +492,27 @@ describe("Sequence callbacks", () => {
         expect(undoCount).toBe(1)
     })
 
+    test("onPlay fires when sequence starts", async () => {
+        const element = document.createElement("div")
+        let played = false
+
+        const animation = animate(
+            [
+                [element, { opacity: 0 }, { duration: 0.01 }],
+                [element, { opacity: 1 }, { duration: 0.01 }],
+            ],
+            {
+                onPlay: () => {
+                    played = true
+                },
+            }
+        )
+
+        await animation.finished
+
+        expect(played).toBe(true)
+    })
+
     test("onComplete fires when sequence finishes", async () => {
         const element = document.createElement("div")
         let completed = false

--- a/packages/framer-motion/src/animation/animate/index.ts
+++ b/packages/framer-motion/src/animation/animate/index.ts
@@ -108,12 +108,16 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
     ): AnimationPlaybackControlsWithThen {
         let animations: AnimationPlaybackControlsWithThen[] = []
         let animationOnComplete: VoidFunction | undefined
+        let animationOnPlay: VoidFunction | undefined
 
         if (isSequence(subjectOrSequence)) {
-            const { onComplete, ...sequenceOptions } =
+            const { onComplete, onPlay, ...sequenceOptions } =
                 (optionsOrKeyframes as SequenceOptions) || {}
             if (typeof onComplete === "function") {
                 animationOnComplete = onComplete as VoidFunction
+            }
+            if (typeof onPlay === "function") {
+                animationOnPlay = onPlay as VoidFunction
             }
             animations = animateSequence(
                 subjectOrSequence,
@@ -139,6 +143,8 @@ export function createScopedAnimate(options: ScopedAnimateOptions = {}) {
         }
 
         const animation = new GroupAnimationWithThen(animations)
+
+        animationOnPlay?.()
 
         if (animationOnComplete) {
             animation.finished.then(animationOnComplete)

--- a/packages/framer-motion/src/animation/sequence/types.ts
+++ b/packages/framer-motion/src/animation/sequence/types.ts
@@ -87,6 +87,7 @@ export interface SequenceOptions extends AnimationPlaybackOptions {
     duration?: number
     defaultTransition?: Transition
     reduceMotion?: boolean
+    onPlay?: () => void
     onComplete?: () => void
 }
 


### PR DESCRIPTION
## Summary

- **Bug**: `onPlay` callback passed to `animate(sequence, { onPlay })` was silently ignored because it wasn't extracted from sequence options or wired up to the group animation
- **Cause**: The sequence code path in `createScopedAnimate` only extracted `onComplete` from options (added in #3571), but not `onPlay`. The `onPlay` property also wasn't declared on the `SequenceOptions` type.
- **Fix**: Extract `onPlay` from sequence options alongside `onComplete`, add it to the `SequenceOptions` type, and call it immediately after creating the group animation (since animations auto-play on creation)

Fixes #3579

## Test plan

- [x] Added unit test `"onPlay fires when sequence starts"` that verifies the callback fires
- [x] All existing tests pass (756 tests, 89 suites)
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)