### PR TITLE
Fix layout jump when nested in motion.div with x/y set

### DIFF
--- a/dev/react/src/tests/layout-parent-xy-offset.tsx
+++ b/dev/react/src/tests/layout-parent-xy-offset.tsx
@@ -1,0 +1,77 @@
+import { motion } from "framer-motion"
+import { useId, useState } from "react"
+
+function Tabs() {
+    const items = ["a", "b", "c", "d", "e"]
+    const [selectedIndex, setSelectedIndex] = useState(0)
+    const uuid = useId()
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                gap: 10,
+                height: 64,
+                width: 500,
+                marginBottom: 12,
+            }}
+        >
+            {items.map((item, index) => (
+                <div
+                    key={item}
+                    onClick={() => setSelectedIndex(index)}
+                    style={{
+                        flex: 1,
+                        borderRadius: 8,
+                        position: "relative",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: "#eee",
+                    }}
+                >
+                    <div
+                        style={{
+                            position: "relative",
+                            zIndex: 1,
+                            color: "white",
+                        }}
+                    >
+                        {item}
+                    </div>
+                    {selectedIndex === index ? (
+                        <motion.div
+                            layoutId={"selected-" + uuid}
+                            className="indicator"
+                            style={{
+                                position: "absolute",
+                                top: 4,
+                                left: 4,
+                                right: 4,
+                                bottom: 4,
+                                background: "#444ccc",
+                                borderRadius: 8,
+                            }}
+                        />
+                    ) : null}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+export const App = () => {
+    return (
+        <div style={{ padding: 12 }}>
+            <motion.div id="motion-parent" style={{ x: 50, y: 50 }}>
+                <div style={{ marginBottom: 12 }}>Motion (x: 50, y: 50)</div>
+                <Tabs />
+            </motion.div>
+            <div style={{ transform: "translate3d(50px, 50px, 0)" }}>
+                <div style={{ marginBottom: 12 }}>Transform</div>
+                <Tabs />
+            </div>
+            <div id="result" />
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/layout-parent-xy-offset.ts
+++ b/packages/framer-motion/cypress/integration/layout-parent-xy-offset.ts
@@ -1,0 +1,54 @@
+describe("Layout: nested in motion.div with x/y (#3244)", () => {
+    it("layoutId element inside motion.div with x/y should not get a projection transform on mount", () => {
+        cy.visit("?test=layout-parent-xy-offset", {
+            onBeforeLoad(win) {
+                // Set up MutationObserver before React renders so we catch
+                // any transient projection transforms during StrictMode remount
+                ;(win as any).__projectionTransforms = []
+                const observer = new win.MutationObserver((mutations) => {
+                    for (const m of mutations) {
+                        if (m.attributeName !== "style") continue
+                        const el = m.target as HTMLElement
+                        if (!el.classList?.contains("indicator")) continue
+                        const motionParent =
+                            win.document.getElementById("motion-parent")
+                        if (!motionParent?.contains(el)) continue
+                        const t = el.style.transform
+                        if (t && t !== "none") {
+                            ;(win as any).__projectionTransforms.push(t)
+                        }
+                    }
+                })
+                // Start observing as soon as DOM is available
+                const startObserving = () => {
+                    observer.observe(win.document.body, {
+                        attributes: true,
+                        attributeFilter: ["style"],
+                        subtree: true,
+                    })
+                }
+                if (win.document.body) {
+                    startObserving()
+                } else {
+                    win.document.addEventListener(
+                        "DOMContentLoaded",
+                        startObserving
+                    )
+                }
+            },
+        })
+            .wait(500)
+            .window()
+            .then((win) => {
+                const transforms = (win as any).__projectionTransforms as string[]
+                // The MutationObserver records every non-"none" transform
+                // set on the indicator inside the motion.div parent.
+                // If the bug is present, the projection system will briefly
+                // apply a translate() transform during StrictMode remount.
+                expect(
+                    transforms.length,
+                    `expected no projection transforms but got: ${transforms.join(", ")}`
+                ).to.equal(0)
+            })
+    })
+})

--- a/packages/motion-dom/src/projection/node/create-projection-node.ts
+++ b/packages/motion-dom/src/projection/node/create-projection-node.ts
@@ -1073,19 +1073,20 @@ export function createProjectionNode<I>({
 
             for (let i = 0; i < this.path.length; i++) {
                 const node = this.path[i]
-                if (!node.instance) continue
                 if (!hasTransform(node.latestValues)) continue
 
-                hasScale(node.latestValues) && node.updateSnapshot()
+                let sourceBox: Box | undefined
 
-                const sourceBox = createBox()
-                const nodeBox = node.measurePageBox()
-                copyBoxInto(sourceBox, nodeBox)
+                if (node.instance) {
+                    hasScale(node.latestValues) && node.updateSnapshot()
+                    sourceBox = createBox()
+                    copyBoxInto(sourceBox, node.measurePageBox())
+                }
 
                 removeBoxTransforms(
                     boxWithoutTransform,
                     node.latestValues,
-                    node.snapshot ? node.snapshot.layoutBox : undefined,
+                    node.snapshot?.layoutBox,
                     sourceBox
                 )
             }


### PR DESCRIPTION
## Summary

- Fixes a layout animation bug where elements with `layoutId` inside a `motion.div` with `x`/`y` style props would jump on first page load in StrictMode
- Root cause: during StrictMode unmount/remount, parent motion elements get unmounted before child layout snapshots are taken. `removeTransform()` skipped unmounted nodes entirely, so parent transforms (x/y) were not removed from snapshot measurements. When parents remounted and their transforms were physically reset before layout measurement, the snapshot and layout became inconsistent by the parent's transform offset
- Fix: when a path node has transform values but no instance (unmounted), still remove those transforms mathematically via `removeBoxTransforms()`

Fixes #3244

## Test plan

- [x] Added Cypress E2E test (`layout-parent-xy-offset`) that uses a MutationObserver to detect spurious projection transforms on `layoutId` elements inside `motion.div` with x/y
- [x] Test passes on React 18 (port 9990)
- [x] Test passes on React 19 (port 9991)
- [x] All existing unit tests pass (`yarn test` — 91 suites, 762 tests)
- [x] Build succeeds (`yarn build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)