### PR TITLE
Add regression test for AnimatePresence onExitComplete (#3233)

### DIFF
--- a/dev/react/src/tests/animate-presence-exit-complete-multiple.tsx
+++ b/dev/react/src/tests/animate-presence-exit-complete-multiple.tsx
@@ -1,0 +1,98 @@
+import { AnimatePresence, motion } from "framer-motion"
+import { useEffect, useState } from "react"
+
+/**
+ * Reproduction from issue #3233:
+ * Multiple AnimatePresence instances with a shared layoutId child that
+ * cycles through them. onExitComplete should fire exactly once per exit.
+ */
+const maxNum = 4
+
+const boxStyle: React.CSSProperties = {
+    width: 100,
+    height: 100,
+    background: "aqua",
+    marginBottom: 20,
+    position: "relative",
+}
+
+const measurerStyle: React.CSSProperties = {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    border: "1px solid",
+    zIndex: 1,
+}
+
+function Boxes({
+    startIndex,
+    onDone,
+}: {
+    startIndex: number
+    onDone: () => void
+}) {
+    const [prevStartIndex, setPrevStartIndex] = useState(-1)
+    const [currentIndex, setCurrentIndex] = useState(startIndex)
+
+    if (prevStartIndex !== startIndex) {
+        setPrevStartIndex(startIndex)
+        setCurrentIndex(startIndex)
+    }
+
+    useEffect(() => {
+        if (startIndex < maxNum - 1) {
+            setCurrentIndex((index) => index + 1)
+        }
+    }, [])
+
+    return (
+        <div>
+            {Array(maxNum)
+                .fill(0)
+                .map((_, index) => (
+                    <div key={index} style={boxStyle}>
+                        <AnimatePresence
+                            onExitComplete={() =>
+                                index === maxNum - 1 && onDone()
+                            }
+                        >
+                            {currentIndex === index && (
+                                <motion.div
+                                    layout
+                                    layoutId="measurer"
+                                    style={measurerStyle}
+                                    onLayoutAnimationComplete={() => {
+                                        if (currentIndex < maxNum - 1) {
+                                            setCurrentIndex(
+                                                (idx) => idx + 1
+                                            )
+                                        }
+                                    }}
+                                />
+                            )}
+                        </AnimatePresence>
+                    </div>
+                ))}
+        </div>
+    )
+}
+
+export const App = () => {
+    const [startIndex, setStartIndex] = useState(0)
+    const [doneCount, setDoneCount] = useState(0)
+
+    return (
+        <>
+            <Boxes
+                startIndex={startIndex}
+                onDone={() => setDoneCount((c) => c + 1)}
+            />
+            <span id="done-count">{doneCount}</span>
+            <button id="start-1" onClick={() => setStartIndex(1)}>
+                start 1
+            </button>
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-exit-complete-multiple.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-exit-complete-multiple.ts
@@ -1,0 +1,22 @@
+/**
+ * Regression test for issue #3233:
+ * AnimatePresence onExitComplete should fire exactly once per exit,
+ * even with shared layoutId cycling through multiple AnimatePresence instances.
+ */
+describe("AnimatePresence onExitComplete", () => {
+    it("Only fires once when layoutId child exits and re-enters", () => {
+        cy.visit("?test=animate-presence-exit-complete-multiple")
+            .wait(2000) // Wait for initial layout animations to settle
+            .get("#done-count")
+            .should((el: any) => {
+                expect(el[0].textContent).to.equal("0")
+            })
+            .get("#start-1")
+            .trigger("click", 10, 10, { force: true })
+            .wait(3000) // Wait for all layout animations to complete
+            .get("#done-count")
+            .should((el: any) => {
+                expect(el[0].textContent).to.equal("1")
+            })
+    })
+})


### PR DESCRIPTION
## Summary

- Adds a Cypress E2E regression test for issue #3233: `<AnimatePresence onExitComplete>` being called multiple times when there is only one exit
- The bug was reported with motion v12.15.0 and was fixed by commit aa8b46be3 ("Fix duplicate exit animation processing in AnimatePresence"), which added the `exitingComponents` guard to prevent duplicate `onExit` calls
- This PR adds a dedicated regression test that reproduces the exact scenario from #3233: multiple `AnimatePresence` instances with a shared `layoutId` child that cycles through them via `onLayoutAnimationComplete`
- The test verifies `onExitComplete` fires exactly once when the last box's child exits and then re-enters

## Test plan

- [x] Cypress test passes on React 18
- [x] Cypress test passes on React 19
- [x] Full test suite passes (`yarn test`)
- [x] Build succeeds (`yarn build`)

Fixes #3233

🤖 Generated with [Claude Code](https://claude.com/claude-code)