### PR TITLE
Fix motion import in React Server Components

### DIFF
--- a/dev/next/app/page.tsx
+++ b/dev/next/app/page.tsx
@@ -1,5 +1,4 @@
-import { AnimatePresence, MotionConfig } from "motion/react"
-import * as motion from "motion/react-client"
+import { AnimatePresence, motion, MotionConfig } from "motion/react"
 import { MotionM } from "./motion-m"
 import {
     MotionCustom,

--- a/packages/framer-motion/package.json
+++ b/packages/framer-motion/package.json
@@ -6,6 +6,11 @@
     "module": "dist/es/index.mjs",
     "exports": {
         ".": {
+            "react-server": {
+                "types": "./dist/types/index.d.ts",
+                "require": "./dist/cjs/server.js",
+                "import": "./dist/es/server.mjs"
+            },
             "types": "./dist/types/index.d.ts",
             "require": "./dist/cjs/index.js",
             "import": "./dist/es/index.mjs",

--- a/packages/framer-motion/rollup.config.mjs
+++ b/packages/framer-motion/rollup.config.mjs
@@ -113,7 +113,7 @@ const umdDomProd = createUmd("lib/dom.js", `dist/dom.js`)
 const umdDomMiniProd = createUmd("lib/dom-mini.js", `dist/dom-mini.js`)
 
 const cjs = Object.assign({}, config, {
-    input: ["lib/index.js", "lib/client.js"],
+    input: ["lib/index.js", "lib/client.js", "lib/server.js"],
     output: {
         entryFileNames: `[name].js`,
         dir: "dist/cjs",
@@ -142,7 +142,7 @@ const cjsDomMini = Object.assign({}, cjs, { input : "lib/dom-mini.js" })
 const cjsM = Object.assign({}, cjs, { input : "lib/m.js" })
 
 export const es = Object.assign({}, config, {
-    input: ["lib/index.js", "lib/mini.js", "lib/debug.js", "lib/dom.js", "lib/dom-mini.js", "lib/client.js", "lib/m.js","lib/projection.js"],
+    input: ["lib/index.js", "lib/mini.js", "lib/debug.js", "lib/dom.js", "lib/dom-mini.js", "lib/client.js", "lib/server.js", "lib/m.js","lib/projection.js"],
     output: {
         entryFileNames: "[name].mjs",
         format: "es",

--- a/packages/framer-motion/src/client.ts
+++ b/packages/framer-motion/src/client.ts
@@ -1,3 +1,5 @@
+export * as motion from "./render/components/motion/namespace"
+
 export {
     a,
     abbr,

--- a/packages/framer-motion/src/render/components/m/proxy.ts
+++ b/packages/framer-motion/src/render/components/m/proxy.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { createMotionProxy } from "../create-proxy"
 
 export const m = /*@__PURE__*/ createMotionProxy()

--- a/packages/framer-motion/src/render/components/motion/proxy.ts
+++ b/packages/framer-motion/src/render/components/motion/proxy.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { createDomVisualElement } from "../../dom/create-visual-element"
 import { createMotionProxy } from "../create-proxy"
 import { featureBundle } from "./feature-bundle"

--- a/packages/framer-motion/src/server.ts
+++ b/packages/framer-motion/src/server.ts
@@ -1,0 +1,2 @@
+export * as motion from "./render/components/motion/namespace"
+export * from "./index"


### PR DESCRIPTION
## Summary
- Add `"use client"` directive to `motion` and `m` proxy files so they establish proper client boundaries in RSC
- Add `react-server` export condition with a server entry that provides `motion` as a static namespace of pre-built client components
- Export `motion` namespace from `framer-motion/client` entry for explicit client imports
- This allows `import { motion } from 'framer-motion'` to work directly in Next.js Server Components (previously `motion.div` was `undefined`)

## Test plan
- [x] Build succeeds (including Next.js dev app static generation)
- [x] RSC Cypress test passes — `dev/next/app/page.tsx` now uses `import { motion } from "motion/react"` directly in a Server Component and renders correctly
- [ ] CI passes all existing tests

Fixes #3159

🤖 Generated with [Claude Code](https://claude.com/claude-code)