### PR TITLE
Fix anticipate easing to return exactly 1 at t=1

### DIFF
--- a/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/waapi.test.tsx
@@ -739,7 +739,7 @@ describe("WAAPI animations", () => {
                 delay: -0,
                 direction: "normal",
                 duration: 50,
-                easing: "linear(0, -0.0336, 0.5, 0.9844, 0.9995)",
+                easing: "linear(0, -0.0336, 0.5, 0.9844, 1)",
                 fill: "both",
                 iterations: 1,
             }

--- a/packages/motion-utils/src/easing/__tests__/anticipate.test.ts
+++ b/packages/motion-utils/src/easing/__tests__/anticipate.test.ts
@@ -1,0 +1,11 @@
+import { anticipate } from "../anticipate"
+
+describe("anticipate easing", () => {
+    test("anticipate(0) returns 0", () => {
+        expect(anticipate(0)).toBe(0)
+    })
+
+    test("anticipate(1) returns 1", () => {
+        expect(anticipate(1)).toBe(1)
+    })
+})

--- a/packages/motion-utils/src/easing/anticipate.ts
+++ b/packages/motion-utils/src/easing/anticipate.ts
@@ -1,4 +1,8 @@
 import { backIn } from "./back"
 
 export const anticipate = (p: number) =>
-    (p *= 2) < 1 ? 0.5 * backIn(p) : 0.5 * (2 - Math.pow(2, -10 * (p - 1)))
+    p >= 1
+        ? 1
+        : (p *= 2) < 1
+          ? 0.5 * backIn(p)
+          : 0.5 * (2 - Math.pow(2, -10 * (p - 1)))


### PR DESCRIPTION
## Summary

- The `anticipate` easing function returned `0.99951...` instead of `1` when `t=1`, because the formula `2 - Math.pow(2, -10 * x)` asymptotically approaches `2` but never reaches it
- Added an early return for `p >= 1` to guarantee the correct boundary value
- Added unit test for `anticipate(0)` and `anticipate(1)` boundary values

Fixes #3123

## Test plan

- [x] New unit test: `anticipate(1)` returns exactly `1`
- [x] New unit test: `anticipate(0)` returns exactly `0`
- [x] Updated WAAPI snapshot to reflect corrected `linear()` easing output (last value `1` instead of `0.9995`)
- [x] All motion-utils tests pass (19 suites, 30 tests)
- [x] All WAAPI-related tests pass
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)