### PR TITLE
Fix spring + delay producing NaN for string keyframes

### DIFF
--- a/packages/motion-dom/src/animation/JSAnimation.ts
+++ b/packages/motion-dom/src/animation/JSAnimation.ts
@@ -300,7 +300,7 @@ export class JSAnimation<T extends number | string>
             ? { done: false, value: keyframes[0] }
             : frameGenerator.next(elapsed)
 
-        if (mixKeyframes) {
+        if (mixKeyframes && !isInDelayPhase) {
             state.value = mixKeyframes(state.value as number)
         }
 

--- a/packages/motion-dom/src/animation/__tests__/JSAnimation.test.ts
+++ b/packages/motion-dom/src/animation/__tests__/JSAnimation.test.ts
@@ -1407,4 +1407,19 @@ describe("JSAnimation", () => {
             }).duration
         ).toEqual(1.2)
     })
+
+    // https://github.com/motiondivision/motion/issues/3351
+    test("Spring with delay and string keyframes returns initial value during delay", () => {
+        const animation = animateValue({
+            keyframes: ["90%", "60%"],
+            type: "spring",
+            delay: 2000,
+            autoplay: false,
+        })
+
+        // During the delay phase, should return the initial keyframe "90%"
+        expect(animation.sample(0).value).toBe("90%")
+        expect(animation.sample(1000).value).toBe("90%")
+        expect(animation.sample(1999).value).toBe("90%")
+    })
 })


### PR DESCRIPTION
## Summary

- **Bug:** When using `type: 'spring'` with `delay` on elements with string keyframes (e.g., SVG attributes like `width: "90%"`), the initial state was not respected during the delay period. The element would render with `NaN%` values, causing it to fill the entire viewport instead of showing the initial state.
- **Cause:** In `JSAnimation.tick()`, during the delay phase, `keyframes[0]` is the original string value (e.g., `"90%"`). For spring animations with non-numeric keyframes, a `mixKeyframes` function maps numbers in [0, 100] to interpolated string values. During delay, the original string was incorrectly passed through `mixKeyframes`, which divided it by 100, producing `NaN`.
- **Fix:** Skip the `mixKeyframes` transformation during the delay phase, since `keyframes[0]` already contains the correct original string value.

Fixes #3351

## Test plan

- [x] Added unit test: spring animation with string keyframes and delay returns correct initial value during delay phase
- [x] `yarn build` passes
- [x] `yarn test` passes (all 760 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)