### PR TITLE
Add rangeStart/rangeEnd support for scroll()

### DIFF
--- a/dev/react/src/tests/scroll-range.tsx
+++ b/dev/react/src/tests/scroll-range.tsx
@@ -1,0 +1,37 @@
+import { animate, scroll } from "framer-motion"
+import * as React from "react"
+import { useEffect } from "react"
+
+export const App = () => {
+    useEffect(() => {
+        const box = document.getElementById("box")!
+
+        const animation = animate(box, {
+            opacity: [0, 0.5],
+        })
+
+        const stop = scroll(animation, {
+            rangeStart: "0%",
+            rangeEnd: "20%",
+        })
+
+        return () => stop()
+    }, [])
+
+    return (
+        <>
+            <div style={{ height: "500vh" }} />
+            <div
+                id="box"
+                style={{
+                    position: "fixed",
+                    top: 0,
+                    left: 0,
+                    width: 100,
+                    height: 100,
+                    backgroundColor: "red",
+                }}
+            />
+        </>
+    )
+}

--- a/packages/framer-motion/cypress/integration/scroll-range.ts
+++ b/packages/framer-motion/cypress/integration/scroll-range.ts
@@ -1,0 +1,29 @@
+describe("scroll() rangeStart/rangeEnd", () => {
+    it("Animation is inactive after rangeEnd", () => {
+        cy.visit("?test=scroll-range")
+            .wait(100)
+            .viewport(100, 400)
+
+        // Scroll to ~50% (well past the 20% rangeEnd)
+        cy.scrollTo(0, 800)
+            .wait(200)
+            .get("#box")
+            .then(([$element]: any) => {
+                const opacity = parseFloat(
+                    getComputedStyle($element).opacity
+                )
+
+                if ((window as any).ScrollTimeline) {
+                    // With native ScrollTimeline + rangeStart/rangeEnd + fill: auto,
+                    // animation is inactive after 20% scroll. Opacity reverts to
+                    // CSS default (1).
+                    expect(opacity).to.equal(1)
+                } else {
+                    // Without native ScrollTimeline, rangeStart/rangeEnd have no
+                    // effect. Animation maps full scroll to progress, so at 50%
+                    // scroll opacity = 0.25 (50% of 0 to 0.5).
+                    expect(opacity).to.equal(0.25)
+                }
+            })
+    })
+})

--- a/packages/framer-motion/src/render/dom/scroll/attach-animation.ts
+++ b/packages/framer-motion/src/render/dom/scroll/attach-animation.ts
@@ -10,6 +10,8 @@ export function attachToAnimation(
 ) {
     const timeline = getTimeline(options)
 
+    const hasUserRange = options.rangeStart || options.rangeEnd
+
     const range = options.target
         ? offsetToViewTimelineRange(options.offset)
         : undefined
@@ -26,11 +28,17 @@ export function attachToAnimation(
 
     return animation.attachTimeline({
         timeline: useNative ? timeline : undefined,
-        ...(range &&
-            useNative && {
-                rangeStart: range.rangeStart,
-                rangeEnd: range.rangeEnd,
-            }),
+        ...(hasUserRange
+            ? {
+                  rangeStart: options.rangeStart,
+                  rangeEnd: options.rangeEnd,
+                  fill: "auto",
+              }
+            : range &&
+              useNative && {
+                  rangeStart: range.rangeStart,
+                  rangeEnd: range.rangeEnd,
+              }),
         observe: (valueAnimation) => {
             valueAnimation.pause()
 

--- a/packages/framer-motion/src/render/dom/scroll/types.ts
+++ b/packages/framer-motion/src/render/dom/scroll/types.ts
@@ -6,6 +6,8 @@ export interface ScrollOptions {
     target?: Element
     axis?: "x" | "y"
     offset?: ScrollOffset
+    rangeStart?: string
+    rangeEnd?: string
 }
 
 export interface ScrollOptionsWithDefaults extends ScrollOptions {

--- a/packages/motion-dom/src/animation/NativeAnimation.ts
+++ b/packages/motion-dom/src/animation/NativeAnimation.ts
@@ -250,6 +250,7 @@ export class NativeAnimation<T extends AnyResolvedKeyframe>
         timeline,
         rangeStart,
         rangeEnd,
+        fill,
         observe,
     }: TimelineWithFallback): VoidFunction {
         if (this.allowFlatten) {
@@ -263,6 +264,7 @@ export class NativeAnimation<T extends AnyResolvedKeyframe>
 
             if (rangeStart) (this.animation as any).rangeStart = rangeStart
             if (rangeEnd) (this.animation as any).rangeEnd = rangeEnd
+            if (fill) this.animation.effect?.updateTiming({ fill } as any)
 
             return noop<void>
         } else {

--- a/packages/motion-dom/src/animation/types.ts
+++ b/packages/motion-dom/src/animation/types.ts
@@ -25,6 +25,7 @@ export interface TimelineWithFallback {
     timeline?: ProgressTimeline
     rangeStart?: string
     rangeEnd?: string
+    fill?: string
     observe: (animation: AnimationPlaybackControls) => VoidFunction
 }
 


### PR DESCRIPTION
## Summary

- Adds `rangeStart` and `rangeEnd` options to `scroll()`, forwarding them to the native WAAPI `Animation` object when using `ScrollTimeline`
- When user-provided range is set, `fill` is automatically changed to `"auto"` so the animation becomes inactive outside the range (matching native CSS/WAAPI behavior)
- Existing ViewTimeline offset-to-range mapping continues to use `fill: "both"` (no behavioral change)

## Problem

Native CSS and WAAPI support `animation-range-start`/`animation-range-end` (and the corresponding `rangeStart`/`rangeEnd` on `Element.animate()`). After the range ends, the animation becomes inactive (`progress === null`), allowing other CSS like `:hover` to take effect.

Motion's `scroll()` only supported `offset`, which clamps progress to 0/1 outside the range. This kept the animation's styles applied even after the range, preventing `:hover` and other CSS from overriding them.

## Fix

- Added `rangeStart`/`rangeEnd` to `ScrollOptions` type
- Added `fill` to `TimelineWithFallback` interface
- `attach-animation.ts` forwards user-provided range values with `fill: "auto"` to `attachTimeline()`
- `NativeAnimation.attachTimeline()` applies the `fill` override via `updateTiming()`

**Note:** This feature requires native `ScrollTimeline` support (Chrome 115+). In browsers without it, `rangeStart`/`rangeEnd` are silently ignored and the JS fallback path is used.

Fixes #3001

## Test plan

- [x] Cypress E2E test (`scroll-range.ts`) verifies animation is inactive after `rangeEnd` in Chrome (native ScrollTimeline)
- [x] Test adapts for Electron (no native ScrollTimeline) by checking `window.ScrollTimeline`
- [x] Passes React 18 and React 19
- [x] All 774 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)