### PR TITLE
Add settled prop for declarative animation suppression

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/animate-prop.test.tsx
@@ -1372,3 +1372,118 @@ describe("animate prop as object", () => {
         expect(scale.get()).toBe(0)
     })
 })
+
+describe("settled prop", () => {
+    test("applies values instantly when settled is false", async () => {
+        const promise = new Promise<number>((resolve) => {
+            const x = motionValue(0)
+            const Component = ({ target }: { target: number }) => (
+                <motion.div
+                    animate={{ x: target }}
+                    transition={{ duration: 1 }}
+                    settled={false}
+                    style={{ x }}
+                />
+            )
+            const { rerender } = render(<Component target={100} />)
+            rerender(<Component target={100} />)
+
+            // Value should be at target instantly despite duration: 1
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+        return expect(promise).resolves.toBe(100)
+    })
+
+    test("applies rapid changes instantly when settled is false", async () => {
+        const promise = new Promise<number>((resolve) => {
+            const x = motionValue(0)
+            const Component = ({ target }: { target: number }) => (
+                <motion.div
+                    animate={{ x: target }}
+                    transition={{ duration: 1 }}
+                    settled={false}
+                    style={{ x }}
+                />
+            )
+            const { rerender } = render(<Component target={50} />)
+            rerender(<Component target={100} />)
+            rerender(<Component target={0} />)
+            rerender(<Component target={200} />)
+
+            // After rapid changes, should be at final value instantly
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+        return expect(promise).resolves.toBe(200)
+    })
+
+    test("animates normally after settled becomes true", async () => {
+        const promise = new Promise<number>((resolve) => {
+            const x = motionValue(0)
+            const Component = ({
+                target,
+                settled,
+            }: {
+                target: number
+                settled: boolean
+            }) => (
+                <motion.div
+                    animate={{ x: target }}
+                    transition={{ type: "tween", ease: () => 0.5 }}
+                    settled={settled}
+                    style={{ x }}
+                />
+            )
+
+            // Start unsettled at 0
+            const { rerender } = render(
+                <Component target={0} settled={false} />
+            )
+            rerender(<Component target={0} settled={false} />)
+
+            // Become settled (no target change)
+            rerender(<Component target={0} settled={true} />)
+
+            // Now change target while settled - should animate via tween
+            rerender(<Component target={100} settled={true} />)
+
+            // With ease: () => 0.5 the value should settle at 50
+            // (midway), not 100 (instant). If settled leaked, it'd be 100.
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+        return expect(promise).resolves.toBe(50)
+    })
+
+    test("settled false-to-true transition applies instantly", async () => {
+        const promise = new Promise<number>((resolve) => {
+            const x = motionValue(0)
+            const Component = ({
+                target,
+                settled,
+            }: {
+                target: number
+                settled: boolean
+            }) => (
+                <motion.div
+                    animate={{ x: target }}
+                    transition={{ duration: 1 }}
+                    settled={settled}
+                    style={{ x }}
+                />
+            )
+
+            // Start unsettled at 0
+            const { rerender } = render(
+                <Component target={0} settled={false} />
+            )
+            rerender(<Component target={0} settled={false} />)
+
+            // Change both settled and target simultaneously
+            // This simulates the settling moment where the final value is applied
+            rerender(<Component target={100} settled={true} />)
+
+            // Value should be at target instantly (no catch-up animation)
+            requestAnimationFrame(() => resolve(x.get()))
+        })
+        return expect(promise).resolves.toBe(100)
+    })
+})

--- a/packages/motion-dom/src/node/types.ts
+++ b/packages/motion-dom/src/node/types.ts
@@ -253,6 +253,25 @@ export interface MotionNodeAnimationOptions {
      * ```
      */
     transition?: Transition
+
+    /**
+     * When `false`, all animations are applied instantly with no interpolation
+     * (equivalent to CSS `transition: none`). When set to `true` or left
+     * `undefined`, animations use the configured `transition`.
+     *
+     * This is useful for suppressing animations during measurement
+     * initialization, where async observers (e.g. `IntersectionObserver`)
+     * may fire several corrections before settling on a stable value.
+     *
+     * ```jsx
+     * <motion.div
+     *   animate={{ opacity: isVisible ? 1 : 0 }}
+     *   transition={{ duration: 0.3 }}
+     *   settled={isSettled}
+     * />
+     * ```
+     */
+    settled?: boolean
 }
 
 export interface MotionNodeEventOptions {

--- a/packages/motion-dom/src/render/utils/animation-state.ts
+++ b/packages/motion-dom/src/render/utils/animation-state.ts
@@ -119,6 +119,15 @@ export function createAnimationState(visualElement: any): AnimationState {
         const context = getVariantContext(visualElement.parent) || {}
 
         /**
+         * When settled is false, or just transitioned from false,
+         * force all animations to apply instantly (no interpolation).
+         */
+        const isUnsettled =
+            props.settled === false ||
+            (props.settled !== false &&
+                visualElement.prevProps?.settled === false)
+
+        /**
          * A list of animations that we'll build into as we iterate through the animation
          * types. This will get executed at the end of the function.
          */
@@ -384,6 +393,10 @@ export function createAnimationState(visualElement: any): AnimationState {
                                     delayChildren
                                 )
                             }
+                        }
+
+                        if (isUnsettled) {
+                            options.transitionOverride = { type: false }
                         }
 
                         return {


### PR DESCRIPTION
## Summary

- Adds a `settled` boolean prop to motion components that suppresses animation interpolation when `false`
- When `settled={false}`, all animations apply instantly (`type: false`), equivalent to CSS `transition: none`
- When `settled` transitions from `false` to `true`, the current `animate` value applies instantly (no catch-up animation), and only subsequent changes respect the configured `transition`

## Problem

When async measurement systems (e.g. `IntersectionObserver`, `ResizeObserver`) fire multiple corrections during initialization, each state change triggers a new animation in motion components. There was no declarative way to suppress interpolation during this unstable period. The existing APIs (`initial={false}`, `transition: { duration: 0 }`, `transition.delay`) each fail to fully address the measurement flutter problem as detailed in #3560.

## Implementation

The fix is minimal — two changes in `motion-dom`:

1. **Type definition** (`node/types.ts`): Added `settled?: boolean` to `MotionNodeAnimationOptions`
2. **Animation behavior** (`render/utils/animation-state.ts`): In `animateChanges()`, when the component is unsettled (`settled === false` or `settled` just flipped from `false` to `true`), all animations receive `transitionOverride: { type: false }` which applies values instantly with no interpolation

## Usage

```tsx
<motion.div
  animate={{ opacity: isVisible ? 1 : 0 }}
  transition={{ duration: 0.3 }}
  settled={isSettled}
/>
```

## Test plan

- [x] Unit test: values applied instantly when `settled={false}`
- [x] Unit test: rapid changes applied instantly when `settled={false}`
- [x] Unit test: normal animation resumes after `settled` becomes `true`
- [x] Unit test: `settled` false→true transition applies instantly (no catch-up)
- [x] All existing animate-prop tests pass (no regressions)
- [x] Full test suite passes

Fixes #3560

🤖 Generated with [Claude Code](https://claude.com/claude-code)