### PR TITLE
fix transform motion svg-attribute conflicts with style-transform

### DIFF
--- a/dev/html/public/playwright/effects/svg-transform.html
+++ b/dev/html/public/playwright/effects/svg-transform.html
@@ -1,0 +1,30 @@
+<html>
+    <head>
+        <style>
+            body {
+                margin: 0;
+                font-family: sans-serif;
+            }
+        </style>
+    </head>
+    <body>
+        <svg width="200" height="200" viewBox="0 0 200 200">
+            <rect
+                id="rect"
+                x="50"
+                y="50"
+                width="100"
+                height="100"
+                fill="#0077ff"
+            />
+        </svg>
+        <script type="module" src="/src/inc.js"></script>
+        <script type="module">
+            const { motionValue, svgEffect } = window.Motion
+
+            // SVG-syntax transform (no units) — must go through setAttribute,
+            // not element.style.transform, so the value is preserved correctly.
+            svgEffect("#rect", { transform: motionValue("rotate(45)") })
+        </script>
+    </body>
+</html>

--- a/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
@@ -195,4 +195,35 @@ describe("SVG", () => {
         expect(rect).toHaveAttribute("transform", "translate(50 50)")
         expect(rect).not.toHaveAttribute("transform", "[object Object]")
     })
+
+    test("animate={{ transform }} keeps transform as SVG attribute on child elements", async () => {
+        // For SVG child elements (non-<svg> tags), a user-supplied transform value
+        // is kept as an SVG attribute rather than being promoted to CSS style.transform.
+        // This is intentional: SVG-syntax transforms (e.g. "translate(50 50)" without
+        // units) only work as SVG attributes, not as CSS properties.
+        const Component = () => {
+            return (
+                <svg>
+                    <motion.rect
+                        data-testid="rect"
+                        animate={{ transform: "translate(50 50)" }}
+                        initial={{ transform: "translate(0 0)" }}
+                        transition={{ type: false }}
+                        x={0}
+                        y={0}
+                        width={50}
+                        height={50}
+                    />
+                </svg>
+            )
+        }
+
+        const { getByTestId } = render(<Component />)
+        await nextFrame()
+
+        const rect = getByTestId("rect")
+        // transform stays as SVG attribute, not promoted to CSS style
+        expect(rect).toHaveAttribute("transform", "translate(50 50)")
+        expect(rect).not.toHaveStyle("transform: translate(50 50)")
+    })
 })

--- a/packages/motion-dom/src/effects/attr/index.ts
+++ b/packages/motion-dom/src/effects/attr/index.ts
@@ -3,15 +3,14 @@ import { MotionValue } from "../../value"
 import { MotionValueState } from "../MotionValueState"
 import { createSelectorEffect } from "../utils/create-dom-effect"
 import { createEffect } from "../utils/create-effect"
-import { isSVGAnimatedProperty } from "../utils/is-svg-animated-property"
+import { isSVGTransformProperty } from "../utils/is-svg-animated-property"
 
 function canSetAsProperty(element: HTMLElement | SVGElement, name: string) {
     if (!(name in element)) return false
 
-    // SVGAnimated* properties (SVGAnimatedTransformList, SVGAnimatedLength, etc.)
-    // expose a setter but are not directly settable with primitive values.
-    // They must be set via setAttribute instead.
-    if (isSVGAnimatedProperty(element, name)) return false
+    // SVGAnimatedTransformList exposes a setter but cannot be set directly with
+    // a string value. It must go through setAttribute instead.
+    if (isSVGTransformProperty(element, name)) return false
 
     const descriptor =
         Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), name) ||

--- a/packages/motion-dom/src/effects/svg/index.ts
+++ b/packages/motion-dom/src/effects/svg/index.ts
@@ -1,4 +1,3 @@
-import { isSVGAnimatedProperty } from "../utils/is-svg-animated-property"
 import { frame } from "../../frameloop"
 import { MotionValue } from "../../value"
 import { addAttrValue } from "../attr"
@@ -6,6 +5,7 @@ import { MotionValueState } from "../MotionValueState"
 import { addStyleValue } from "../style"
 import { createSelectorEffect } from "../utils/create-dom-effect"
 import { createEffect } from "../utils/create-effect"
+import { isSVGTransformProperty } from "../utils/is-svg-animated-property"
 
 function addSVGPathValue(
     element: SVGElement,
@@ -50,10 +50,11 @@ const addSVGValue = (
         return addAttrValue(element, state, convertAttrKey(key), value)
     }
 
-    // SVGAnimated* properties (like transform) exist in both element.style
-    // and as IDL properties, but must be set via setAttribute when using
-    // SVG-syntax values.
-    if (isSVGAnimatedProperty(element, key)) {
+    // `transform` on SVG elements is an SVGAnimatedTransformList — a complex
+    // object that cannot be set directly with a string value via element.style.
+    // Route it through setAttribute so SVG-syntax values (e.g. "rotate(45)"
+    // without units) work correctly.
+    if (isSVGTransformProperty(element, key)) {
         return addAttrValue(element, state, key, value)
     }
 

--- a/packages/motion-dom/src/effects/utils/is-svg-animated-property.ts
+++ b/packages/motion-dom/src/effects/utils/is-svg-animated-property.ts
@@ -1,6 +1,9 @@
-export function isSVGAnimatedProperty(element: Element, name: string): boolean {
+export function isSVGTransformProperty(
+    element: Element,
+    name: string
+): boolean {
+    if (name !== "transform") return false
     const value = (element as any)[name]
-
     return (
         value !== null &&
         typeof value === "object" &&

--- a/packages/motion-dom/src/render/svg/utils/build-attrs.ts
+++ b/packages/motion-dom/src/render/svg/utils/build-attrs.ts
@@ -51,10 +51,12 @@ export function buildSVGAttrs(
     const { attrs, style } = state
 
     /**
-     * However, we apply motion-synthesized transforms (from x/y/scale/rotate props) as CSS
-     * transforms. If the user has explicitly provided a `transform` value (e.g. as a native
-     * SVG attribute or MotionValue), we keep it as an SVG attribute so it renders correctly
-     * and overrides any leaked MotionValue object from React props.
+     * Motion-synthesized transforms (from x/y/scale/rotate props) are applied as CSS
+     * transforms. If the user has explicitly provided a `transform` value — whether
+     * as a MotionValue prop or via `animate={{ transform }}` — we keep it as an SVG
+     * attribute. This allows SVG-syntax values (e.g. "rotate(45)" without units) to
+     * render correctly, and ensures the resolved string overrides any MotionValue
+     * object that would otherwise leak into the DOM from React's filteredProps.
      */
     if (attrs.transform) {
         if (latest.transform === undefined) {

--- a/tests/effects/svg.spec.ts
+++ b/tests/effects/svg.spec.ts
@@ -66,6 +66,17 @@ test.describe("svgEffect", () => {
         expect(numOctaves).toBe("4")
     })
 
+    test("sets transform as SVG attribute (not CSS style)", async ({ page }) => {
+        await page.goto("effects/svg-transform.html")
+        const rect = page.locator("#rect")
+        const attrTransform = await rect.getAttribute("transform")
+        expect(attrTransform).toBe("rotate(45)")
+        const styleTransform = await rect.evaluate(
+            (el) => (el as HTMLElement).style.transform
+        )
+        expect(styleTransform).toBe("")
+    })
+
     test("applies transform-box: fill-box via style if element has transform", async ({
         page,
     }) => {


### PR DESCRIPTION
This pull request addresses a bug where SVG attributes like `transform` could incorrectly render as `[object Object]` when using MotionValues, and ensures that SVG-animated properties are handled correctly in the DOM. It introduces detection for SVGAnimated* properties, updates attribute handling logic, and adds tests to prevent regressions. The changes improve compatibility with SVG and prevent incorrect rendering of MotionValue objects.

fixes #3082 

**SVG attribute handling improvements:**

* Added a utility function `isSVGAnimatedProperty` to detect SVGAnimated* properties (e.g., `transform`), ensuring they are set via `setAttribute` instead of as properties, which prevents rendering issues.
* Updated `addSVGValue` and `canSetAsProperty` logic to use `isSVGAnimatedProperty`, ensuring SVG-animated properties are handled as attributes, not as DOM properties. [[1]](diffhunk://#diff-97504548e78ac28040def25e282974791b22278282dc26f512080374370523abR1) [[2]](diffhunk://#diff-966d84997f3857bb8a3d29493d20f15d52414984ccb122ad1cbef6ef53acbc24R6-R15) [[3]](diffhunk://#diff-97504548e78ac28040def25e282974791b22278282dc26f512080374370523abR53-R59)
* Improved the handling of `transform` in `buildSVGAttrs` to ensure user-provided SVG transform attributes override motion-synthesized transforms and prevent leaking MotionValue objects into the DOM.

**Testing and reliability:**

* Added tests to verify that MotionValues used as SVG attributes render correctly and do not appear as `[object Object]`, and that animated MotionValues update SVG attributes as expected.

**Minor fixes:**

* Improved regex in `convertAttrKey` for better Unicode handling.


**It's my first contribution in open-source project ever, so please let me know if smth wrong! I've tried to follow all recommendations**