### PR TITLE
Fix AnimatePresence not removing children when exit matches current values

### DIFF
--- a/dev/react/src/tests/animate-presence-exit-no-op.tsx
+++ b/dev/react/src/tests/animate-presence-exit-no-op.tsx
@@ -1,0 +1,107 @@
+import { AnimatePresence, motion } from "framer-motion"
+import { useState } from "react"
+import { createPortal } from "react-dom"
+
+/**
+ * Reproduction for #3078: AnimatePresence won't remove modal if a
+ * child animation has a defined exit matching current values.
+ *
+ * Uses createPortal like the original reproduction. The modal's dialog
+ * uses variants for enter/exit. Children use variants for enter and
+ * exit={{ opacity: 1, scale: 1 }} (same as their animated state).
+ */
+
+function Modal({
+    children,
+    onClose,
+}: {
+    children: React.ReactNode
+    onClose: () => void
+}) {
+    return createPortal(
+        <>
+            <div
+                id="backdrop"
+                onClick={onClose}
+                style={{
+                    position: "fixed",
+                    inset: 0,
+                    background: "rgba(0,0,0,0.5)",
+                }}
+            />
+            <motion.dialog
+                id="modal"
+                variants={{
+                    hidden: { opacity: 0, y: -30 },
+                    visible: { opacity: 1, y: 0 },
+                }}
+                initial="hidden"
+                animate="visible"
+                exit="hidden"
+                transition={{ type: "tween", duration: 0.3 }}
+                open
+                style={{
+                    position: "fixed",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                }}
+            >
+                {children}
+            </motion.dialog>
+        </>,
+        document.body
+    )
+}
+
+function NewChallenge({ onDone }: { onDone: () => void }) {
+    return (
+        <Modal onClose={onDone}>
+            <h2>New Challenge</h2>
+            <motion.ul
+                variants={{
+                    visible: {
+                        transition: { staggerChildren: 0.05 },
+                    },
+                }}
+                style={{ listStyle: "none", display: "flex", gap: 10 }}
+            >
+                {[0, 1].map((i) => (
+                    <motion.li
+                        key={i}
+                        data-testid={`item-${i}`}
+                        variants={{
+                            hidden: { opacity: 0, scale: 0.5 },
+                            visible: { opacity: 1, scale: 1 },
+                        }}
+                        exit={{ opacity: 1, scale: 1 }}
+                        transition={{ type: "spring", stiffness: 260 }}
+                        style={{
+                            width: 50,
+                            height: 50,
+                            background: "coral",
+                        }}
+                    />
+                ))}
+            </motion.ul>
+            <button id="cancel" onClick={onDone}>
+                Cancel
+            </button>
+        </Modal>
+    )
+}
+
+export const App = () => {
+    const [show, setShow] = useState(false)
+
+    return (
+        <div style={{ padding: 20 }}>
+            <button id="toggle" onClick={() => setShow(true)}>
+                Add Challenge
+            </button>
+            <AnimatePresence mode="wait">
+                {show && <NewChallenge key="challenge" onDone={() => setShow(false)} />}
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-exit-no-op.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-exit-no-op.ts
@@ -1,0 +1,25 @@
+describe("AnimatePresence exit no-op (#3078)", () => {
+    it("Removes modal when child exit targets match current values", () => {
+        cy.visit("?test=animate-presence-exit-no-op")
+            .wait(200)
+            .get("#toggle")
+            .click()
+            .wait(200)
+
+        // Modal should be visible
+        cy.get("#modal").should("exist")
+
+        // Wait for enter animations to complete
+        cy.wait(2000)
+
+        // Close the modal via the cancel button
+        cy.get("#cancel").click()
+
+        // Modal should be removed promptly. The bug was that
+        // value.isAnimating (property access, always truthy) prevented
+        // the skip check from working, so exit animations targeting the
+        // same values as the current state were never skipped.
+        cy.wait(1000)
+        cy.get("#modal").should("not.exist")
+    })
+})

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -1626,4 +1626,113 @@ describe("AnimatePresence with custom components", () => {
         expect(container.childElementCount).toBe(1)
         expect(getByTestId("content").textContent).toBe("3")
     })
+
+    test("Removes child when nested variant children have exit matching current values", async () => {
+        /**
+         * Reproduction for #3078: When a child motion component uses
+         * variants for enter animation and has exit={{ opacity: 1, scale: 1 }}
+         * (same as animated values), AnimatePresence should still remove
+         * the parent after exit completes. The bug was that
+         * value.isAnimating (property access, always truthy) was used
+         * instead of value.isAnimating() (method call), preventing the
+         * skip check from ever working. Without the fix, the
+         * exit animation starts a long tween that blocks removal.
+         */
+        const Component = ({ isVisible }: { isVisible: boolean }) => {
+            return (
+                <AnimatePresence mode="wait">
+                    {isVisible && (
+                        <motion.div
+                            key="modal"
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ type: false }}
+                        >
+                            <motion.ul
+                                initial="hidden"
+                                animate="visible"
+                                variants={{
+                                    hidden: {},
+                                    visible: {
+                                        transition: {
+                                            staggerChildren: 0.05,
+                                        },
+                                    },
+                                }}
+                            >
+                                <motion.li
+                                    variants={{
+                                        hidden: {
+                                            opacity: 0,
+                                            scale: 0.5,
+                                        },
+                                        visible: {
+                                            opacity: 1,
+                                            scale: 1,
+                                        },
+                                    }}
+                                    exit={{
+                                        opacity: 1,
+                                        scale: 1,
+                                        transition: { duration: 100 },
+                                    }}
+                                    transition={{ type: false }}
+                                />
+                                <motion.li
+                                    variants={{
+                                        hidden: {
+                                            opacity: 0,
+                                            scale: 0.5,
+                                        },
+                                        visible: {
+                                            opacity: 1,
+                                            scale: 1,
+                                        },
+                                    }}
+                                    exit={{
+                                        opacity: 1,
+                                        scale: 1,
+                                        transition: { duration: 100 },
+                                    }}
+                                    transition={{ type: false }}
+                                />
+                            </motion.ul>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            )
+        }
+
+        const { container, rerender } = render(<Component isVisible />)
+        rerender(<Component isVisible />)
+
+        // Wait for enter animations to complete (type: "tween", duration: 100s
+        // applies to enter too, but the enter target values use variants
+        // which have their own transition, not the component's transition prop)
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 200))
+        })
+
+        expect(container.childElementCount).toBe(1)
+
+        // Trigger exit - children have exit targets matching their
+        // current values. With the fix, the skip check detects the
+        // values are at rest and skips animation. Without the fix,
+        // a 100-second tween starts, blocking removal.
+        await act(async () => {
+            rerender(<Component isVisible={false} />)
+        })
+
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 500))
+        })
+        await act(async () => {
+            await nextFrame()
+            await nextFrame()
+        })
+
+        // Child should have been removed after exit animation completes
+        expect(container.childElementCount).toBe(0)
+    })
 })

--- a/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
+++ b/packages/motion-dom/src/animation/interfaces/visual-element-target.ts
@@ -78,15 +78,18 @@ export function animateTarget(
 
         /**
          * If the value is already at the defined target, skip the animation.
+         * We still re-assert the value via frame.update to take precedence
+         * over any stale transitionEnd callbacks from previous animations.
          */
         const currentValue = value.get()
         if (
             currentValue !== undefined &&
-            !value.isAnimating &&
+            !value.isAnimating() &&
             !Array.isArray(valueTarget) &&
             valueTarget === currentValue &&
             !valueTransition.velocity
         ) {
+            frame.update(() => value.set(valueTarget as any))
             continue
         }
 


### PR DESCRIPTION
## Summary

- Fixed `value.isAnimating` (property access, always truthy) → `value.isAnimating()` (method call) in `animateTarget`
- The skip check that prevents redundant animations when exit targets match current values was completely broken — it never fired because accessing a method as a property returns a truthy function reference
- When the skip fires, we re-assert the value via `frame.update` to take precedence over any stale `transitionEnd` callbacks from previous animations

## Bug

When a child `motion` component inside `AnimatePresence` has `exit={{ opacity: 1, scale: 1 }}` (matching its current animated values), the skip check in `animateTarget` should detect that no animation is needed and skip it. Instead, `!value.isAnimating` (property access) was always `false`, so the skip never fired, causing unnecessary exit animations that blocked element removal.

## Fix

One-character fix: `!value.isAnimating` → `!value.isAnimating()` in `packages/motion-dom/src/animation/interfaces/visual-element-target.ts`.

Additionally, when the skip fires, we schedule `frame.update(() => value.set(valueTarget))` to ensure the value takes precedence over any stale `transitionEnd` callbacks from previous animation rounds.

Fixes #3078

## Test plan

- [x] Unit test in `AnimatePresence.test.tsx` validates modal removal with exit matching current values
- [x] Cypress E2E test (`animate-presence-exit-no-op`) reproduces the exact bug scenario with `createPortal`, variants, and spring transitions
- [x] All 770 existing unit tests pass
- [x] Cypress passes on React 18
- [x] Cypress passes on React 19

🤖 Generated with [Claude Code](https://claude.com/claude-code)