### PR TITLE
Add test coverage for spring animations with sequences

### DIFF
--- a/dev/react/src/tests/animate-sequence-spring.tsx
+++ b/dev/react/src/tests/animate-sequence-spring.tsx
@@ -1,0 +1,46 @@
+import { useAnimate } from "framer-motion"
+import { useEffect, useState } from "react"
+
+/**
+ * Reproduction for #3158: spring animations with animation sequences
+ * should not throw "Only two keyframes currently supported with spring
+ * and inertia animations".
+ */
+export const App = () => {
+    const [scope, animate] = useAnimate()
+    const [result, setResult] = useState("")
+
+    useEffect(() => {
+        animate(
+            [
+                ["#box-a", { x: [0, 20], y: [0, 20] }],
+                ["#box-b", { scale: [1, 2] }],
+            ],
+            { defaultTransition: { type: "spring" } }
+        )
+            .then(() => setResult("Success"))
+            .catch(() => setResult("Error"))
+    }, [])
+
+    return (
+        <div ref={scope} style={{ padding: 100 }}>
+            <div
+                id="box-a"
+                style={{
+                    width: 100,
+                    height: 100,
+                    backgroundColor: "red",
+                }}
+            />
+            <div
+                id="box-b"
+                style={{
+                    width: 100,
+                    height: 100,
+                    backgroundColor: "blue",
+                }}
+            />
+            <input id="result" readOnly value={result} />
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-sequence-spring.ts
+++ b/packages/framer-motion/cypress/integration/animate-sequence-spring.ts
@@ -1,0 +1,10 @@
+describe("animate() sequence with spring defaultTransition (#3158)", () => {
+    it("does not throw when using type: spring with 2-keyframe sequence segments", () => {
+        cy.visit("?test=animate-sequence-spring")
+            .wait(2000)
+            .get("#result")
+            .should(($el: any) => {
+                expect($el.val()).to.equal("Success")
+            })
+    })
+})

--- a/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
+++ b/packages/framer-motion/src/animation/sequence/__tests__/index.test.ts
@@ -794,6 +794,36 @@ describe("createAnimationsFromSequence", () => {
         expect(times).toEqual([0, 0.25, 0.25, 0.5, 0.5, 0.75, 0.75, 1])
     })
 
+    test("Spring defaultTransition does not leak type into multi-element sequence (#3158)", () => {
+        const img = document.createElement("img")
+        const h1 = document.createElement("h1")
+
+        const animations = createAnimationsFromSequence(
+            [
+                [img, { x: [0, 20], y: [0, 20] }],
+                [h1, { scale: [1, 2] }],
+            ],
+            { defaultTransition: { type: "spring" } },
+            undefined,
+            { spring }
+        )
+
+        // type: "spring" must be stripped — sequence converts springs to easing
+        const imgTransition = animations.get(img)!.transition
+        expect(imgTransition.x.type).toBeUndefined()
+        expect(imgTransition.y.type).toBeUndefined()
+
+        const h1Transition = animations.get(h1)!.transition
+        expect(h1Transition.scale.type).toBeUndefined()
+
+        // Verify easing functions were generated from spring
+        expect(
+            (imgTransition.x.ease as Easing[]).some(
+                (e) => typeof e === "function"
+            )
+        ).toBe(true)
+    })
+
     test("It skips null elements in sequence", () => {
         const animations = createAnimationsFromSequence(
             [


### PR DESCRIPTION
## Summary

- Adds unit test and Cypress E2E test for #3158: spring animations throwing "Only two keyframes currently supported" when used with `defaultTransition: { type: "spring" }` in animation sequences
- The underlying bug was already fixed in 3d5cab42b (which resolved #3404), which strips `type` from `defaultTransition` before building the final per-key transition in `createAnimationsFromSequence`
- This PR adds test coverage for the specific multi-element reproduction from #3158 to prevent regression

## Bug details

When using `defaultTransition: { type: "spring" }` with `useAnimate` sequences containing multiple elements, the `type: "spring"` was being spread into the final transition object. Since sequence animations merge keyframes (adding padding keyframes at offset 0 and 1), the resulting keyframe arrays often exceed 2 entries, triggering the spring 2-keyframe constraint check in `JSAnimation`.

The fix (already applied) destructures `type` out of `defaultTransition` before spreading it into the per-key transition, since springs are already converted to duration-based easing functions during sequence creation.

## Test plan

- [x] Unit test: verifies `createAnimationsFromSequence` strips `type: "spring"` from multi-element sequences
- [x] Cypress E2E (React 18): verifies the animation completes without errors in the browser
- [x] Cypress E2E (React 19): same verification on React 19
- [x] Full test suite passes (763 tests, 91 suites)

Fixes #3158

🤖 Generated with [Claude Code](https://claude.com/claude-code)