### PR TITLE
feat: support native CSS easing strings

### DIFF
--- a/packages/motion-dom/src/animation/waapi/easing/__tests__/map-easing.test.ts
+++ b/packages/motion-dom/src/animation/waapi/easing/__tests__/map-easing.test.ts
@@ -20,6 +20,26 @@ describe("mapEasingToNativeEasing", () => {
         )
     })
 
+    test("should pass through native easing directly", () => {
+        expect(
+            mapEasingToNativeEasing({ native: "steps(6, end)" }, 1000)
+        ).toBe("steps(6, end)")
+    })
+
+    test("should pass through native easing in array", () => {
+        const easings: Easing[] = [
+            "linear",
+            { native: "steps(6, end)" },
+            "easeOut",
+        ]
+        const result = mapEasingToNativeEasing(easings, 1000) as string[]
+
+        expect(Array.isArray(result)).toBe(true)
+        expect(result[0]).toBe("linear")
+        expect(result[1]).toBe("steps(6, end)")
+        expect(result[2]).toBe("ease-out")
+    })
+
     test("should map array of easings to array of strings", () => {
         // Only test with known easings that don't require mocking
         const easings: Easing[] = ["linear", "easeIn", "easeOut"]

--- a/packages/motion-dom/src/animation/waapi/easing/map-easing.ts
+++ b/packages/motion-dom/src/animation/waapi/easing/map-easing.ts
@@ -1,4 +1,5 @@
 import { Easing, isBezierDefinition } from "motion-utils"
+import { isNativeEasing } from "../../../utils/is-native-easing"
 import { supportsLinearEasing } from "../../../utils/supports/linear-easing"
 import { generateLinearEasing } from "../utils/linear"
 import { cubicBezierAsString } from "./cubic-bezier"
@@ -10,6 +11,8 @@ export function mapEasingToNativeEasing(
 ): undefined | string | string[] {
     if (!easing) {
         return undefined
+    } else if (isNativeEasing(easing)) {
+        return easing.native
     } else if (typeof easing === "function") {
         return supportsLinearEasing()
             ? generateLinearEasing(easing, duration)

--- a/packages/motion-dom/src/utils/is-native-easing.ts
+++ b/packages/motion-dom/src/utils/is-native-easing.ts
@@ -1,0 +1,1 @@
+export { isNativeEasing } from "motion-utils"

--- a/packages/motion-utils/src/easing/types.ts
+++ b/packages/motion-utils/src/easing/types.ts
@@ -18,13 +18,19 @@ export type EasingDefinition =
     | "backInOut"
     | "anticipate"
 
+export interface NativeEasing {
+    native: string
+}
+
 /**
  * The easing function to use. Set as one of:
  *
  * - The name of an in-built easing function.
  * - An array of four numbers to define a cubic bezier curve.
  * - An easing function, that accepts and returns a progress value between `0` and `1`.
+ * - A `{ native: string }` object to pass a CSS easing string directly to the browser.
+ *   This will only work with WAAPI-powered animations.
  *
  * @public
  */
-export type Easing = EasingDefinition | EasingFunction
+export type Easing = EasingDefinition | EasingFunction | NativeEasing

--- a/packages/motion-utils/src/easing/utils/map.ts
+++ b/packages/motion-utils/src/easing/utils/map.ts
@@ -5,8 +5,15 @@ import { backIn, backInOut, backOut } from "../back"
 import { circIn, circInOut, circOut } from "../circ"
 import { cubicBezier } from "../cubic-bezier"
 import { easeIn, easeInOut, easeOut } from "../ease"
-import { Easing, EasingFunction } from "../types"
+import { Easing, EasingFunction, NativeEasing } from "../types"
 import { isBezierDefinition } from "./is-bezier-definition"
+
+export const isNativeEasing = (
+    easing: Easing | Easing[]
+): easing is NativeEasing =>
+    typeof easing === "object" &&
+    !Array.isArray(easing) &&
+    "native" in easing
 
 const easingLookup = {
     linear: noop,
@@ -29,7 +36,9 @@ const isValidEasing = (easing: Easing): easing is keyof typeof easingLookup => {
 export const easingDefinitionToFunction = (
     definition: Easing
 ): EasingFunction => {
-    if (isBezierDefinition(definition)) {
+    if (isNativeEasing(definition)) {
+        return noop
+    } else if (isBezierDefinition(definition)) {
         // If cubic bezier definition, create bezier curve
         invariant(
             definition.length === 4,


### PR DESCRIPTION
## Summary

- Adds support for passing native CSS timing functions directly to WAAPI animations via `ease: { native: string }`
- This allows using CSS easing functions like `steps(6, end)`, `linear(...)`, or any valid CSS `<easing-function>` that the browser supports natively
- When used in the JS animation fallback path, native easing gracefully falls back to linear

### Usage

```js
import { animate } from "motion/mini"

animate(
  ".box",
  { transform: "translateX(100px)" },
  { duration: 1, ease: { native: "steps(6, end)" } }
)
```

## Changes

- **`motion-utils`**: Added `NativeEasing` interface and `isNativeEasing` type guard; updated `Easing` type union; added fallback handling in `easingDefinitionToFunction`
- **`motion-dom`**: Updated `mapEasingToNativeEasing` to pass through native easing strings directly to WAAPI

## Test plan

- [x] Added unit tests for `mapEasingToNativeEasing` with native easing (direct and in arrays)
- [x] All motion-dom tests pass
- [x] Full build succeeds

Fixes #3246

🤖 Generated with [Claude Code](https://claude.com/claude-code)