### PR TITLE
Fix scroll-driven opacity broken in Safari & Firefox

### DIFF
--- a/dev/react/src/tests/scroll-opacity-native.tsx
+++ b/dev/react/src/tests/scroll-opacity-native.tsx
@@ -1,0 +1,30 @@
+import { motion, useScroll, useTransform } from "framer-motion"
+import * as React from "react"
+
+export const App = () => {
+    const { scrollYProgress } = useScroll()
+    const opacity = useTransform(scrollYProgress, [0, 1], [0, 1])
+    const scale = useTransform(scrollYProgress, [0, 1], [0.5, 1])
+
+    return (
+        <>
+            <div style={spacer} />
+            <div style={spacer} />
+            <div style={spacer} />
+            <motion.div
+                id="target"
+                style={{ ...box, opacity, scale }}
+            />
+        </>
+    )
+}
+
+const spacer = { height: "100vh" }
+const box: React.CSSProperties = {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    width: 100,
+    height: 100,
+    background: "red",
+}

--- a/packages/framer-motion/cypress/integration/scroll-opacity-native.ts
+++ b/packages/framer-motion/cypress/integration/scroll-opacity-native.ts
@@ -1,0 +1,52 @@
+describe("scroll-driven opacity animation", () => {
+    it("Opacity animates from 0 to 1 when scrolling with native timeline", () => {
+        cy.visit("?test=scroll-opacity-native")
+            .wait(200)
+            .get("#target")
+            .should(([$el]: any) => {
+                // At scroll top, opacity should be near 0
+                const opacity = parseFloat(getComputedStyle($el).opacity)
+                expect(opacity).to.be.lessThan(0.15)
+            })
+        cy.scrollTo("bottom", { duration: 100 })
+            .wait(200)
+            .get("#target")
+            .should(([$el]: any) => {
+                // At scroll bottom, opacity should be near 1
+                const opacity = parseFloat(getComputedStyle($el).opacity)
+                expect(opacity).to.be.greaterThan(0.9)
+            })
+    })
+
+    it("Scale animates correctly alongside opacity", () => {
+        cy.visit("?test=scroll-opacity-native")
+            .wait(200)
+            .get("#target")
+            .should(([$el]: any) => {
+                const transform = getComputedStyle($el).transform
+                // At scroll top, scale should be ~0.5
+                // matrix(0.5, 0, 0, 0.5, 0, 0)
+                if (transform && transform !== "none") {
+                    const match = transform.match(/matrix\(([^,]+)/)
+                    if (match) {
+                        const scaleValue = parseFloat(match[1])
+                        expect(scaleValue).to.be.lessThan(0.65)
+                    }
+                }
+            })
+        cy.scrollTo("bottom", { duration: 100 })
+            .wait(200)
+            .get("#target")
+            .should(([$el]: any) => {
+                const transform = getComputedStyle($el).transform
+                // At scroll bottom, scale should be ~1
+                if (transform && transform !== "none") {
+                    const match = transform.match(/matrix\(([^,]+)/)
+                    if (match) {
+                        const scaleValue = parseFloat(match[1])
+                        expect(scaleValue).to.be.greaterThan(0.9)
+                    }
+                }
+            })
+    })
+})

--- a/packages/motion-dom/src/utils/supports/scroll-timeline.ts
+++ b/packages/motion-dom/src/utils/supports/scroll-timeline.ts
@@ -24,12 +24,47 @@ declare class ViewTimeline implements ProgressTimeline {
     cancel?: VoidFunction
 }
 
-export const supportsScrollTimeline = /* @__PURE__ */ memoSupports(
-    () => window.ScrollTimeline !== undefined,
-    "scrollTimeline"
-)
+export const supportsScrollTimeline = /* @__PURE__ */ memoSupports(() => {
+    if (window.ScrollTimeline === undefined) return false
+
+    // Safari and Firefox expose ScrollTimeline but have bugs
+    // with non-transform properties (e.g. opacity). Verify
+    // the implementation works by running a small runtime test.
+    try {
+        const container = document.createElement("div")
+        container.style.cssText =
+            "position:fixed;top:-99999px;width:10px;height:10px;overflow:scroll"
+        const child = document.createElement("div")
+        child.style.height = "100px"
+        container.appendChild(child)
+        document.body.appendChild(container)
+
+        // Force layout so scroll metrics are available
+        container.offsetHeight
+
+        const anim = container.animate(
+            { opacity: [0, 1] },
+            { duration: 1, fill: "both" }
+        )
+        anim.timeline = new ScrollTimeline({
+            source: container,
+        } as any) as any
+
+        container.scrollTop = container.scrollHeight
+        const opacity = parseFloat(getComputedStyle(container).opacity)
+
+        anim.cancel()
+        container.remove()
+
+        return opacity > 0.9
+    } catch (e) {
+        return false
+    }
+}, "scrollTimeline")
 
 export const supportsViewTimeline = /* @__PURE__ */ memoSupports(
-    () => window.ViewTimeline !== undefined,
+    // ViewTimeline uses the same scroll-driven animation engine.
+    // If ScrollTimeline can't correctly drive opacity, neither can ViewTimeline.
+    () => window.ViewTimeline !== undefined && supportsScrollTimeline(),
     "viewTimeline"
 )


### PR DESCRIPTION
## Summary

- Replace simple `window.ScrollTimeline !== undefined` existence check with a runtime test that verifies scroll-driven opacity actually works
- Gate `supportsViewTimeline()` on the same check since ViewTimeline shares the same rendering engine
- Add Cypress E2E test for scroll-driven opacity animation

## Problem

Safari and Firefox expose `window.ScrollTimeline` but their implementations have bugs with non-transform properties like `opacity`:
- **Safari**: opacity stays at an intermediate value even after scrolling past the animation endpoint
- **Firefox**: opacity jumps to full immediately with no gradual transition

`scale` and `rotate` transforms work correctly in both browsers. The issue is specifically with non-transform CSS properties driven by scroll timelines via WAAPI.

## Fix

The `supportsScrollTimeline()` check now creates a tiny off-screen scrollable element, attaches a scroll-driven opacity animation, scrolls to the end, and verifies the computed opacity is correct (~1.0). This runs once (memoized) and automatically adapts as browsers fix their implementations.

In browsers where the test fails (Safari, Firefox currently), the library falls back to the JS-based scroll tracking path which correctly drives all CSS properties.

Fixes #3559

🤖 Generated with [Claude Code](https://claude.com/claude-code)