### PR TITLE
Remove data-motion-pop-id on interrupted popLayout exit

### DIFF
--- a/dev/react/src/tests/animate-presence-pop-interrupt.tsx
+++ b/dev/react/src/tests/animate-presence-pop-interrupt.tsx
@@ -1,0 +1,61 @@
+import { AnimatePresence, motion } from "framer-motion"
+import { useState } from "react"
+
+const containerStyles = {
+    position: "relative" as const,
+    display: "flex",
+    flexDirection: "column" as const,
+    padding: "100px",
+}
+
+const boxStyles = {
+    width: "100px",
+    height: "100px",
+    backgroundColor: "red",
+}
+
+export const App = () => {
+    const [show, setShow] = useState(true)
+
+    return (
+        <div id="container" style={containerStyles}>
+            <button id="toggle" onClick={() => setShow(!show)}>
+                Toggle
+            </button>
+            <AnimatePresence mode="popLayout">
+                <motion.div
+                    key="a"
+                    id="a"
+                    layout
+                    style={boxStyles}
+                />
+                {show ? (
+                    <motion.div
+                        key="target"
+                        id="target"
+                        layout
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{
+                            opacity: 0,
+                            transition: { duration: 10 },
+                        }}
+                        style={{
+                            ...boxStyles,
+                            backgroundColor: "green",
+                        }}
+                    />
+                ) : null}
+                <motion.div
+                    key="c"
+                    id="c"
+                    layout
+                    style={{
+                        ...boxStyles,
+                        backgroundColor: "blue",
+                    }}
+                />
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-pop-interrupt.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-pop-interrupt.ts
@@ -1,0 +1,29 @@
+describe("AnimatePresence popLayout interrupt", () => {
+    it("removes data-motion-pop-id when exit animation is interrupted", () => {
+        cy.visit("?test=animate-presence-pop-interrupt")
+            .wait(50)
+            .get("#target")
+            .should(([$el]: any) => {
+                // Initially no pop id
+                expect($el.hasAttribute("data-motion-pop-id")).to.be.false
+            })
+            // Click to start exit (long duration so it won't complete)
+            .get("#toggle")
+            .click()
+            .wait(200)
+            .get("#target")
+            .should(([$el]: any) => {
+                // During exit, element should have pop id
+                expect($el.hasAttribute("data-motion-pop-id")).to.be.true
+            })
+            // Click again to re-enter (interrupt the exit)
+            .get("#toggle")
+            .click()
+            .wait(200)
+            .get("#target")
+            .should(([$el]: any) => {
+                // After re-entry, pop id must be removed
+                expect($el.hasAttribute("data-motion-pop-id")).to.be.false
+            })
+    })
+})

--- a/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/PopChild.tsx
@@ -127,6 +127,7 @@ export function PopChild({ children, isPresent, anchorX, anchorY, root, pop }: P
         }
 
         return () => {
+            ref.current?.removeAttribute("data-motion-pop-id")
             if (parent.contains(style)) {
                 parent.removeChild(style)
             }


### PR DESCRIPTION
## Summary

- When a `popLayout` exit animation is interrupted (element re-enters before exit completes), the `data-motion-pop-id` attribute now gets properly removed from the DOM element
- The `useInsertionEffect` cleanup in `PopChild` previously only removed the injected stylesheet but left the `data-motion-pop-id` attribute on the element
- Users targeting `[data-motion-pop-id]` with CSS (e.g. for `pointer-events: none` during exit) would see those styles persist after the element re-entered

## Bug

The `PopChild` component sets `data-motion-pop-id` on the DOM element when an exit animation starts (line 109 of `PopChild.tsx`). The `useInsertionEffect` cleanup removes the injected `<style>` element but did not remove the `data-motion-pop-id` attribute. When the exit is interrupted by re-entry, the attribute persisted, causing CSS selectors like `[data-motion-pop-id] { pointer-events: none }` to incorrectly match the re-entered element.

## Fix

Added `ref.current?.removeAttribute("data-motion-pop-id")` to the `useInsertionEffect` cleanup function, ensuring both the stylesheet and the attribute are cleaned up when `isPresent` changes.

## Test plan

- [x] Added Cypress E2E test (`animate-presence-pop-interrupt`) that verifies `data-motion-pop-id` is absent initially, present during exit, and removed after interrupted re-entry
- [x] Passes on React 18
- [x] Passes on React 19
- [x] Existing `animate-presence-pop` tests still pass on both React versions
- [x] Build passes

**Note:** In our test environment, React's reconciliation appears to handle attribute cleanup in some scenarios, but the explicit removal ensures correctness across all environments and React versions.

Fixes #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)