### PR TITLE
[audit] motion-dom/effects: dead code removal and subscriptions bug fix

### DIFF
--- a/packages/motion-dom/src/effects/MotionValueState.ts
+++ b/packages/motion-dom/src/effects/MotionValueState.ts
@@ -58,10 +58,4 @@ export class MotionValueState {
     get(name: string): MotionValue | undefined {
         return this.values.get(name)?.value
     }
-
-    destroy() {
-        for (const value of this.values.values()) {
-            value.onRemove()
-        }
-    }
 }

--- a/packages/motion-dom/src/effects/style/transform.ts
+++ b/packages/motion-dom/src/effects/style/transform.ts
@@ -33,8 +33,7 @@ export function buildTransform(state: MotionValueState) {
         if (!valueIsDefault) {
             transformIsDefault = false
             const transformName = translateAlias[key] || key
-            const valueToRender = state.latest[key]
-            transform += `${transformName}(${valueToRender}) `
+            transform += `${transformName}(${value}) `
         }
     }
 

--- a/packages/motion-dom/src/effects/types.ts
+++ b/packages/motion-dom/src/effects/types.ts
@@ -1,5 +1,0 @@
-import { MotionValue } from "../value"
-
-export interface MotionValueMap {
-    [key: string]: MotionValue
-}

--- a/packages/motion-dom/src/effects/utils/create-effect.ts
+++ b/packages/motion-dom/src/effects/utils/create-effect.ts
@@ -10,7 +10,6 @@ export function createEffect<Subject extends object>(
     ) => VoidFunction
 ) {
     const stateCache = new WeakMap<Subject, MotionValueState>()
-    const subscriptions: VoidFunction[] = []
 
     return (
         subject: Subject,
@@ -19,6 +18,8 @@ export function createEffect<Subject extends object>(
         const state = stateCache.get(subject) ?? new MotionValueState()
 
         stateCache.set(subject, state)
+
+        const subscriptions: VoidFunction[] = []
 
         for (const key in values) {
             const value = values[key]


### PR DESCRIPTION
## What this directory does

`packages/motion-dom/src/effects/` provides the effect system for binding MotionValues to DOM elements. It includes:
- **styleEffect** — binds MotionValues to CSS styles (including transforms and transform-origin)
- **attrEffect** — binds MotionValues to HTML/SVG attributes
- **svgEffect** — binds MotionValues to SVG elements (routing to style vs attribute as appropriate)
- **propEffect** — binds MotionValues to arbitrary object properties
- **MotionValueState** — shared state container that tracks latest values and manages subscriptions
- **createEffect / createSelectorEffect** — factory utilities for building effects

## Findings

### Dead code
- `types.ts` exports `MotionValueMap` interface that is never imported anywhere in the monorepo
- `MotionValueState.destroy()` method is never called anywhere

### Correctness bug (shared subscriptions)
In `create-effect.ts`, the `subscriptions` array was declared in the factory closure, meaning it was **shared across all invocations** of the returned effect function. This caused cleanup of one effect to cancel subscriptions from **all** effects created by the same factory. For example:
```ts
const cleanup1 = styleEffect(el, { x })
const cleanup2 = styleEffect(el, { y })
cleanup1() // also cancels y's subscription!
```
Existing tests pass by coincidence (values are set before cleanup is called, so `state.latest` is already updated).

### Redundant variable
`valueToRender` in `effects/style/transform.ts` is identical to `value` — both read `state.latest[key]`.

## Changes

1. **Delete `types.ts`** — unused `MotionValueMap` interface
2. **Fix `create-effect.ts`** — move `subscriptions` array inside the returned function so each call gets its own array
3. **Remove `valueToRender`** in `transform.ts` — use `value` directly
4. **Remove `MotionValueState.destroy()`** — dead method

All changes are internal (nothing exported from the package was modified).

## Test plan
- [x] `yarn build` passes
- [x] `yarn test` passes (all 7 tasks, 762 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)