### PR TITLE
Add AnimateSuspense component

### DIFF
--- a/dev/react/src/tests/animate-suspense.tsx
+++ b/dev/react/src/tests/animate-suspense.tsx
@@ -1,0 +1,50 @@
+import { lazy } from "react"
+import { motion, AnimateSuspense } from "framer-motion"
+
+/**
+ * Test for AnimateSuspense component (issue #3173).
+ *
+ * Uses React.lazy() to create a component that suspends for 500ms.
+ * The fallback (motion.div) should animate out when children resolve.
+ */
+
+const LazyContent = lazy(
+    () =>
+        new Promise<{ default: React.ComponentType }>((resolve) => {
+            setTimeout(() => {
+                resolve({
+                    default: () => (
+                        <motion.div
+                            id="content"
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            transition={{ duration: 0.3 }}
+                        >
+                            Loaded Content
+                        </motion.div>
+                    ),
+                })
+            }, 500)
+        })
+)
+
+export function App() {
+    return (
+        <AnimateSuspense
+            fallback={
+                <motion.div
+                    id="fallback"
+                    key="fallback"
+                    initial={{ opacity: 1 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.5 }}
+                >
+                    Loading...
+                </motion.div>
+            }
+        >
+            <LazyContent />
+        </AnimateSuspense>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-suspense.ts
+++ b/packages/framer-motion/cypress/integration/animate-suspense.ts
@@ -1,0 +1,27 @@
+/**
+ * Test for AnimateSuspense component (issue #3173).
+ *
+ * Verifies that:
+ * 1. The fallback is visible while children are suspended
+ * 2. The content appears when children resolve
+ * 3. The fallback animates out (exit animation) after resolve
+ */
+describe("AnimateSuspense", () => {
+    it("shows fallback while suspended, then animates it out on resolve", () => {
+        cy.visit("?test=animate-suspense")
+            .wait(100)
+            // Fallback should be visible while children are suspended
+            .get("#fallback")
+            .should("exist")
+            .should("have.css", "opacity", "1")
+
+            // Wait for content to appear (promise resolves at ~500ms)
+            .get("#content", { timeout: 5000 })
+            .should("exist")
+            .should("contain", "Loaded Content")
+
+            // Fallback should be removed after exit animation completes
+            .get("#fallback", { timeout: 5000 })
+            .should("not.exist")
+    })
+})

--- a/packages/framer-motion/src/components/AnimateSuspense/index.tsx
+++ b/packages/framer-motion/src/components/AnimateSuspense/index.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import * as React from "react"
+import { Suspense, useState } from "react"
+import { AnimatePresence } from "../AnimatePresence"
+import { useIsomorphicLayoutEffect } from "../../utils/use-isomorphic-effect"
+import type { AnimateSuspenseProps } from "./types"
+
+/**
+ * Internal component rendered as React Suspense's fallback.
+ * Mounts when children suspend, unmounts when they resolve.
+ */
+function SuspenseTracker({
+    onChange,
+}: {
+    onChange: (v: boolean) => void
+}) {
+    useIsomorphicLayoutEffect(() => {
+        onChange(true)
+        return () => onChange(false)
+    }, [onChange])
+    return null
+}
+
+/**
+ * Internal wrapper that detects when children render without suspending.
+ * Handles the case where children never throw a promise.
+ */
+function ResolveTracker({
+    children,
+    onChange,
+}: {
+    children: React.ReactNode
+    onChange: (v: boolean) => void
+}) {
+    useIsomorphicLayoutEffect(() => {
+        onChange(false)
+    }, [onChange])
+    return <>{children}</>
+}
+
+/**
+ * `AnimateSuspense` enables animated transitions between a loading fallback
+ * and streamed/lazy-loaded content using React Suspense.
+ *
+ * It has the same basic API as React's `Suspense`, but the `fallback` can be
+ * a `motion` component with `exit` animations that will play when children resolve.
+ *
+ * ```jsx
+ * import { motion, AnimateSuspense } from "framer-motion"
+ *
+ * <AnimateSuspense
+ *   fallback={
+ *     <motion.div
+ *       initial={{ opacity: 0 }}
+ *       animate={{ opacity: 1 }}
+ *       exit={{ opacity: 0 }}
+ *     >
+ *       Loading...
+ *     </motion.div>
+ *   }
+ * >
+ *   <AsyncContent />
+ * </AnimateSuspense>
+ * ```
+ *
+ * @public
+ */
+export function AnimateSuspense({
+    children,
+    fallback,
+    initial,
+    mode = "wait",
+    onExitComplete,
+}: AnimateSuspenseProps) {
+    const [isSuspended, setIsSuspended] = useState(true)
+
+    return (
+        <>
+            <Suspense
+                fallback={
+                    <SuspenseTracker onChange={setIsSuspended} />
+                }
+            >
+                <ResolveTracker onChange={setIsSuspended}>
+                    {children}
+                </ResolveTracker>
+            </Suspense>
+            <AnimatePresence
+                initial={initial}
+                mode={mode}
+                onExitComplete={onExitComplete}
+            >
+                {isSuspended ? fallback : null}
+            </AnimatePresence>
+        </>
+    )
+}

--- a/packages/framer-motion/src/components/AnimateSuspense/types.ts
+++ b/packages/framer-motion/src/components/AnimateSuspense/types.ts
@@ -1,0 +1,47 @@
+/**
+ * @public
+ */
+export interface AnimateSuspenseProps {
+    /**
+     * Content that may suspend (e.g. lazy-loaded components, data fetching).
+     */
+    children: React.ReactNode
+
+    /**
+     * A `motion` component to display while children are suspended.
+     * Use `exit` props on this element to animate it out when children resolve.
+     *
+     * ```jsx
+     * <AnimateSuspense
+     *   fallback={
+     *     <motion.div exit={{ opacity: 0 }}>Loading...</motion.div>
+     *   }
+     * >
+     *   <AsyncContent />
+     * </AnimateSuspense>
+     * ```
+     */
+    fallback: React.ReactNode
+
+    /**
+     * By passing `initial={false}`, the fallback will not animate in on first render.
+     *
+     * @public
+     */
+    initial?: boolean
+
+    /**
+     * @see AnimatePresenceProps.mode
+     * @default "wait"
+     *
+     * @public
+     */
+    mode?: "sync" | "popLayout" | "wait"
+
+    /**
+     * Fires when the fallback has finished its exit animation.
+     *
+     * @public
+     */
+    onExitComplete?: () => void
+}

--- a/packages/framer-motion/src/index.ts
+++ b/packages/framer-motion/src/index.ts
@@ -3,6 +3,7 @@
  */
 export type * from "./animation/types"
 export { AnimatePresence } from "./components/AnimatePresence"
+export { AnimateSuspense } from "./components/AnimateSuspense"
 export { PopChild } from "./components/AnimatePresence/PopChild"
 export { PresenceChild } from "./components/AnimatePresence/PresenceChild"
 export { LayoutGroup } from "./components/LayoutGroup"
@@ -124,6 +125,7 @@ export { SwitchLayoutGroupContext } from "./context/SwitchLayoutGroupContext"
  * Types
  */
 export type { AnimatePresenceProps } from "./components/AnimatePresence/types"
+export type { AnimateSuspenseProps } from "./components/AnimateSuspense/types"
 export type { LazyProps } from "./components/LazyMotion/types"
 export type { MotionConfigProps } from "./components/MotionConfig"
 export type {


### PR DESCRIPTION
## Summary

- Adds a new `AnimateSuspense` component that combines React's `<Suspense>` with `AnimatePresence` to enable animated transitions between loading fallbacks and streamed/lazy-loaded content
- The component uses a sentinel-based approach: an internal `SuspenseTracker` detects when children are suspended, and a `ResolveTracker` detects when children resolve, toggling `AnimatePresence` to animate the fallback in and out
- API matches React's `<Suspense>` signature (`children` + `fallback`) with additional AnimatePresence-compatible props (`initial`, `mode`, `onExitComplete`)

### Usage

```jsx
import { motion, AnimateSuspense } from "motion/react"

<AnimateSuspense
  fallback={
    <motion.div
      initial={{ opacity: 0 }}
      animate={{ opacity: 1 }}
      exit={{ opacity: 0 }}
    >
      Loading...
    </motion.div>
  }
>
  <LazyContent />
</AnimateSuspense>
```

Fixes #3173

## Test plan

- [x] Cypress E2E test verifies fallback appears during suspension, content loads, and fallback animates out
- [x] Tested against both React 18 and React 19
- [x] All existing unit tests pass (91 suites, 762 tests)
- [x] Full build succeeds across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)