### PR TITLE
Fix useSpring isAnimating() returning false during animation

### DIFF
--- a/packages/motion-dom/src/value/__tests__/spring-value.test.ts
+++ b/packages/motion-dom/src/value/__tests__/spring-value.test.ts
@@ -256,3 +256,64 @@ const runSpringTests = (unit?: string | undefined) => {
 // Run tests for both number values and percentage values
 runSpringTests()
 runSpringTests("%")
+
+describe("spring isAnimating and animationComplete", () => {
+    test("isAnimating returns true during spring animation via set()", async () => {
+        const spring = followValue(0 as number, {
+            type: "spring",
+            driver: syncDriver(10),
+        } as any)
+
+        const isAnimatingValues: boolean[] = []
+
+        spring.on("change", () => {
+            isAnimatingValues.push(spring.isAnimating())
+        })
+
+        spring.set(100)
+
+        await new Promise<void>((resolve) => {
+            setTimeout(() => resolve(), 100)
+        })
+
+        // isAnimating should have been true during the animation
+        expect(isAnimatingValues.length).toBeGreaterThan(0)
+        expect(isAnimatingValues[0]).toBe(true)
+    })
+
+    test("animationComplete fires after spring animation via set()", async () => {
+        const spring = followValue(0 as number, {
+            type: "spring",
+            driver: syncDriver(10),
+        } as any)
+
+        const completed = await new Promise<boolean>((resolve) => {
+            spring.on("animationComplete", () => {
+                resolve(true)
+            })
+
+            spring.set(100)
+
+            // Timeout fallback if animationComplete never fires
+            setTimeout(() => resolve(false), 2000)
+        })
+
+        expect(completed).toBe(true)
+    })
+
+    test("isAnimating returns false after spring animation completes", async () => {
+        const spring = followValue(0 as number, {
+            type: "spring",
+            driver: syncDriver(10),
+        } as any)
+
+        await new Promise<void>((resolve) => {
+            spring.on("animationComplete", () => {
+                resolve()
+            })
+            spring.set(100)
+        })
+
+        expect(spring.isAnimating()).toBe(false)
+    })
+})

--- a/packages/motion-dom/src/value/follow-value.ts
+++ b/packages/motion-dom/src/value/follow-value.ts
@@ -84,6 +84,7 @@ export function attachFollow<T extends AnyResolvedKeyframe>(
             activeAnimation.stop()
             activeAnimation = null
         }
+        value.animation = undefined
     }
 
     const startAnimation = () => {
@@ -121,8 +122,10 @@ export function attachFollow<T extends AnyResolvedKeyframe>(
     // multiple calls within the same frame (e.g. rapid mouse events)
     const scheduleAnimation = () => {
         startAnimation()
+        value.animation = activeAnimation ?? undefined
         value["events"].animationStart?.notify()
         activeAnimation?.then(() => {
+            value.animation = undefined
             value["events"].animationComplete?.notify()
         })
     }


### PR DESCRIPTION
## Summary

- `useSpring`'s `isAnimating()` always returned `false` during spring animations triggered via `.set()`, and `animationComplete` events weren't reliably tied to the MotionValue lifecycle
- **Root cause:** `attachFollow` stored the spring animation in a local `activeAnimation` variable but never assigned it to `value.animation`, which `isAnimating()` checks
- **Fix:** Set `value.animation` when the spring animation starts in `scheduleAnimation`, and clear it on completion or stop

Fixes #2957

## Test plan

- [x] Added unit test: `isAnimating()` returns `true` during spring animation via `set()`
- [x] Added unit test: `animationComplete` event fires after spring animation via `set()`
- [x] Added unit test: `isAnimating()` returns `false` after animation completes
- [x] All 784 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)