### PR TITLE
fix: handle percentage x/y values in layout animation projection

### DIFF
--- a/dev/react/src/tests/layout-percent-x-flex.tsx
+++ b/dev/react/src/tests/layout-percent-x-flex.tsx
@@ -1,10 +1,29 @@
 import { useState } from "react"
 import { motion } from "framer-motion"
 
-export const App = () => {
-    const [items, setItems] = useState<number[]>([])
+/**
+ * Regression test for https://github.com/motiondivision/motion/issues/3401
+ *
+ * Matches the reporter's sandbox pattern: only the most-recently-added item
+ * has initial/animate props. When the next item is added, shouldAnimate flips
+ * false for the previous item — its x animation stops and latestValues.x
+ * stays at "100%" indefinitely. The layout update then fires with an
+ * unresolved percentage, triggering the teleport bug.
+ */
 
-    const addItem = () => setItems((prev) => [...prev, prev.length])
+interface Item {
+    id: number
+    isAdded: boolean
+}
+
+export const App = () => {
+    const [items, setItems] = useState<Item[]>([
+        { id: 0, isAdded: false },
+        { id: 1, isAdded: false },
+    ])
+
+    const addItem = () =>
+        setItems((prev) => [...prev, { id: prev.length, isAdded: true }])
 
     return (
         <div
@@ -19,25 +38,29 @@ export const App = () => {
                 Add
             </button>
             <div style={{ display: "flex", gap: 10, marginTop: 20 }}>
-                {items.map((id) => (
-                    <motion.div
-                        key={id}
-                        layout
-                        id={`item-${id}`}
-                        initial={{ x: "100%" }}
-                        animate={{ x: 0 }}
-                        transition={{
-                            duration: 0.1,
-                            layout: { duration: 10 },
-                        }}
-                        style={{
-                            width: 100,
-                            height: 100,
-                            background: "red",
-                            flexShrink: 0,
-                        }}
-                    />
-                ))}
+                {items.map((item, i) => {
+                    const shouldAnimate =
+                        i === items.length - 1 && item.isAdded
+
+                    return (
+                        <motion.div
+                            key={item.id}
+                            layout
+                            id={`item-${item.id}`}
+                            initial={
+                                shouldAnimate ? { x: "100%" } : undefined
+                            }
+                            animate={shouldAnimate ? { x: 0 } : undefined}
+                            transition={{ duration: 10 }}
+                            style={{
+                                width: 100,
+                                height: 100,
+                                background: "red",
+                                flexShrink: 0,
+                            }}
+                        />
+                    )
+                })}
             </div>
         </div>
     )

--- a/packages/framer-motion/cypress/integration/layout-percent-x-flex.ts
+++ b/packages/framer-motion/cypress/integration/layout-percent-x-flex.ts
@@ -2,36 +2,39 @@
  * Regression test for:
  * https://github.com/motiondivision/motion/issues/3401
  *
- * Bug: Layout animation breaks when an element has x: "100%" (percentage) and
- * a sibling is added before the entrance animation's keyframes are resolved.
+ * Bug: layout animation breaks when x: "100%" (percentage) is in latestValues
+ * at the moment the layout update fires.
  *
- * The projection system calls transformBox(targetWithTransforms, latestValues)
- * which previously couldn't handle percentage strings, producing NaN and causing
- * the element to teleport to its natural DOM position instead of layout-animating.
+ * The test page replicates the sandbox pattern:
+ *   - Only the most-recently-added item has initial/animate props (shouldAnimate)
+ *   - When a new item is added, shouldAnimate flips false for the previous item
+ *     → its x animation stops and latestValues.x stays at "100%"
+ *   - The subsequent layout update fires with latestValues.x = "100%"
+ *   - Before the fix, transformBox produced NaN → projection identity →
+ *     element teleported to its natural DOM position (no correction transform)
  */
 describe("Layout animation: percentage x in flex container", () => {
     it("Correctly layout-animates when sibling added before keyframes resolve", () => {
         cy.visit("?test=layout-percent-x-flex")
             .get("#add")
-            // Click twice rapidly — second click fires before the entrance
-            // animation's keyframes (x: "100%") are resolved to pixels by
-            // DOMKeyframesResolver. This triggers the layout update while
-            // latestValues.x is still the string "100%".
+            // First click: item-2 is added with initial={{ x: "100%" }},
+            // animate={{ x: 0 }}, latestValues.x = "100%"
             .click()
+            // Second click: item-3 is added, shouldAnimate flips false for
+            // item-2 → its animate prop is removed → x animation stops →
+            // latestValues.x stays at "100%". Layout update fires immediately.
             .click()
-            // Wait long enough for the x entrance animation (0.1s) to finish,
-            // but short enough that the layout animation (10s) is still running.
             .wait(300)
-            .get("#item-0")
+            .get("#item-2")
             .should(([$item]: any) => {
-                // If the layout animation is running, framer-motion applies a
-                // non-identity CSS transform to item-0 to animate it from its
-                // old position toward its new position.
+                // If the layout animation is running correctly, framer-motion
+                // applies a non-identity CSS transform to item-2 (the layout
+                // correction that accounts for x: "100%" in latestValues).
                 //
-                // If the bug occurred (teleport), the layout animation was never
-                // started, so after the entrance animation finishes (x=0) the
-                // transform would be "none" — the item snapped instantly to its
-                // natural DOM position.
+                // If the bug occurred, transformBox produced NaN → projection
+                // delta was forced to identity → no correction transform →
+                // item-2 snapped to its natural DOM position immediately.
+                // After snapping, with no animate prop, the transform stays "none".
                 const transform = $item.style.transform
                 expect(transform).to.not.equal("none")
                 expect(transform).to.not.equal("")


### PR DESCRIPTION
## Bug

When an element has `initial={{ x: "100%" }}` (or any percentage) and `layout` is enabled, adding a sibling causes the element to instantly teleport to its new position rather than animating smoothly.

Fixes #3401

## Root Cause

The entrance animation (`x: "100%" → 0`) uses `DOMKeyframesResolver`, which detects the unit mismatch and schedules an async DOM measurement to convert `"100%"` to pixels. During this window, `latestValues.x = "100%"`.

If a layout update fires before resolution (e.g. a sibling is added), `applyTransformsToTarget()` calls:

```js
transformBox(targetWithTransforms, latestValues) // latestValues.x = "100%"
```

`transformAxis` received the string where a number was expected. String arithmetic produces `NaN`, which `calcAxisDelta`'s NaN guards collapse to identity (`translate=0, scale=1`). The projection transform becomes a no-op and the element snaps to its natural layout position — a teleport.

## Fix

`resolveAxisTranslate` converts percentage strings to pixel values (`"N%"` → `N/100 * axisSize`) before they reach `transformAxis`. This mirrors the identical handling already present in `removeAxisDelta`.

`transformAxis` itself stays monomorphic (always receives numbers), which matters because it's in the hot per-frame render path — calling it with mixed string/number types would prevent V8 from JIT-specialising it.

## Tests

- **Unit tests** (`delta-apply.test.ts`): verify `transformBox` correctly resolves `x: "100%"`, `y: "50%"`, and `x: "0%"` to the right pixel translations.
- **Cypress E2E** (`layout-percent-x-flex`): replicates the sandbox's `shouldAnimate` pattern — the most-recently-added item has `initial={{ x: "100%" }}`; when the next item is added `shouldAnimate` flips false, removing `animate` so `latestValues.x` stays at `"100%"` indefinitely. Verified: fails on unfixed code (`transform = "none"`), passes with fix (`transform = translate3d(145px, 0, 0)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)