### PR TITLE
Fix AnimatePresence key warnings for keyless children

### DIFF
--- a/dev/react/src/tests/animate-presence-key-warning.tsx
+++ b/dev/react/src/tests/animate-presence-key-warning.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react"
+import { AnimatePresence, motion } from "framer-motion"
+
+export const App = () => {
+    const [open, setOpen] = useState(false)
+
+    return (
+        <div>
+            <button
+                id="toggle"
+                onClick={() => setOpen((prev) => !prev)}
+            >
+                Toggle
+            </button>
+            <AnimatePresence>
+                {open && (
+                    <div id="container" className="fixed inset-0">
+                        <motion.div
+                            id="drawer"
+                            initial={{ x: "-100%" }}
+                            animate={{ x: 0 }}
+                            exit={{ x: "-100%" }}
+                            transition={{
+                                type: "tween",
+                                duration: 0.3,
+                            }}
+                        >
+                            Drawer Content
+                        </motion.div>
+                    </div>
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}

--- a/packages/framer-motion/cypress/integration/animate-presence-key-warning.ts
+++ b/packages/framer-motion/cypress/integration/animate-presence-key-warning.ts
@@ -1,0 +1,21 @@
+describe("AnimatePresence key warning", () => {
+    it("Does not produce key warnings for conditional children without explicit keys", () => {
+        cy.visit("?test=animate-presence-key-warning")
+            .wait(200)
+            .get("#toggle")
+            .click()
+            .wait(200)
+
+        cy.get("#drawer").should("exist").should("contain", "Drawer Content")
+
+        // Toggle off then on again to test exit/re-enter cycle
+        cy.get("#toggle")
+            .click()
+            .wait(500)
+            .get("#toggle")
+            .click()
+            .wait(200)
+
+        cy.get("#drawer").should("exist").should("contain", "Drawer Content")
+    })
+})

--- a/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
+++ b/packages/framer-motion/src/components/AnimatePresence/__tests__/AnimatePresence.test.tsx
@@ -1626,4 +1626,102 @@ describe("AnimatePresence with custom components", () => {
         expect(container.childElementCount).toBe(1)
         expect(getByTestId("content").textContent).toBe("3")
     })
+
+    test("Does not produce React key warning for conditional children without explicit keys", async () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+
+        const Component = ({ show }: { show: boolean }) => {
+            return (
+                <AnimatePresence>
+                    {show && (
+                        <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            data-testid="child"
+                        />
+                    )}
+                </AnimatePresence>
+            )
+        }
+
+        const { rerender } = render(<Component show={false} />)
+
+        rerender(<Component show={true} />)
+
+        await act(async () => {
+            await nextFrame()
+        })
+
+        rerender(<Component show={false} />)
+
+        await act(async () => {
+            await nextFrame()
+        })
+
+        rerender(<Component show={true} />)
+
+        await act(async () => {
+            await nextFrame()
+        })
+
+        const keyWarnings = errorSpy.mock.calls.filter((call) =>
+            call.some(
+                (arg: any) =>
+                    typeof arg === "string" &&
+                    arg.includes("unique") &&
+                    arg.includes("key")
+            )
+        )
+
+        errorSpy.mockRestore()
+
+        expect(keyWarnings).toHaveLength(0)
+    })
+
+    test("Does not produce React key warning for multiple children without explicit keys", async () => {
+        const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+
+        const Component = ({ show }: { show: boolean }) => {
+            return (
+                <AnimatePresence>
+                    {show && (
+                        <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                        />
+                    )}
+                    {show && (
+                        <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                        />
+                    )}
+                </AnimatePresence>
+            )
+        }
+
+        const { rerender } = render(<Component show={false} />)
+
+        rerender(<Component show={true} />)
+
+        await act(async () => {
+            await nextFrame()
+        })
+
+        const keyWarnings = errorSpy.mock.calls.filter((call) =>
+            call.some(
+                (arg: any) =>
+                    typeof arg === "string" &&
+                    arg.includes("unique") &&
+                    arg.includes("key")
+            )
+        )
+
+        errorSpy.mockRestore()
+
+        expect(keyWarnings).toHaveLength(0)
+    })
 })

--- a/packages/framer-motion/src/components/AnimatePresence/utils.ts
+++ b/packages/framer-motion/src/components/AnimatePresence/utils.ts
@@ -1,4 +1,10 @@
-import { isValidElement, Children, ReactElement, ReactNode } from "react"
+import {
+    isValidElement,
+    Children,
+    ReactElement,
+    ReactNode,
+    cloneElement,
+} from "react"
 
 export type ComponentKey = string | number
 
@@ -10,7 +16,12 @@ export function onlyElements(children: ReactNode): ReactElement<any>[] {
 
     // We use forEach here instead of map as map mutates the component key by preprending `.$`
     Children.forEach(children, (child) => {
-        if (isValidElement(child)) filtered.push(child)
+        if (isValidElement(child))
+            filtered.push(
+                child.key !== null
+                    ? child
+                    : cloneElement(child, { key: `.${filtered.length}` })
+            )
     })
 
     return filtered


### PR DESCRIPTION
## Summary

- **Bug:** `AnimatePresence` produced React's "Each child in a list should have a unique key prop" / "Encountered two children with the same key" console warnings when children lacked explicit `key` props
- **Cause:** `onlyElements()` preserved children with `key: null`, and `getChildKey()` mapped all of them to `key=""` — so every keyless child shared the same empty-string key in the rendered `PresenceChild` array
- **Fix:** `onlyElements()` now assigns position-based keys (`.0`, `.1`, …) to keyless children via `cloneElement`, ensuring unique keys while leaving explicitly-keyed children untouched

Fixes #2954

## Test plan

- [x] Unit test: single conditional child toggled on/off/on produces no key warnings
- [x] Unit test: multiple keyless children produce no key warnings
- [x] Cypress E2E test: drawer open/close/reopen pattern works on React 18 and React 19
- [x] All 776 existing unit tests pass
- [x] `yarn build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)