### PR TITLE
[audit] motion-dom/frameloop: reduce per-frame allocations

### DIFF
--- a/packages/motion-dom/src/frameloop/batcher.ts
+++ b/packages/motion-dom/src/frameloop/batcher.ts
@@ -40,12 +40,13 @@ export function createRenderBatcher(
     } = steps
 
     const processBatch = () => {
-        const timestamp = MotionGlobalConfig.useManualTiming
+        const useManualTiming = MotionGlobalConfig.useManualTiming
+        const timestamp = useManualTiming
             ? state.timestamp
             : performance.now()
         runNextFrame = false
 
-        if (!MotionGlobalConfig.useManualTiming) {
+        if (!useManualTiming) {
             state.delta = useDefaultElapsed
                 ? 1000 / 60
                 : Math.max(Math.min(timestamp - state.timestamp, maxElapsed), 1)

--- a/packages/motion-dom/src/frameloop/render-step.ts
+++ b/packages/motion-dom/src/frameloop/render-step.ts
@@ -54,7 +54,7 @@ export function createRenderStep(
 
             if (keepAlive) toKeepAlive.add(callback)
 
-            if (!queue.has(callback)) queue.add(callback)
+            queue.add(callback)
 
             return callback
         },
@@ -86,7 +86,9 @@ export function createRenderStep(
             isProcessing = true
 
             // Swap this frame and the next to avoid GC
-            ;[thisFrame, nextFrame] = [nextFrame, thisFrame]
+            const prevFrame = thisFrame
+            thisFrame = nextFrame
+            nextFrame = prevFrame
 
             // Execute this frame
             thisFrame.forEach(triggerCallback)


### PR DESCRIPTION
## What this directory does

`motion-dom/src/frameloop/` is the animation heartbeat — it schedules and executes callbacks across 8 ordered render steps (setup, read, resolveKeyframes, preUpdate, update, preRender, render, postRender) every animation frame. Every animation in Motion flows through this loop.

## Findings

Performance audit of the hot path (`process()` runs 8× per frame, `processBatch()` runs 1× per frame):

1. **Array allocation in Set swap** — `[thisFrame, nextFrame] = [nextFrame, thisFrame]` creates a temporary array on every `process()` call (8× per frame). Replaced with a temp variable swap — zero allocations.

2. **Redundant `Set.has()` guard** — `if (!queue.has(callback)) queue.add(callback)` performs an unnecessary hash lookup since `Set.add()` already handles duplicates as a no-op. Removed the guard.

3. **Repeated config property lookup** — `MotionGlobalConfig.useManualTiming` was accessed twice in `processBatch()`. Cached in a local `const`.

## Changes

| File | Change | Rationale |
|------|--------|-----------|
| `render-step.ts:89` | Array destructuring → temp variable swap | Eliminates 8 temporary array allocations per frame |
| `render-step.ts:57` | Remove `Set.has()` before `Set.add()` | `Set.add()` already deduplicates; saves a hash lookup per schedule call |
| `batcher.ts:43-49` | Cache `useManualTiming` in local const | Avoids two property lookups on global config per frame |

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes (92 suites, 766 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)