### PR TITLE
Add global frameRate setting to reduce animation frame rate

### DIFF
--- a/packages/motion-dom/src/frameloop/__tests__/frame-rate.test.ts
+++ b/packages/motion-dom/src/frameloop/__tests__/frame-rate.test.ts
@@ -1,0 +1,81 @@
+import { MotionGlobalConfig } from "motion-utils"
+import { createRenderBatcher } from "../batcher"
+
+describe("frameRate", () => {
+    afterEach(() => {
+        delete MotionGlobalConfig.frameRate
+        MotionGlobalConfig.useManualTiming = false
+    })
+
+    it("throttles frame processing when frameRate is set", () => {
+        MotionGlobalConfig.useManualTiming = true
+        MotionGlobalConfig.frameRate = 30 // 33.33ms per frame
+
+        let processBatchFn: Function | null = null
+        const { schedule, state } = createRenderBatcher((cb) => {
+            processBatchFn = cb
+        }, true)
+
+        let updateCount = 0
+        schedule.update(() => updateCount++, true)
+
+        // Simulate 6 rAF callbacks at ~60fps (16.67ms apart)
+        const startTime = 1000
+        for (let i = 0; i < 6; i++) {
+            state.timestamp = startTime + i * 16.67
+            processBatchFn!()
+        }
+
+        // At 30fps, over 6 frames at 16.67ms, only ~3 should process:
+        // i=0: 1000ms    → process (first frame)
+        // i=1: 1016.67ms → skip (16.67ms < 33.33ms)
+        // i=2: 1033.34ms → process (33.34ms elapsed)
+        // i=3: 1050.01ms → skip (16.67ms < 33.33ms)
+        // i=4: 1066.68ms → process (33.34ms elapsed)
+        // i=5: 1083.35ms → skip (16.67ms < 33.33ms)
+        expect(updateCount).toBe(3)
+    })
+
+    it("does not throttle when frameRate is not set", () => {
+        MotionGlobalConfig.useManualTiming = true
+
+        let processBatchFn: Function | null = null
+        const { schedule, state } = createRenderBatcher((cb) => {
+            processBatchFn = cb
+        }, true)
+
+        let updateCount = 0
+        schedule.update(() => updateCount++, true)
+
+        const startTime = 1000
+        for (let i = 0; i < 6; i++) {
+            state.timestamp = startTime + i * 16.67
+            processBatchFn!()
+        }
+
+        // Without frameRate set, all 6 frames should process
+        expect(updateCount).toBe(6)
+    })
+
+    it("processes every frame when frameRate is >= 60", () => {
+        MotionGlobalConfig.useManualTiming = true
+        MotionGlobalConfig.frameRate = 60
+
+        let processBatchFn: Function | null = null
+        const { schedule, state } = createRenderBatcher((cb) => {
+            processBatchFn = cb
+        }, true)
+
+        let updateCount = 0
+        schedule.update(() => updateCount++, true)
+
+        const startTime = 1000
+        for (let i = 0; i < 6; i++) {
+            state.timestamp = startTime + i * 16.67
+            processBatchFn!()
+        }
+
+        // At 60fps (16.67ms interval), every 16.67ms frame should process
+        expect(updateCount).toBe(6)
+    })
+})

--- a/packages/motion-dom/src/frameloop/batcher.ts
+++ b/packages/motion-dom/src/frameloop/batcher.ts
@@ -39,10 +39,25 @@ export function createRenderBatcher(
         postRender,
     } = steps
 
+    let lastProcessedTimestamp = 0
+
     const processBatch = () => {
         const timestamp = MotionGlobalConfig.useManualTiming
             ? state.timestamp
             : performance.now()
+
+        // Throttle frame rate if configured
+        const { frameRate } = MotionGlobalConfig
+        if (frameRate && frameRate < 60) {
+            const interval = 1000 / frameRate
+            if (lastProcessedTimestamp && timestamp - lastProcessedTimestamp < interval) {
+                // Skip this frame but keep the loop alive
+                if (allowKeepAlive) scheduleNextBatch(processBatch)
+                return
+            }
+        }
+        lastProcessedTimestamp = timestamp
+
         runNextFrame = false
 
         if (!MotionGlobalConfig.useManualTiming) {

--- a/packages/motion-utils/src/global-config.ts
+++ b/packages/motion-utils/src/global-config.ts
@@ -2,6 +2,7 @@ export const MotionGlobalConfig: {
     skipAnimations?: boolean
     instantAnimations?: boolean
     useManualTiming?: boolean
+    frameRate?: number
     WillChange?: any
     mix?: <T>(a: T, b: T) => (p: number) => T
 } = {}


### PR DESCRIPTION
## Summary

- Adds a `frameRate` option to `MotionGlobalConfig` that throttles the frame loop to the specified rate
- When set (e.g. `MotionGlobalConfig.frameRate = 30`), frames arriving faster than the target interval are skipped while keeping the animation loop alive
- Values >= 60 or unset have no effect (no overhead on the default path)

This enables smoother animations on low-end devices (e.g. Raspberry Pi) that can't sustain 60fps at high resolutions. Usage:

```js
import { MotionGlobalConfig } from "motion"
MotionGlobalConfig.frameRate = 30
```

Fixes #3157

## Test plan

- [x] Unit test verifies frame throttling at 30fps (3 out of 6 frames processed)
- [x] Unit test verifies no throttling when `frameRate` is unset
- [x] Unit test verifies no throttling when `frameRate >= 60`
- [x] All existing frameloop tests pass
- [x] Full motion-dom test suite passes
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)