### PR TITLE
Fix animate prop not working with motion/react-m

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/minimal-component.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/minimal-component.test.tsx
@@ -1,0 +1,58 @@
+import { motionValue } from "motion-dom"
+import { createMinimalMotionComponent } from "../../render/components/m/create"
+import { render } from "../../jest.setup"
+
+/**
+ * Issue #3194: motion/react-m components should animate with the animate prop
+ * without requiring LazyMotion.
+ */
+describe("Minimal motion component (motion/react-m)", () => {
+    test("animates with the animate prop", async () => {
+        const MotionDiv = createMinimalMotionComponent("div")
+
+        const promise = new Promise((resolve) => {
+            const x = motionValue(0)
+            const onComplete = () => resolve(x.get())
+
+            const Component = () => (
+                <MotionDiv
+                    animate={{ x: 20 }}
+                    transition={{ duration: 0.01 }}
+                    style={{ x }}
+                    onAnimationComplete={onComplete}
+                />
+            )
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+            setTimeout(() => resolve(x.get()), 100)
+        })
+
+        return expect(promise).resolves.toBe(20)
+    })
+
+    test("applies animate values with initial prop", async () => {
+        const MotionDiv = createMinimalMotionComponent("div")
+
+        const promise = new Promise((resolve) => {
+            const opacity = motionValue(0)
+            const onComplete = () => resolve(opacity.get())
+
+            const Component = () => (
+                <MotionDiv
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={{ duration: 0.01 }}
+                    style={{ opacity }}
+                    onAnimationComplete={onComplete}
+                />
+            )
+
+            const { rerender } = render(<Component />)
+            rerender(<Component />)
+            setTimeout(() => resolve(opacity.get()), 100)
+        })
+
+        return expect(promise).resolves.toBe(1)
+    })
+})

--- a/packages/framer-motion/src/render/components/m/create.ts
+++ b/packages/framer-motion/src/render/components/m/create.ts
@@ -1,5 +1,8 @@
 import { createMotionComponent, MotionComponentOptions } from "../../../motion"
+import { animations } from "../../../motion/features/animations"
+import { CreateVisualElement } from "../../types"
 import { DOMMotionComponents } from "../../dom/types"
+import { createDomVisualElement } from "../../dom/create-visual-element"
 
 export function createMinimalMotionComponent<
     Props,
@@ -8,5 +11,10 @@ export function createMinimalMotionComponent<
     Component: TagName | string | React.ComponentType<Props>,
     options?: MotionComponentOptions
 ) {
-    return createMotionComponent(Component, options)
+    return createMotionComponent(
+        Component,
+        options,
+        animations,
+        createDomVisualElement as CreateVisualElement<Props, TagName>
+    )
 }


### PR DESCRIPTION
## Summary

- Components imported via `motion/react-m` (which use `createMinimalMotionComponent`) were missing the DOM visual element creator and animation features
- Without these, no `VisualElement` was instantiated and no `AnimationState` was created, so the `animate` prop was silently ignored and elements stayed at their `initial` values (e.g. `opacity: 0`)
- Passes `animations` and `createDomVisualElement` to `createMotionComponent` in `createMinimalMotionComponent`, so `motion/react-m` components work for basic animations without requiring `LazyMotion`
- The `m` proxy (used with `LazyMotion` from the main `framer-motion` import) is unchanged

Fixes #3194

## Test plan

- [x] Added unit tests verifying `createMinimalMotionComponent` components animate with the `animate` prop
- [x] Existing lazy loading tests pass (the `m` proxy behavior is unchanged)
- [x] Full test suite passes (764 tests, 0 failures)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)