### PR TITLE
Fix opacity animation broken with React StrictMode

### DIFF
--- a/dev/react/src/tests/strict-mode-opacity.tsx
+++ b/dev/react/src/tests/strict-mode-opacity.tsx
@@ -1,0 +1,49 @@
+import { useAnimate } from "framer-motion"
+import { StrictMode, useEffect, useRef, useState } from "react"
+
+function Test() {
+    const [scope, animate] = useAnimate()
+    const controlsRef = useRef<any>(null)
+    const [shouldAnimate, setShouldAnimate] = useState(false)
+
+    useEffect(() => {
+        controlsRef.current = animate(
+            scope.current,
+            { opacity: 1 },
+            { duration: 0.5, autoplay: false }
+        )
+
+        return () => controlsRef.current?.stop()
+    }, [])
+
+    useEffect(() => {
+        if (!controlsRef.current || !shouldAnimate) return
+        controlsRef.current.play()
+    }, [shouldAnimate])
+
+    return (
+        <>
+            <div
+                id="box"
+                ref={scope}
+                style={{
+                    width: 100,
+                    height: 100,
+                    background: "red",
+                    opacity: 0,
+                }}
+            />
+            <button id="trigger" onClick={() => setShouldAnimate(true)}>
+                Animate
+            </button>
+        </>
+    )
+}
+
+export function App() {
+    return (
+        <StrictMode>
+            <Test />
+        </StrictMode>
+    )
+}

--- a/packages/framer-motion/cypress/integration/strict-mode-opacity.ts
+++ b/packages/framer-motion/cypress/integration/strict-mode-opacity.ts
@@ -1,0 +1,35 @@
+describe("StrictMode opacity animation", () => {
+    it("element starts at opacity 0 when using single 'to' value with autoplay: false", () => {
+        cy.visit("?test=strict-mode-opacity")
+            .wait(200)
+            .get("#box")
+            .should(($el: any) => {
+                const opacity = parseFloat(
+                    window.getComputedStyle($el[0]).opacity
+                )
+                expect(opacity).to.equal(0)
+            })
+    })
+
+    it("element animates to opacity 1 when triggered", () => {
+        cy.visit("?test=strict-mode-opacity")
+            .wait(200)
+            .get("#box")
+            .should(($el: any) => {
+                const opacity = parseFloat(
+                    window.getComputedStyle($el[0]).opacity
+                )
+                expect(opacity).to.equal(0)
+            })
+            .get("#trigger")
+            .click()
+            .wait(800)
+            .get("#box")
+            .should(($el: any) => {
+                const opacity = parseFloat(
+                    window.getComputedStyle($el[0]).opacity
+                )
+                expect(opacity).to.equal(1)
+            })
+    })
+})

--- a/packages/motion-dom/src/animation/NativeAnimationExtended.ts
+++ b/packages/motion-dom/src/animation/NativeAnimationExtended.ts
@@ -45,7 +45,12 @@ export class NativeAnimationExtended<
 
         super(options)
 
-        if (options.startTime !== undefined) {
+        /**
+         * Only set startTime when the animation should autoplay.
+         * Setting startTime on a paused WAAPI animation unpauses it
+         * (per the WAAPI spec), which breaks autoplay: false.
+         */
+        if (options.startTime !== undefined && options.autoplay !== false) {
             this.startTime = options.startTime
         }
 


### PR DESCRIPTION
## Summary

- **Bug**: When React StrictMode is enabled, opacity animations using a single "to" value (e.g., `animate(el, { opacity: 1 })`) would immediately jump to the final value instead of staying at the initial value or animating correctly
- **Cause**: `NativeAnimationExtended` sets `startTime` on the WAAPI animation after pausing it. Per the WAAPI spec, setting `startTime` on a paused animation **unpauses** it, causing the animation to immediately play to completion
- **Fix**: Skip setting `startTime` when `autoplay: false`, since it's unnecessary for paused animations and causes this unintended side effect

The one-line fix in `NativeAnimationExtended.ts`:
```diff
-if (options.startTime !== undefined) {
+if (options.startTime !== undefined && options.autoplay !== false) {
```

Fixes #3221

## Test plan

- [x] Added Cypress E2E test (`strict-mode-opacity.ts`) with React StrictMode that verifies:
  - Element stays at opacity 0 when animation has `autoplay: false`
  - Element animates to opacity 1 when `play()` is called
- [x] Cypress test passes on both React 18 and React 19
- [x] Full test suite passes (`yarn test` — 91 suites, 762 tests)
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)