### PR TITLE
Allow dragSnapToOrigin to accept 'x' or 'y' for per-axis snap

### DIFF
--- a/dev/react/src/tests/drag.tsx
+++ b/dev/react/src/tests/drag.tsx
@@ -22,7 +22,11 @@ export const App = () => {
     const right = parseFloat(params.get("right")) || undefined
     const bottom = parseFloat(params.get("bottom")) || undefined
     const showChild = Boolean(params.get("showChild"))
-    const snapToOrigin = Boolean(params.get("return"))
+    const returnParam = params.get("return")
+    const snapToOrigin: boolean | "x" | "y" =
+        returnParam === "x" || returnParam === "y"
+            ? returnParam
+            : Boolean(returnParam)
     const x = getValueParam(params, "x", isPercentage)
     const y = getValueParam(params, "y", isPercentage)
     const layout = params.get("layout") || undefined

--- a/packages/framer-motion/cypress/integration/drag.ts
+++ b/packages/framer-motion/cypress/integration/drag.ts
@@ -247,6 +247,52 @@ describe("Drag", () => {
             })
     })
 
+    it("Element returns to center on x axis only with dragSnapToOrigin='x'", () => {
+        cy.visit("?test=drag&return=x&left=-10&top=-10")
+            .wait(200)
+            .get("[data-testid='draggable']")
+            .wait(100)
+            .trigger("pointerdown", 40, 40)
+            .trigger("pointermove", 30, 30) // Gesture will start from first move past threshold
+            .wait(50)
+            .trigger("pointermove", 10, 10, { force: true })
+            .wait(50)
+            .trigger("pointerup", { force: true })
+            .wait(300)
+            .should(($draggable: any) => {
+                const draggable = $draggable[0] as HTMLDivElement
+                const { left, top } = draggable.getBoundingClientRect()
+
+                // x should snap back to origin (0)
+                expect(left).to.equal(0)
+                // y should NOT snap back - it stays at the constraint
+                expect(top).to.equal(-10)
+            })
+    })
+
+    it("Element returns to center on y axis only with dragSnapToOrigin='y'", () => {
+        cy.visit("?test=drag&return=y&left=-10&top=-10")
+            .wait(200)
+            .get("[data-testid='draggable']")
+            .wait(100)
+            .trigger("pointerdown", 40, 40)
+            .trigger("pointermove", 30, 30) // Gesture will start from first move past threshold
+            .wait(50)
+            .trigger("pointermove", 10, 10, { force: true })
+            .wait(50)
+            .trigger("pointerup", { force: true })
+            .wait(300)
+            .should(($draggable: any) => {
+                const draggable = $draggable[0] as HTMLDivElement
+                const { left, top } = draggable.getBoundingClientRect()
+
+                // x should NOT snap back - it stays at the constraint
+                expect(left).to.equal(-10)
+                // y should snap back to origin (0)
+                expect(top).to.equal(0)
+            })
+    })
+
     it("doesn't reset drag constraints (ref-based), while dragging, on unrelated parent component updates", () => {
         cy.visit("?test=drag-ref-constraints")
             .wait(200)

--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -459,7 +459,11 @@ export class VisualElementDragControls {
 
             let transition = (constraints && constraints[axis]) || {}
 
-            if (dragSnapToOrigin) transition = { min: 0, max: 0 }
+            if (
+                dragSnapToOrigin === true ||
+                dragSnapToOrigin === axis
+            )
+                transition = { min: 0, max: 0 }
 
             /**
              * Overdamp the boundary spring if `dragElastic` is disabled. There's still a frame

--- a/packages/framer-motion/src/gestures/pan/PanSession.ts
+++ b/packages/framer-motion/src/gestures/pan/PanSession.ts
@@ -22,7 +22,7 @@ interface PanSessionHandlers {
 
 interface PanSessionOptions {
     transformPagePoint?: TransformPoint
-    dragSnapToOrigin?: boolean
+    dragSnapToOrigin?: boolean | "x" | "y"
     distanceThreshold?: number
     contextWindow?: (Window & typeof globalThis) | null
     /**
@@ -90,7 +90,7 @@ export class PanSession {
      *
      * @internal
      */
-    private dragSnapToOrigin: boolean
+    private dragSnapToOrigin: boolean | "x" | "y"
 
     /**
      * The distance after which panning should start.

--- a/packages/motion-dom/src/node/types.ts
+++ b/packages/motion-dom/src/node/types.ts
@@ -723,14 +723,15 @@ export interface MotionNodeDraggableOptions {
     dragControls?: any // TODO: Replace with DragControls when ported to motion-dom
 
     /**
-     * If true, element will snap back to its origin when dragging ends.
+     * If `true`, element will snap back to its origin when dragging ends.
+     * Set to `"x"` or `"y"` to only snap back on a specific axis.
      *
      * Enabling this is the equivalent of setting all `dragConstraints` axes to `0`
      * with `dragElastic={1}`, but when used together `dragConstraints` can define
      * a wider draggable area and `dragSnapToOrigin` will ensure the element
      * animates back to its origin on release.
      */
-    dragSnapToOrigin?: boolean
+    dragSnapToOrigin?: boolean | "x" | "y"
 
     /**
      * By default, if `drag` is defined on a component then an event listener will be attached


### PR DESCRIPTION
## Summary
- Expands `dragSnapToOrigin` type from `boolean` to `boolean | "x" | "y"` so users can snap back on only one axis
- When set to `"x"`, only the x-axis snaps back to origin on release; y remains free (and vice versa for `"y"`)
- `true` continues to work exactly as before (both axes snap back)

Fixes #3191

## Test plan
- [x] Added Cypress E2E test for `dragSnapToOrigin="x"` — verifies x snaps back, y stays
- [x] Added Cypress E2E test for `dragSnapToOrigin="y"` — verifies y snaps back, x stays
- [x] All 26 drag tests pass on React 18
- [x] All 26 drag tests pass on React 19
- [x] Existing `dragSnapToOrigin={true}` test still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)