### PR TITLE
Fix MotionValues on SVG transform attribute rendering as [object Object]

### DIFF
--- a/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
+++ b/packages/framer-motion/src/gestures/drag/VisualElementDragControls.ts
@@ -461,7 +461,7 @@ export class VisualElementDragControls {
 
             if (
                 dragSnapToOrigin === true ||
-                dragSnapToOrigin === axis
+                (dragSnapToOrigin as unknown) === axis
             )
                 transition = { min: 0, max: 0 }
 

--- a/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
+++ b/packages/framer-motion/src/motion/__tests__/component-svg.test.tsx
@@ -120,6 +120,30 @@ describe("SVG", () => {
         )
     })
 
+    test("MotionValue can be used for transform attribute on g element", async () => {
+        const Component = () => {
+            const transformValue = useMotionValue("translate(50, 50)")
+
+            return (
+                <svg>
+                    <motion.g transform={transformValue as any}>
+                        <motion.rect width={50} height={50} />
+                    </motion.g>
+                </svg>
+            )
+        }
+
+        const { container } = render(<Component />)
+
+        await nextFrame()
+
+        const gElement = container.querySelector("g")!
+        // The transform should NOT be rendered as "[object Object]"
+        expect(gElement.getAttribute("transform")).not.toBe("[object Object]")
+        // It should be applied as a CSS style transform
+        expect(gElement).toHaveStyle("transform: translate(50, 50)")
+    })
+
     test("animates viewBox", async () => {
         const Component = () => {
             return (

--- a/packages/framer-motion/src/render/dom/utils/filter-props.ts
+++ b/packages/framer-motion/src/render/dom/utils/filter-props.ts
@@ -1,3 +1,4 @@
+import { isMotionValue } from "motion-dom"
 import type { MotionProps } from "../../../motion/types"
 import { isValidMotionProp } from "../../../motion/utils/valid-prop"
 
@@ -57,6 +58,8 @@ export function filterProps(
          * element, which we support.
          */
         if (key === "values" && typeof props.values === "object") continue
+
+        if (isMotionValue(props[key as keyof typeof props])) continue
 
         if (
             shouldForward(key) ||


### PR DESCRIPTION
## Summary

- **Bug**: Passing a MotionValue to `<motion.g transform={motionValue}>` rendered `[object Object]` as the DOM attribute instead of the resolved value
- **Cause**: `filterProps` forwarded raw MotionValue objects to the DOM. For most SVG attributes (e.g. `cx`, `fill`), `visualProps` from `useSVGProps` overrides this, but `transform` is special — `buildSVGAttrs` moves it from attrs to style (CSS transform), so there was no override
- **Fix**: Filter out MotionValue objects in `filterProps` so they're never passed to the DOM. The motion value system already handles them through the visual element's value map

Also fixes a pre-existing TS error in `VisualElementDragControls` that blocked the test suite.

Fixes #3082

## Test plan

- [x] Added unit test proving MotionValue on `<motion.g transform={...}>` renders correctly (not `[object Object]`)
- [x] All 92 test suites pass (767 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)