### PR TITLE
Add AnimateNumber component with LazyMotion support

### DIFF
--- a/packages/framer-motion/src/components/AnimateNumber/__tests__/AnimateNumber.test.tsx
+++ b/packages/framer-motion/src/components/AnimateNumber/__tests__/AnimateNumber.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react"
+import { AnimateNumber } from ".."
+import { LazyMotion } from "../../LazyMotion"
+import { domAnimation } from "../../../render/dom/features-animation"
+
+describe("AnimateNumber", () => {
+    it("renders the initial value", () => {
+        const { container } = render(<AnimateNumber>{100}</AnimateNumber>)
+        expect(container.textContent).toBe("100")
+    })
+
+    it("renders with formatting", () => {
+        const { container } = render(
+            <AnimateNumber
+                format={{ style: "currency", currency: "USD" }}
+                locales="en-US"
+            >
+                {1234.56}
+            </AnimateNumber>
+        )
+        expect(container.textContent).toBe("$1,234.56")
+    })
+
+    it("renders inside LazyMotion without errors", () => {
+        const { container } = render(
+            <LazyMotion features={domAnimation}>
+                <AnimateNumber>{42}</AnimateNumber>
+            </LazyMotion>
+        )
+        expect(container.textContent).toBe("42")
+    })
+
+    it("applies additional HTML attributes", () => {
+        const { container } = render(
+            <AnimateNumber className="count" data-testid="num">
+                {99}
+            </AnimateNumber>
+        )
+        const span = container.querySelector("span")!
+        expect(span.className).toBe("count")
+        expect(span.getAttribute("data-testid")).toBe("num")
+    })
+
+    it("is exported from the m entry point", async () => {
+        const m = await import("../../../m")
+        expect(m.AnimateNumber).toBeDefined()
+    })
+})

--- a/packages/framer-motion/src/components/AnimateNumber/index.tsx
+++ b/packages/framer-motion/src/components/AnimateNumber/index.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { useRef, useCallback } from "react"
+import { SpringOptions } from "motion-dom"
+import { useSpring } from "../../value/use-spring"
+import { useMotionValueEvent } from "../../utils/use-motion-value-event"
+
+interface AnimateNumberProps
+    extends Omit<React.HTMLAttributes<HTMLSpanElement>, "children"> {
+    /**
+     * The target number to animate to.
+     */
+    children: number
+
+    /**
+     * Intl.NumberFormat options for formatting the displayed number.
+     *
+     * @example
+     * ```jsx
+     * <AnimateNumber format={{ style: "currency", currency: "USD" }}>
+     *   {1234.56}
+     * </AnimateNumber>
+     * ```
+     */
+    format?: Intl.NumberFormatOptions
+
+    /**
+     * A BCP 47 language tag or array of tags for number formatting.
+     *
+     * @default undefined (uses runtime default locale)
+     */
+    locales?: Intl.LocalesArgument
+
+    /**
+     * Spring animation options.
+     *
+     * @default \{ damping: 60, stiffness: 500 \}
+     */
+    transition?: SpringOptions
+}
+
+const defaultTransition: SpringOptions = {
+    damping: 60,
+    stiffness: 500,
+}
+
+function AnimateNumber({
+    children: value,
+    format,
+    locales,
+    transition = defaultTransition,
+    ...props
+}: AnimateNumberProps) {
+    const ref = useRef<HTMLSpanElement>(null)
+
+    const formatter = React.useMemo(
+        () => new Intl.NumberFormat(locales, format),
+        [locales, JSON.stringify(format)]
+    )
+
+    const springValue = useSpring(value, transition)
+
+    const updateDisplay = useCallback(
+        (latest: number) => {
+            if (ref.current) {
+                ref.current.textContent = formatter.format(latest)
+            }
+        },
+        [formatter]
+    )
+
+    useMotionValueEvent(springValue, "change", updateDisplay)
+
+    return (
+        <span ref={ref} {...props}>
+            {formatter.format(value)}
+        </span>
+    )
+}
+
+export { AnimateNumber }
+export type { AnimateNumberProps }

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -2,6 +2,8 @@
  * Components
  */
 export type * from "./animation/types"
+export { AnimateNumber } from "./components/AnimateNumber"
+export type { AnimateNumberProps } from "./components/AnimateNumber"
 export { AnimatePresence } from "./components/AnimatePresence"
 export { PopChild } from "./components/AnimatePresence/PopChild"
 export { PresenceChild } from "./components/AnimatePresence/PresenceChild"

--- a/packages/framer-motion/src/m.ts
+++ b/packages/framer-motion/src/m.ts
@@ -1,1 +1,3 @@
+export { AnimateNumber } from "./components/AnimateNumber"
+export type { AnimateNumberProps } from "./components/AnimateNumber"
 export * from "./render/components/m/namespace"


### PR DESCRIPTION
## Summary

- Adds a new `AnimateNumber` component that smoothly animates between numeric values using spring physics
- Exports from both the main entry point (`framer-motion`) and the lazy/m entry point (`framer-motion/m`), so it works with `LazyMotion` + `m` imports
- The component uses `useSpring` and motion values internally (no `motion.*` elements), so it works in any context without needing separate lazy/non-lazy variants

## Usage

```tsx
import { AnimateNumber } from "motion/react"
// or for lazy contexts:
import { AnimateNumber } from "motion/react-m"

<AnimateNumber
  format={{ style: "currency", currency: "USD" }}
  locales="en-US"
  transition={{ damping: 60, stiffness: 500 }}
>
  {1234.56}
</AnimateNumber>
```

## Test plan

- [x] Unit test: renders initial value correctly
- [x] Unit test: formats numbers with `Intl.NumberFormat` options
- [x] Unit test: works inside `LazyMotion` without errors
- [x] Unit test: passes through HTML attributes to the `<span>`
- [x] Unit test: exported from the `m` entry point
- [x] `yarn build` passes
- [x] `yarn test` passes (pre-existing delay/velocity test failures only)

Fixes #3257

🤖 Generated with [Claude Code](https://claude.com/claude-code)