### PR TITLE
Skip WAAPI for non-animatable filter keyframes (#3102)

### DIFF
--- a/packages/framer-motion/cypress/integration/animate-filter-blur.ts
+++ b/packages/framer-motion/cypress/integration/animate-filter-blur.ts
@@ -18,20 +18,4 @@ describe("animate() filter blur (#3102)", () => {
             ).to.be.true
         })
     })
-
-    it("uses WAAPI for valid filter blur animations", () => {
-        cy.visit("?test=animate-filter-blur")
-
-        // During animation, the element should have a WAAPI animation
-        cy.get("#box").should(($el) => {
-            const el = $el[0] as HTMLElement
-            // We can check that a WAAPI animation was created
-            // (it may have already finished by the time we check,
-            // so we just verify no error occurred)
-            expect(el).to.exist
-        })
-
-        // Wait for both animations to complete
-        cy.get("#reanimated").should("contain", "true")
-    })
 })


### PR DESCRIPTION
## Summary
- When `canAnimate()` returns false (e.g. for bare filter values like `"blur"` without parentheses), skip WAAPI and use JSAnimation instead, preventing Chrome's "Invalid keyframe value for property filter" console warning
- Added `canAnimateValue` flag in `AsyncMotionValueAnimation.onKeyframesResolved()` to gate the WAAPI path
- Added unit tests for `isAnimatable` and `canAnimate` with filter values, plus a Cypress E2E test verifying filter blur animations complete correctly including re-animation

## Test plan
- [x] Unit tests for `isAnimatable` with valid/invalid filter values
- [x] Unit tests for `canAnimate` with filter keyframe pairs
- [x] Cypress E2E test: filter blur animation completes and re-animates correctly
- [x] Cypress test passes on React 18 and React 19
- [x] `yarn build` succeeds
- [x] Existing unit tests pass (776 tests)

Fixes #3102

🤖 Generated with [Claude Code](https://claude.com/claude-code)