### PR TITLE
Fix whileInView not triggering after remount

### DIFF
--- a/dev/react/src/tests/while-in-view-remount.tsx
+++ b/dev/react/src/tests/while-in-view-remount.tsx
@@ -1,0 +1,63 @@
+import { motion } from "framer-motion"
+import { useRef, useState } from "react"
+
+/**
+ * Reproduces #3079: whileInView not triggering after soft navigation.
+ * Tests several scenarios:
+ * - Element already in viewport on mount
+ * - Element remounting after unmount (soft navigation)
+ * - Element with custom root ref
+ */
+export const App = () => {
+    const [page, setPage] = useState<"home" | "projects">("home")
+
+    return (
+        <div>
+            <nav>
+                <button id="go-home" onClick={() => setPage("home")}>
+                    Home
+                </button>
+                <button id="go-projects" onClick={() => setPage("projects")}>
+                    Projects
+                </button>
+            </nav>
+            {page === "home" && <HomePage />}
+            {page === "projects" && <ProjectsPage />}
+        </div>
+    )
+}
+
+function HomePage() {
+    return <div id="home-page">Home</div>
+}
+
+function ProjectsPage() {
+    return (
+        <div id="projects-page">
+            <Card id="card1" />
+            <Card id="card2" />
+        </div>
+    )
+}
+
+function Card({ id }: { id: string }) {
+    const scrollRef = useRef<HTMLDivElement>(null)
+
+    return (
+        <article ref={scrollRef}>
+            <motion.div
+                id={id}
+                data-in-view="false"
+                initial={{ opacity: 0 }}
+                whileInView={{ opacity: 1 }}
+                viewport={{ root: scrollRef, once: true }}
+                transition={{ duration: 0.01 }}
+                onViewportEnter={() => {
+                    const el = document.getElementById(id)
+                    if (el) el.dataset.inView = "true"
+                }}
+                style={{ width: 100, height: 100, background: "red" }}
+            />
+        </article>
+    )
+}

--- a/packages/framer-motion/cypress/integration/while-in-view-remount.ts
+++ b/packages/framer-motion/cypress/integration/while-in-view-remount.ts
@@ -1,0 +1,77 @@
+describe("whileInView remount (#3079)", () => {
+    it("Triggers whileInView on initial mount", () => {
+        cy.visit("?test=while-in-view-remount")
+            .wait(100)
+            .get("#go-projects")
+            .click()
+            .wait(200)
+            .get("#card1")
+            .should(($el: any) => {
+                // Element should be visible (opacity 1) after mount
+                const opacity = parseFloat(
+                    getComputedStyle($el[0]).opacity
+                )
+                expect(opacity).to.equal(1)
+            })
+    })
+
+    it("Triggers whileInView after remount (soft navigation)", () => {
+        // Start on projects page
+        cy.visit("?test=while-in-view-remount")
+            .wait(100)
+            .get("#go-projects")
+            .click()
+            .wait(200)
+            .get("#card1")
+            .should(($el: any) => {
+                const opacity = parseFloat(
+                    getComputedStyle($el[0]).opacity
+                )
+                expect(opacity).to.equal(1)
+            })
+
+        // Navigate away (unmount)
+        cy.get("#go-home").click().wait(100)
+
+        // Navigate back (remount - simulates soft navigation)
+        cy.get("#go-projects").click().wait(200)
+
+        // Cards should animate again
+        cy.get("#card1").should(($el: any) => {
+            const opacity = parseFloat(
+                getComputedStyle($el[0]).opacity
+            )
+            expect(opacity).to.equal(1)
+        })
+        cy.get("#card2").should(($el: any) => {
+            const opacity = parseFloat(
+                getComputedStyle($el[0]).opacity
+            )
+            expect(opacity).to.equal(1)
+        })
+    })
+
+    it("Fires onViewportEnter after remount", () => {
+        // Start on projects page
+        cy.visit("?test=while-in-view-remount")
+            .wait(100)
+            .get("#go-projects")
+            .click()
+            .wait(200)
+            .get("#card1")
+            .should(($el: any) => {
+                expect($el[0].dataset.inView).to.equal("true")
+            })
+
+        // Navigate away
+        cy.get("#go-home").click().wait(100)
+
+        // Navigate back (remount)
+        cy.get("#go-projects").click().wait(200)
+
+        // onViewportEnter should fire again
+        cy.get("#card1").should(($el: any) => {
+            expect($el[0].dataset.inView).to.equal("true")
+        })
+    })
+})

--- a/packages/framer-motion/src/motion/features/viewport/index.ts
+++ b/packages/framer-motion/src/motion/features/viewport/index.ts
@@ -12,8 +12,10 @@ export class InViewFeature extends Feature<Element> {
 
     private isInView = false
 
+    private stopObserver?: () => void
+
     private startObserver() {
-        this.unmount()
+        this.stopObserver?.()
 
         const { viewport = {} } = this.node.getProps()
         const { root, margin: rootMargin, amount = "some", once } = viewport
@@ -61,7 +63,7 @@ export class InViewFeature extends Feature<Element> {
             callback && callback(entry)
         }
 
-        return observeIntersection(
+        this.stopObserver = observeIntersection(
             this.node.current!,
             options,
             onIntersectionUpdate
@@ -85,7 +87,11 @@ export class InViewFeature extends Feature<Element> {
         }
     }
 
-    unmount() {}
+    unmount() {
+        this.stopObserver?.()
+        this.hasEnteredView = false
+        this.isInView = false
+    }
 }
 
 function hasViewportOptionChanged(


### PR DESCRIPTION
## Summary

- **Bug:** `whileInView` animations failed to trigger after soft navigation (e.g., Next.js client-side route changes). Elements stayed in their `initial` state instead of animating to `whileInView` values.
- **Cause:** `InViewFeature.unmount()` was empty — the IntersectionObserver was never cleaned up and internal state (`isInView`, `hasEnteredView`) was never reset. On remount, `observer.observe()` was a no-op for already-observed elements (per the IntersectionObserver spec, re-observing a target that's already being watched is silently ignored). Stale state also caused the intersection callback to early-return without triggering animations.
- **Fix:** Store the cleanup function returned by `observeIntersection()` and call it in `unmount()`. Reset `isInView` and `hasEnteredView` so the observer fires correctly on re-observation after remount.

Fixes #3079

## Test plan

- [x] Added Cypress E2E test (`while-in-view-remount`) that simulates soft navigation by unmounting/remounting components with `whileInView`
- [x] Existing `while-in-view` and `while-in-view-custom-root` Cypress tests pass
- [x] All 779 unit tests pass (`yarn test`)
- [x] Cypress tests pass on both React 18 and React 19
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)